### PR TITLE
fix: Resolve SDK consumer panic and stabilize streaming mode

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,18 @@
+# Broker Settings
+broker_addrs:
+  - "localhost:9000"
+
+# Topic Settings
+topic: "example-topic"
+partitions: 1
+
+# Publisher Settings
+acks: "1"
+batch_size: 1
+linger_ms: 0
+
+# Consumer Settings
+group_id: "example-group"
+consumer_id: "example-consumer-1"
+mode: "streaming"
+auto_commit_interval: "1s"

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -8,15 +8,22 @@ import (
 
 func main() {
 	cfg := sdk.NewDefaultConsumerConfig()
+	// Try loading from current dir, then parent dir
 	if err := sdk.LoadConfig("config.yaml", cfg); err != nil {
-		log.Printf("Config file not found or invalid, using defaults: %v", err)
+		if err := sdk.LoadConfig("../config.yaml", cfg); err != nil {
+			log.Printf("Config file not found or invalid, using defaults: %v", err)
+		}
 	}
 
 	c, err := sdk.NewConsumer(cfg)
 	if err != nil {
 		log.Fatalf("Failed to create consumer: %v", err)
 	}
-	defer c.Close()
+	defer func() {
+		if err := c.Close(); err != nil {
+			log.Printf("Error closing consumer: %v", err)
+		}
+	}()
 
 	log.Printf("Starting consumer for topic: %s", cfg.Topic)
 	err = c.Start(func(msg sdk.Message) error {

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/cursus-io/cursus/sdk"
 )
@@ -15,11 +19,17 @@ func main() {
 		}
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	c, err := sdk.NewConsumer(cfg)
 	if err != nil {
 		log.Fatalf("Failed to create consumer: %v", err)
 	}
-	defer func() {
+
+	go func() {
+		<-ctx.Done()
+		log.Println("Shutting down consumer...")
 		if err := c.Close(); err != nil {
 			log.Printf("Error closing consumer: %v", err)
 		}
@@ -31,7 +41,7 @@ func main() {
 		return nil
 	})
 
-	if err != nil {
+	if err != nil && err != context.Canceled {
 		log.Fatalf("Consumer error: %v", err)
 	}
 }

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+
+	"github.com/cursus-io/cursus/sdk"
+)
+
+func main() {
+	cfg := sdk.NewDefaultConsumerConfig()
+	if err := sdk.LoadConfig("config.yaml", cfg); err != nil {
+		log.Printf("Config file not found or invalid, using defaults: %v", err)
+	}
+
+	c, err := sdk.NewConsumer(cfg)
+	if err != nil {
+		log.Fatalf("Failed to create consumer: %v", err)
+	}
+	defer c.Close()
+
+	log.Printf("Starting consumer for topic: %s", cfg.Topic)
+	err = c.Start(func(msg sdk.Message) error {
+		log.Printf("Received message: Offset=%d, SeqNum=%d, Payload=%s", msg.Offset, msg.SeqNum, msg.Payload)
+		return nil
+	})
+
+	if err != nil {
+		log.Fatalf("Consumer error: %v", err)
+	}
+}

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   broker:
     image: cursus-broker:latest

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  broker:
+    image: cursus-broker:latest
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    ports:
+      - "9000:9000"
+    environment:
+      - CURSUS_BROKER_PORT=9000
+    volumes:
+      - ./data:/data

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/cursus-io/cursus/sdk"
+)
+
+func main() {
+	cfg := sdk.NewDefaultPublisherConfig()
+	if err := sdk.LoadConfig("config.yaml", cfg); err != nil {
+		log.Printf("Config file not found or invalid, using defaults: %v", err)
+	}
+
+	p, err := sdk.NewProducer(cfg)
+	if err != nil {
+		log.Fatalf("Failed to create producer: %v", err)
+	}
+	defer p.Close()
+
+	for i := 0; i < 10; i++ {
+		payload := fmt.Sprintf("Hello Cursus! Message %d", i)
+		seqNum, err := p.Send(payload)
+		if err != nil {
+			log.Printf("Failed to send message: %v", err)
+		} else {
+			log.Printf("Sent message %d with sequence number %d", i, seqNum)
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	p.Flush()
+	log.Println("Publisher finished.")
+}

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -10,15 +10,22 @@ import (
 
 func main() {
 	cfg := sdk.NewDefaultPublisherConfig()
+	// Try loading from current dir, then parent dir
 	if err := sdk.LoadConfig("config.yaml", cfg); err != nil {
-		log.Printf("Config file not found or invalid, using defaults: %v", err)
+		if err := sdk.LoadConfig("../config.yaml", cfg); err != nil {
+			log.Printf("Config file not found or invalid, using defaults: %v", err)
+		}
 	}
 
 	p, err := sdk.NewProducer(cfg)
 	if err != nil {
 		log.Fatalf("Failed to create producer: %v", err)
 	}
-	defer p.Close()
+	defer func() {
+		if err := p.Close(); err != nil {
+			log.Printf("Error closing producer: %v", err)
+		}
+	}()
 
 	for i := 0; i < 10; i++ {
 		payload := fmt.Sprintf("Hello Cursus! Message %d", i)

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -335,7 +335,12 @@ func (ch *CommandHandler) parseCommonArgs(args map[string]string) (CommonArgs, e
 	}
 
 	gen := -1
-	if g, err := strconv.Atoi(args["generation"]); err == nil {
+	genStr := args["generation"]
+	if genStr != "" {
+		g, err := strconv.Atoi(genStr)
+		if err != nil {
+			return CommonArgs{}, fmt.Errorf("invalid generation value: %s", genStr)
+		}
 		gen = g
 	}
 

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -115,9 +115,15 @@ func (ch *CommandHandler) readFromTopic(topicName string, cArgs CommonArgs, ctx 
 		}
 	}
 
+	// Use generation from arguments if provided, otherwise fallback to coordinator
+	if cArgs.Generation != -1 {
+		currentGen = cArgs.Generation
+	}
+
 	if ctx.Generation != currentGen {
 		ctx.OffsetCache = make(map[string]uint64)
 		ctx.Generation = currentGen
+		ctx.MemberID = cArgs.MemberID
 		util.Debug("Generation changed to %d, cache cleared", currentGen)
 	}
 
@@ -136,8 +142,8 @@ func (ch *CommandHandler) readFromTopic(topicName string, cArgs CommonArgs, ctx 
 		currentOffset = actualOffset
 	}
 
-	if !ch.ValidateOwnership(cArgs.GroupName, cArgs.MemberID, ctx.Generation, cArgs.PartitionID) {
-		util.Debug("Ownership validation failed for topic %s", topicName)
+	if !ch.ValidateOwnership(cArgs.GroupName, cArgs.MemberID, currentGen, cArgs.PartitionID) {
+		util.Debug("Ownership validation failed for topic %s (gen=%d)", topicName, currentGen)
 		return nil, nil // Skip this topic if not owned (allowing regex to continue with other owned topics)
 	}
 
@@ -214,9 +220,12 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 		return err
 	}
 
-	if !ch.ValidateOwnership(ctx.ConsumerGroup, cArgs.MemberID, ctx.Generation, cArgs.PartitionID) {
+	if !ch.ValidateOwnership(ctx.ConsumerGroup, cArgs.MemberID, cArgs.Generation, cArgs.PartitionID) {
 		return fmt.Errorf("not partition owner or generation mismatch")
 	}
+
+	ctx.Generation = cArgs.Generation
+	ctx.MemberID = cArgs.MemberID
 
 	_, p, err := ch.getTopicAndPartition(cArgs.TopicName, cArgs.PartitionID)
 	if err != nil {
@@ -311,6 +320,7 @@ type CommonArgs struct {
 	PartitionID     int
 	GroupName       string
 	MemberID        string
+	Generation      int
 	HasOffset       bool
 	Offset          uint64
 	BatchSize       int
@@ -322,6 +332,11 @@ func (ch *CommandHandler) parseCommonArgs(args map[string]string) (CommonArgs, e
 	pID, err := strconv.Atoi(args["partition"])
 	if err != nil && args["partition"] != "" {
 		return CommonArgs{}, fmt.Errorf("invalid partition value: %s", args["partition"])
+	}
+
+	gen := -1
+	if g, err := strconv.Atoi(args["generation"]); err == nil {
+		gen = g
 	}
 
 	offsetStr, hasOffsetKey := args["offset"]
@@ -349,6 +364,7 @@ func (ch *CommandHandler) parseCommonArgs(args map[string]string) (CommonArgs, e
 		PartitionID:     pID,
 		GroupName:       ch.resolveConsumerGroup(args["group"]),
 		MemberID:        args["member"],
+		Generation:      gen,
 		HasOffset:       hasOffsetKey && offsetStr != "",
 		Offset:          offset,
 		BatchSize:       batch,

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -161,7 +161,12 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 
 // HandleConnection processes a single client connection
 func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager, cfg *config.Config, cd *coordinator.Coordinator, sm *stream.StreamManager, cc *clusterController.ClusterController) {
-	defer func() { _ = conn.Close() }()
+	isStreamed := false
+	defer func() {
+		if !isStreamed {
+			_ = conn.Close()
+		}
+	}()
 
 	clientCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -189,6 +194,21 @@ func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager
 
 		shouldExit, err := processMessage(data, cmdHandler, cmdCtx, conn)
 		if err != nil || shouldExit {
+			// Check if this was a STREAM command to prevent closing the connection
+			if shouldExit {
+				// Try to decode or inspect the command
+				_, payload, decodeErr := util.DecodeMessage(data)
+				cmd := ""
+				if decodeErr == nil {
+					cmd = strings.TrimSpace(payload)
+				} else {
+					cmd = strings.TrimSpace(string(data))
+				}
+
+				if strings.HasPrefix(strings.ToUpper(cmd), "STREAM ") {
+					isStreamed = true
+				}
+			}
 			return
 		}
 	}
@@ -284,8 +304,9 @@ func handleCommandMessage(payload string, cmdHandler *controller.CommandHandler,
 		if strings.HasPrefix(strings.ToUpper(payload), "STREAM ") {
 			if err := cmdHandler.HandleStreamCommand(conn, payload, ctx); err != nil {
 				writeResponse(conn, fmt.Sprintf("ERROR: %v", err))
+				return false, nil // 에러 발생 시 연결 유지
 			}
-			return true, nil
+			return true, nil // 성공 시 스트림 매니저에게 소유권 이전
 		} else {
 			if _, err := cmdHandler.HandleConsumeCommand(conn, payload, ctx); err != nil {
 				writeResponse(conn, fmt.Sprintf("ERROR: %v", err))

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -193,21 +193,21 @@ func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager
 		}
 
 		shouldExit, err := processMessage(data, cmdHandler, cmdCtx, conn)
-		if err != nil || shouldExit {
+		if err != nil {
+			return
+		}
+		if shouldExit {
 			// Check if this was a STREAM command to prevent closing the connection
-			if shouldExit {
-				// Try to decode or inspect the command
-				_, payload, decodeErr := util.DecodeMessage(data)
-				cmd := ""
-				if decodeErr == nil {
-					cmd = strings.TrimSpace(payload)
-				} else {
-					cmd = strings.TrimSpace(string(data))
-				}
+			_, payload, decodeErr := util.DecodeMessage(data)
+			cmd := ""
+			if decodeErr == nil {
+				cmd = strings.TrimSpace(payload)
+			} else {
+				cmd = strings.TrimSpace(string(data))
+			}
 
-				if strings.HasPrefix(strings.ToUpper(cmd), "STREAM ") {
-					isStreamed = true
-				}
+			if strings.HasPrefix(strings.ToUpper(cmd), "STREAM ") {
+				isStreamed = true
 			}
 			return
 		}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -304,9 +304,9 @@ func handleCommandMessage(payload string, cmdHandler *controller.CommandHandler,
 		if strings.HasPrefix(strings.ToUpper(payload), "STREAM ") {
 			if err := cmdHandler.HandleStreamCommand(conn, payload, ctx); err != nil {
 				writeResponse(conn, fmt.Sprintf("ERROR: %v", err))
-				return false, nil // 에러 발생 시 연결 유지
+				return false, nil
 			}
-			return true, nil // 성공 시 스트림 매니저에게 소유권 이전
+			return true, nil
 		} else {
 			if _, err := cmdHandler.HandleConsumeCommand(conn, payload, ctx); err != nil {
 				writeResponse(conn, fmt.Sprintf("ERROR: %v", err))

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -16,7 +16,6 @@ type Partition struct {
 	id            int
 	topic         string
 	newMessageCh  chan struct{}
-	broadcastCh   chan types.Message
 	LEO           atomic.Uint64
 	HWM           uint64
 	mu            sync.RWMutex
@@ -29,11 +28,6 @@ type Partition struct {
 
 // NewPartition creates a partition instance.
 func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManager, cfg *config.Config) *Partition {
-	bufSize := DefaultBufSize
-	if cfg != nil && cfg.BroadcastChannelBufferSize > 0 {
-		bufSize = cfg.BroadcastChannelBufferSize
-	}
-
 	latest := dh.GetLatestOffset()
 	initialOffset := latest + 1
 
@@ -43,7 +37,6 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 		dh:            dh,
 		streamManager: sm,
 		newMessageCh:  make(chan struct{}, 1),
-		broadcastCh:   make(chan types.Message, bufSize),
 	}
 
 	p.LEO.Store(initialOffset)
@@ -59,14 +52,7 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 		}
 	}
 
-	go p.runBroadcaster()
 	return p
-}
-
-func (p *Partition) runBroadcaster() {
-	for msg := range p.broadcastCh {
-		p.broadcastToStreams(msg)
-	}
 }
 
 func (p *Partition) isDuplicate(msg *types.Message) bool {
@@ -123,7 +109,6 @@ func (p *Partition) Enqueue(msg types.Message) {
 	}
 
 	p.NotifyNewMessage()
-	p.enqueueToBroadcast(msg)
 }
 
 func (p *Partition) EnqueueSync(msg types.Message) error {
@@ -151,7 +136,6 @@ func (p *Partition) EnqueueSync(msg types.Message) error {
 	}
 
 	p.NotifyNewMessage()
-	p.enqueueToBroadcast(msg)
 	return nil
 }
 
@@ -182,7 +166,6 @@ func (p *Partition) EnqueueBatchSync(msgs []types.Message) error {
 		if p.HWM < offset+1 {
 			p.HWM = offset + 1
 		}
-		p.enqueueToBroadcast(msgs[i])
 	}
 	p.NotifyNewMessage()
 	return nil
@@ -214,23 +197,9 @@ func (p *Partition) EnqueueBatch(msgs []types.Message) error {
 		if p.HWM < offset+1 {
 			p.HWM = offset + 1
 		}
-		p.enqueueToBroadcast(msgs[i])
 	}
 	p.NotifyNewMessage()
 	return nil
-}
-
-func (p *Partition) enqueueToBroadcast(msg types.Message) {
-	select {
-	case p.broadcastCh <- msg:
-	default:
-		util.Warn("⚠️ partition %d: Broadcast channel full, dropping real-time delivery", p.id)
-	}
-}
-
-func (p *Partition) broadcastToStreams(msg types.Message) {
-	// Real-time broadcast is disabled to prevent data interleaving with StreamConnection.Run.
-	// StreamConnection.Run handles fetching and delivering messages based on the client's offset.
 }
 
 func (p *Partition) NotifyNewMessage() {
@@ -302,5 +271,4 @@ func (p *Partition) Close() {
 		return
 	}
 	p.closed = true
-	close(p.broadcastCh)
 }

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/disk"
@@ -230,30 +229,8 @@ func (p *Partition) enqueueToBroadcast(msg types.Message) {
 }
 
 func (p *Partition) broadcastToStreams(msg types.Message) {
-	if util.IsNil(p.streamManager) {
-		return
-	}
-
-	streams := p.streamManager.GetStreamsForPartition(p.topic, p.id)
-	for _, stream := range streams {
-		conn := stream.Conn()
-		if conn == nil {
-			continue
-		}
-
-		if err := conn.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
-			util.Error("⚠️ SetWriteDeadline error: %v", err)
-			continue
-		}
-
-		if err := util.WriteWithLength(conn, []byte(msg.Payload)); err != nil {
-			util.Warn("Failed to broadcast to stream for topic '%s' partition %d: %v", p.topic, p.id, err)
-			continue
-		}
-
-		stream.IncrementOffset()
-		stream.SetLastActive(time.Now())
-	}
+	// Real-time broadcast is disabled to prevent data interleaving with StreamConnection.Run.
+	// StreamConnection.Run handles fetching and delivering messages based on the client's offset.
 }
 
 func (p *Partition) NotifyNewMessage() {

--- a/sdk/backoff.go
+++ b/sdk/backoff.go
@@ -12,14 +12,14 @@ type backoff struct {
 	factor  float64
 }
 
-func newBackoff(min, max time.Duration) *backoff {
-	if min <= 0 {
-		min = time.Millisecond
+func newBackoff(minWait, maxWait time.Duration) *backoff {
+	if minWait <= 0 {
+		minWait = time.Millisecond
 	}
-	if max < min {
-		max = min
+	if maxWait < minWait {
+		maxWait = minWait
 	}
-	return &backoff{current: min, min: min, max: max, factor: 2.0}
+	return &backoff{current: minWait, min: minWait, max: maxWait, factor: 2.0}
 }
 
 // duration returns the next backoff duration with 10% jitter, then advances the internal state.

--- a/sdk/backoff.go
+++ b/sdk/backoff.go
@@ -1,0 +1,47 @@
+package sdk
+
+import (
+	"math/rand"
+	"time"
+)
+
+type backoff struct {
+	current time.Duration
+	min     time.Duration
+	max     time.Duration
+	factor  float64
+}
+
+func newBackoff(min, max time.Duration) *backoff {
+	if min <= 0 {
+		min = time.Millisecond
+	}
+	if max < min {
+		max = min
+	}
+	return &backoff{current: min, min: min, max: max, factor: 2.0}
+}
+
+// duration returns the next backoff duration with 10% jitter, then advances the internal state.
+func (b *backoff) duration() time.Duration {
+	if b.current <= 0 {
+		b.current = time.Millisecond
+	}
+
+	jitterRange := int64(b.current) / 10
+	var jitter time.Duration
+	if jitterRange > 0 {
+		jitter = time.Duration(rand.Int63n(jitterRange))
+	}
+
+	d := b.current + jitter
+	b.current = time.Duration(float64(b.current) * b.factor)
+	if b.current > b.max {
+		b.current = b.max
+	}
+	return d
+}
+
+func (b *backoff) reset() {
+	b.current = b.min
+}

--- a/sdk/bench/bloom_filter.go
+++ b/sdk/bench/bloom_filter.go
@@ -62,8 +62,9 @@ func hashf(data []byte) (uint64, uint64) {
 	h1.Write(data)
 	sum1 := h1.Sum64()
 
+	// Use a different seed/type of hash for better independence
 	h2 := fnv.New64()
-	h2.Write([]byte{0x9e, 0x37, 0x79, 0xb9})
+	h2.Write([]byte{0xDE, 0xAD, 0xBE, 0xEF})
 	h2.Write(data)
 	sum2 := h2.Sum64()
 

--- a/sdk/bench/bloom_filter.go
+++ b/sdk/bench/bloom_filter.go
@@ -8,9 +8,9 @@ import (
 )
 
 func encodeOffset(partition int, offset int64) []byte {
-	var buf [16]byte
-	binary.BigEndian.PutUint64(buf[0:8], uint64(partition))
-	binary.BigEndian.PutUint64(buf[8:16], uint64(offset))
+	var buf [12]byte
+	binary.BigEndian.PutUint32(buf[0:4], uint32(partition))
+	binary.BigEndian.PutUint64(buf[4:12], uint64(offset))
 	return buf[:]
 }
 

--- a/sdk/bench/bloom_filter.go
+++ b/sdk/bench/bloom_filter.go
@@ -1,0 +1,90 @@
+package bench
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"math"
+	"sync/atomic"
+)
+
+func encodeOffset(partition int, offset int64) []byte {
+	var buf [16]byte
+	binary.BigEndian.PutUint64(buf[0:8], uint64(partition))
+	binary.BigEndian.PutUint64(buf[8:16], uint64(offset))
+	return buf[:]
+}
+
+func encodeMessageID(partition int, producerID string, seqNum uint64) []byte {
+	idLen := len(producerID)
+	buf := make([]byte, 4+idLen+8)
+	binary.BigEndian.PutUint32(buf[:4], uint32(partition))
+	copy(buf[4:4+idLen], []byte(producerID))
+	binary.BigEndian.PutUint64(buf[4+idLen:], seqNum)
+	return buf
+}
+
+// BloomFilter is a lock-free probabilistic set membership structure.
+type BloomFilter struct {
+	bits []uint64
+	m    uint64
+	k    uint64
+}
+
+// NewBloomFilter creates a bloom filter sized for expected elements and target false-positive rate.
+func NewBloomFilter(expected uint64, fpRate float64) *BloomFilter {
+	if expected == 0 {
+		expected = 1
+	}
+	if fpRate <= 0 || fpRate >= 1 {
+		fpRate = 0.001
+	}
+
+	m := uint64(-1 * float64(expected) * math.Log(fpRate) / (math.Ln2 * math.Ln2))
+	if m < 64 {
+		m = 64
+	}
+
+	k := uint64(float64(m) / float64(expected) * math.Ln2)
+	if k < 1 {
+		k = 1
+	}
+
+	size := (m + 63) / 64
+	return &BloomFilter{
+		bits: make([]uint64, size),
+		m:    m,
+		k:    k,
+	}
+}
+
+func hashf(data []byte) (uint64, uint64) {
+	h1 := fnv.New64a()
+	h1.Write(data)
+	sum1 := h1.Sum64()
+
+	h2 := fnv.New64()
+	h2.Write([]byte{0x9e, 0x37, 0x79, 0xb9})
+	h2.Write(data)
+	sum2 := h2.Sum64()
+
+	return sum1, sum2
+}
+
+// Add inserts data and returns true if it was already present (probable duplicate).
+func (bf *BloomFilter) Add(data []byte) bool {
+	if bf.m == 0 {
+		return false
+	}
+
+	h1, h2 := hashf(data)
+	seen := true
+	for i := uint64(0); i < bf.k; i++ {
+		idx := (h1 + i*h2) % bf.m
+		word, bit := idx/64, uint64(1)<<(idx%64)
+		old := atomic.OrUint64(&bf.bits[word], bit)
+		if old&bit == 0 {
+			seen = false
+		}
+	}
+	return seen
+}

--- a/sdk/bench/consumer_metrics.go
+++ b/sdk/bench/consumer_metrics.go
@@ -285,15 +285,14 @@ func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
 		for id := range pm.partitions {
 			pIDs = append(pIDs, id)
 		}
-		pm.mu.RUnlock()
 		sort.Ints(pIDs)
 
 		var tpsValues []float64
-		pm.mu.RLock()
 		for _, id := range pIDs {
 			tpsValues = append(tpsValues, pm.partitions[id].TPS())
 		}
 		pm.mu.RUnlock()
+
 		sort.Float64s(tpsValues)
 
 		fmt.Fprintln(w)

--- a/sdk/bench/consumer_metrics.go
+++ b/sdk/bench/consumer_metrics.go
@@ -1,0 +1,314 @@
+package bench
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const consumerSep = "========================================"
+
+// Phase labels for consumer metric partitioning.
+type Phase string
+
+const (
+	PhaseInitial    Phase = "initial"
+	PhaseRebalanced Phase = "rebalanced"
+)
+
+type partitionMetrics struct {
+	ID        int
+	mu        sync.RWMutex
+	firstSeen time.Time
+	lastSeen  time.Time
+	totalMsgs int64
+}
+
+func (pm *partitionMetrics) record(count int) {
+	now := time.Now()
+	pm.mu.Lock()
+	if pm.firstSeen.IsZero() {
+		pm.firstSeen = now
+	}
+	pm.lastSeen = now
+	pm.mu.Unlock()
+	atomic.AddInt64(&pm.totalMsgs, int64(count))
+}
+
+func (pm *partitionMetrics) TPS() float64 {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	if pm.firstSeen.IsZero() || pm.lastSeen.Equal(pm.firstSeen) {
+		return 0
+	}
+	elapsed := pm.lastSeen.Sub(pm.firstSeen).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return float64(atomic.LoadInt64(&pm.totalMsgs)) / elapsed
+}
+
+type phaseMetrics struct {
+	startTime  time.Time
+	endTime    time.Time
+	mu         sync.RWMutex
+	totalMsgs  int64
+	partitions map[int]*partitionMetrics
+}
+
+func (pm *phaseMetrics) TPS() float64 {
+	if pm.startTime.IsZero() {
+		return 0
+	}
+	end := pm.endTime
+	if end.IsZero() {
+		end = time.Now()
+	}
+	d := end.Sub(pm.startTime).Seconds()
+	if d <= 0 {
+		return 0
+	}
+	return float64(atomic.LoadInt64(&pm.totalMsgs)) / d
+}
+
+// RebalanceEvent records the timing of a single rebalance.
+type RebalanceEvent struct {
+	Start time.Time
+	End   time.Time
+}
+
+// ConsumerMetrics tracks throughput and optional correctness across phases.
+type ConsumerMetrics struct {
+	startTime time.Time
+	started   bool
+
+	totalMsgs  int64
+	uniqueMsgs int64
+
+	currentPhase Phase
+	phases       map[Phase]*phaseMetrics
+
+	enableCorrectness bool
+	expectedTotal     int64
+	seenOffsetFilter  *BloomFilter
+	seenIDFilter      *BloomFilter
+	dupCount          int64
+	dupOffsetCount    int64
+	missingCount      int64
+
+	mu        sync.RWMutex
+	rebalance *RebalanceEvent
+}
+
+// NewConsumerMetrics creates a metrics collector.
+// If enableCorrectness is true, bloom filters track duplicate offsets and message IDs.
+func NewConsumerMetrics(expected int64, enableCorrectness bool) *ConsumerMetrics {
+	var offsetBF, idBF *BloomFilter
+	if enableCorrectness {
+		offsetBF = NewBloomFilter(uint64(expected), 0.0001)
+		idBF = NewBloomFilter(uint64(expected), 0.0001)
+	}
+
+	return &ConsumerMetrics{
+		currentPhase: PhaseInitial,
+		phases: map[Phase]*phaseMetrics{
+			PhaseInitial: {partitions: make(map[int]*partitionMetrics)},
+		},
+		expectedTotal:     expected,
+		enableCorrectness: enableCorrectness,
+		seenOffsetFilter:  offsetBF,
+		seenIDFilter:      idBF,
+	}
+}
+
+// RecordBatch records that count messages were consumed from partition.
+func (m *ConsumerMetrics) RecordBatch(partition int, count int) {
+	m.mu.Lock()
+	if !m.started {
+		now := time.Now()
+		m.startTime = now
+		m.started = true
+		if ph, ok := m.phases[m.currentPhase]; ok && ph.startTime.IsZero() {
+			ph.startTime = now
+		}
+	}
+	currentPhase := m.currentPhase
+	ph := m.phases[currentPhase]
+	m.mu.Unlock()
+
+	ph.mu.Lock()
+	pm, ok := ph.partitions[partition]
+	if !ok {
+		pm = &partitionMetrics{ID: partition}
+		ph.partitions[partition] = pm
+	}
+	ph.mu.Unlock()
+
+	atomic.AddInt64(&m.totalMsgs, int64(count))
+	atomic.AddInt64(&ph.totalMsgs, int64(count))
+	pm.record(count)
+}
+
+// RecordMessage checks for duplicate offsets and message IDs (requires enableCorrectness).
+func (m *ConsumerMetrics) RecordMessage(partition int, offset int64, producerID string, seqNum uint64) {
+	if !m.enableCorrectness {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	offsetKey := encodeOffset(partition, offset)
+	if m.seenOffsetFilter.Add(offsetKey) {
+		atomic.AddInt64(&m.dupOffsetCount, 1)
+	}
+
+	messageKey := encodeMessageID(partition, producerID, seqNum)
+	if !m.seenIDFilter.Add(messageKey) {
+		atomic.AddInt64(&m.uniqueMsgs, 1)
+	} else {
+		atomic.AddInt64(&m.dupCount, 1)
+	}
+}
+
+// RebalanceStart marks the beginning of a rebalance event.
+func (m *ConsumerMetrics) RebalanceStart() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.rebalance = &RebalanceEvent{Start: time.Now()}
+	if _, ok := m.phases[PhaseRebalanced]; !ok {
+		m.phases[PhaseRebalanced] = &phaseMetrics{partitions: make(map[int]*partitionMetrics)}
+	}
+}
+
+// OnFirstConsumeAfterRebalance transitions to PhaseRebalanced on the first batch after rejoin.
+func (m *ConsumerMetrics) OnFirstConsumeAfterRebalance() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.rebalance == nil || !m.rebalance.End.IsZero() {
+		return
+	}
+
+	now := time.Now()
+	m.rebalance.End = now
+
+	if pm := m.phases[PhaseInitial]; pm != nil && pm.endTime.IsZero() {
+		pm.endTime = now
+	}
+
+	m.phases[PhaseRebalanced].startTime = now
+	m.currentPhase = PhaseRebalanced
+}
+
+// IsFullyConsumed returns (true, "") when totalMsgs >= expectedTotal.
+func (m *ConsumerMetrics) IsFullyConsumed(expectedTotal int64) (bool, string) {
+	current := atomic.LoadInt64(&m.totalMsgs)
+	unique := atomic.LoadInt64(&m.uniqueMsgs)
+	if current < expectedTotal {
+		return false, fmt.Sprintf("receiving... (%d/%d) unique=%d missing=%d",
+			current, expectedTotal, unique, expectedTotal-current)
+	}
+	return true, ""
+}
+
+// Finalize computes missing message count.
+func (m *ConsumerMetrics) Finalize() {
+	consumed := atomic.LoadInt64(&m.totalMsgs)
+	unique := atomic.LoadInt64(&m.uniqueMsgs)
+
+	if consumed < m.expectedTotal {
+		atomic.StoreInt64(&m.missingCount, m.expectedTotal-consumed)
+	} else {
+		atomic.StoreInt64(&m.missingCount, 0)
+	}
+
+	_ = unique // may differ from consumed due to bloom filter false positives
+}
+
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	i := int(float64(len(sorted)-1) * p)
+	return sorted[i]
+}
+
+// PrintSummaryTo writes a formatted summary to w.
+func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	elapsed := time.Since(m.startTime).Seconds()
+	total := atomic.LoadInt64(&m.totalMsgs)
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, consumerSep)
+	fmt.Fprintln(w, "CONSUMER BENCHMARK SUMMARY")
+	fmt.Fprintf(w, "Total Messages       : %d\n", total)
+	fmt.Fprintf(w, "Elapsed Time         : %.2fs\n", elapsed)
+
+	overallTPS := 0.0
+	if elapsed > 0 {
+		overallTPS = float64(total) / elapsed
+	}
+	fmt.Fprintf(w, "Overall TPS          : %.2f msg/s\n", overallTPS)
+
+	if m.enableCorrectness {
+		fmt.Fprintf(w, "Duplicate (MessageID): %d (fp possible)\n", atomic.LoadInt64(&m.dupCount))
+		fmt.Fprintf(w, "Duplicate (Offset)   : %d (fp possible)\n", atomic.LoadInt64(&m.dupOffsetCount))
+		fmt.Fprintf(w, "Messages missing     : %d\n", atomic.LoadInt64(&m.missingCount))
+	} else {
+		fmt.Fprintf(w, "Correctness Check    : disabled\n")
+	}
+
+	if m.rebalance != nil && !m.rebalance.End.IsZero() {
+		fmt.Fprintf(w, "Rebalancing Cost     : %d ms\n", m.rebalance.End.Sub(m.rebalance.Start).Milliseconds())
+	}
+
+	var phaseKeys []string
+	for k := range m.phases {
+		phaseKeys = append(phaseKeys, string(k))
+	}
+	sort.Strings(phaseKeys)
+
+	for _, k := range phaseKeys {
+		pm := m.phases[Phase(k)]
+
+		var pIDs []int
+		for id := range pm.partitions {
+			pIDs = append(pIDs, id)
+		}
+		sort.Ints(pIDs)
+
+		var tpsValues []float64
+		for _, id := range pIDs {
+			tpsValues = append(tpsValues, pm.partitions[id].TPS())
+		}
+		sort.Float64s(tpsValues)
+
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Phase: %s\n", k)
+		fmt.Fprintf(w, "  Phase Total TPS       : %.2f\n", pm.TPS())
+		fmt.Fprintf(w, "  p95 Partition TPS     : %.2f\n", percentile(tpsValues, 0.95))
+		fmt.Fprintf(w, "  p99 Partition TPS     : %.2f\n", percentile(tpsValues, 0.99))
+
+		for _, id := range pIDs {
+			p := pm.partitions[id]
+			fmt.Fprintf(w, "    #%-2d total=%-8d avgTPS=%.1f\n", p.ID, atomic.LoadInt64(&p.totalMsgs), p.TPS())
+		}
+	}
+
+	fmt.Fprintln(w, consumerSep)
+}
+
+// PrintSummary writes the summary to stdout.
+func (m *ConsumerMetrics) PrintSummary() {
+	fmt.Fprintln(os.Stdout, "Benchmark completed successfully!")
+	m.PrintSummaryTo(os.Stdout)
+}

--- a/sdk/bench/consumer_metrics.go
+++ b/sdk/bench/consumer_metrics.go
@@ -281,15 +281,19 @@ func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
 		pm := m.phases[Phase(k)]
 
 		var pIDs []int
+		pm.mu.RLock()
 		for id := range pm.partitions {
 			pIDs = append(pIDs, id)
 		}
+		pm.mu.RUnlock()
 		sort.Ints(pIDs)
 
 		var tpsValues []float64
+		pm.mu.RLock()
 		for _, id := range pIDs {
 			tpsValues = append(tpsValues, pm.partitions[id].TPS())
 		}
+		pm.mu.RUnlock()
 		sort.Float64s(tpsValues)
 
 		fmt.Fprintln(w)

--- a/sdk/bench/producer_metrics.go
+++ b/sdk/bench/producer_metrics.go
@@ -1,0 +1,176 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	sdk "github.com/cursus-io/cursus/sdk"
+)
+
+const producerSep = "========================================"
+
+// BenchmarkResult is the JSON-serialisable output of a producer benchmark run.
+type BenchmarkResult struct {
+	Timestamp      time.Time         `json:"timestamp"`
+	TotalTarget    int               `json:"total_target"`
+	UniqueSent     int               `json:"unique_sent"`
+	TotalPublished int               `json:"total_published"`
+	RetryCount     int               `json:"retry_count"`
+	SentMessages   int               `json:"sent_messages"`
+	FailedMessages int               `json:"failed_messages"`
+	SuccessRate    float64           `json:"success_rate"`
+	TotalDuration  float64           `json:"duration_seconds"`
+	MsgPerSec      float64           `json:"msg_per_sec"`
+	LatencyP95     float64           `json:"latency_p95_ms"`
+	LatencyP99     float64           `json:"latency_p99_ms"`
+	Errors         map[string]uint64 `json:"errors,omitempty"`
+}
+
+// CalculateLatencyPercentiles returns the p95 and p99 of the provided latency slice.
+func CalculateLatencyPercentiles(latencies []time.Duration) (p95, p99 time.Duration) {
+	if len(latencies) == 0 {
+		return 0, 0
+	}
+
+	sorted := make([]time.Duration, len(latencies))
+	copy(sorted, latencies)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	n := len(sorted)
+	p95Idx := int(float64(n) * 0.95)
+	p99Idx := int(float64(n) * 0.99)
+	if p95Idx >= n {
+		p95Idx = n - 1
+	}
+	if p99Idx >= n {
+		p99Idx = n - 1
+	}
+	return sorted[p95Idx], sorted[p99Idx]
+}
+
+// GenerateMessage creates a padded benchmark message of the given byte size.
+func GenerateMessage(size int, seqNum int) string {
+	if size <= 0 {
+		return fmt.Sprintf("Hello World! #%d", seqNum)
+	}
+	header := fmt.Sprintf("msg-%d-", seqNum)
+	paddingSize := size - len(header)
+	if paddingSize < 0 {
+		paddingSize = 0
+	}
+	return header + strings.Repeat("x", paddingSize)
+}
+
+// PrintBenchmarkSummaryFixedTo writes a formatted producer benchmark summary to w.
+// partitionStats is []sdk.PartitionStat.
+func PrintBenchmarkSummaryFixedTo(
+	w io.Writer,
+	partitionStats []sdk.PartitionStat,
+	totalSent int,
+	publishedMessages int,
+	targetCount int,
+	totalDuration time.Duration,
+	errSummary map[string]uint64,
+	allLatencies []time.Duration,
+) {
+	totalBatches := 0
+	for _, ps := range partitionStats {
+		totalBatches += ps.BatchCount
+	}
+
+	retryCount := totalSent - publishedMessages
+	if retryCount < 0 {
+		retryCount = 0
+	}
+	failedCount := targetCount - publishedMessages
+	if failedCount < 0 {
+		failedCount = 0
+	}
+
+	seconds := totalDuration.Seconds()
+	if seconds <= 0 {
+		seconds = 0.001
+	}
+
+	successRate := 0.0
+	if targetCount > 0 {
+		successRate = float64(publishedMessages) / float64(targetCount) * 100
+	}
+	messagesPerSec := float64(publishedMessages) / seconds
+	batchesPerSec := float64(totalBatches) / seconds
+
+	p95, p99 := CalculateLatencyPercentiles(allLatencies)
+
+	fmt.Fprint(w, "\r\n")
+	fmt.Fprintln(w, producerSep)
+	fmt.Fprintln(w, "PRODUCER BENCHMARK SUMMARY")
+	fmt.Fprintf(w, "%-28s : %d\n", "Partitions", len(partitionStats))
+	fmt.Fprintf(w, "%-28s : %d\n", "Total Batches", totalBatches)
+	fmt.Fprintf(w, "%-28s : %d / %d (rate: %.2f%%)\n", "Total Messages", publishedMessages, targetCount, successRate)
+	fmt.Fprintf(w, "%-28s : %d\n", "Failed messages", failedCount)
+	fmt.Fprintf(w, "%-28s : %d\n", "Retry Count", retryCount)
+	fmt.Fprintf(w, "%-28s : %.3fs\n", "Publish Elapsed Time", seconds)
+	fmt.Fprintf(w, "%-28s : %.2f batches/s\n", "Batch Throughput", batchesPerSec)
+	fmt.Fprintf(w, "%-28s : %.2f msg/s\n", "Message Throughput", messagesPerSec)
+	fmt.Fprintf(w, "%-28s : %.2f ms\n", "Latency P95", float64(p95.Microseconds())/1000.0)
+	fmt.Fprintf(w, "%-28s : %.2f ms\n", "Latency P99", float64(p99.Microseconds())/1000.0)
+	fmt.Fprint(w, "\r\n")
+
+	fmt.Fprintln(w, "Partition Breakdown:")
+	for _, ps := range partitionStats {
+		fmt.Fprintf(w, "  #%-2d batches=%-4d avg_batch=%.2fms\n",
+			ps.PartitionID, ps.BatchCount, float64(ps.AvgDuration.Microseconds())/1000.0)
+	}
+
+	if len(errSummary) > 0 {
+		fmt.Fprintln(w, "\nError Root Cause Analysis:")
+		for msg, count := range errSummary {
+			fmt.Fprintf(w, "  - [%d occurrences]: %s\n", count, msg)
+		}
+	}
+	fmt.Fprintln(w, producerSep)
+
+	result := BenchmarkResult{
+		Timestamp:      time.Now(),
+		TotalTarget:    targetCount,
+		UniqueSent:     publishedMessages,
+		TotalPublished: totalSent,
+		RetryCount:     retryCount,
+		SentMessages:   publishedMessages,
+		FailedMessages: failedCount,
+		SuccessRate:    successRate,
+		TotalDuration:  seconds,
+		MsgPerSec:      messagesPerSec,
+		LatencyP95:     float64(p95.Microseconds()) / 1000.0,
+		LatencyP99:     float64(p99.Microseconds()) / 1000.0,
+		Errors:         errSummary,
+	}
+	saveResultToJSON(result)
+}
+
+func saveResultToJSON(res BenchmarkResult) {
+	data, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		log.Printf("[ERROR] Failed to marshal benchmark result: %v", err)
+		return
+	}
+
+	dir := "bench_results"
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Printf("[ERROR] Failed to create bench_results dir: %v", err)
+		return
+	}
+
+	filename := fmt.Sprintf("%s/bench_%d.json", dir, time.Now().Unix())
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		log.Printf("[ERROR] Failed to save benchmark JSON '%s': %v", filename, err)
+		return
+	}
+	log.Printf("[INFO] Benchmark result saved to %s", filename)
+}

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
 
@@ -37,7 +38,7 @@ type PublisherConfig struct {
 	TLSCertPath string `yaml:"tls_cert_path" json:"tls_cert_path"`
 	TLSKeyPath  string `yaml:"tls_key_path" json:"tls_key_path"`
 
-	CompressionType string `yaml:"compression_type" json:"compression.type"` // "none", "gzip", "snappy", "lz4"
+	CompressionType string `yaml:"compression_type" json:"compression_type"` // "none", "gzip", "snappy", "lz4"
 
 	EnableBenchmark bool   `yaml:"enable_benchmark" json:"enable_benchmark"`
 	BenchTopicName  string `yaml:"bench_topic_name" json:"bench_topic_name"`
@@ -118,7 +119,7 @@ type ConsumerConfig struct {
 
 	LeaderStaleness time.Duration `yaml:"leader_staleness" json:"leader_staleness"`
 
-	CompressionType string `yaml:"compression_type" json:"compression.type"` // "none", "gzip", "snappy", "lz4"
+	CompressionType string `yaml:"compression_type" json:"compression_type"` // "none", "gzip", "snappy", "lz4"
 
 	LogLevel LogLevel `yaml:"log_level" json:"log_level"`
 }
@@ -126,7 +127,7 @@ type ConsumerConfig struct {
 func NewDefaultConsumerConfig() *ConsumerConfig {
 	return &ConsumerConfig{
 		BrokerAddrs:              []string{"localhost:9000"},
-		ConsumerID:               "default-consumer",
+		ConsumerID:               "consumer-" + uuid.New().String()[:8],
 		GroupID:                  "default-group",
 		WorkerChannelSize:        1000,
 		PollInterval:             500 * time.Millisecond,
@@ -152,6 +153,13 @@ func NewDefaultConsumerConfig() *ConsumerConfig {
 }
 
 func LoadConfig(path string, cfg interface{}) error {
+	// Seed default values before unmarshalling if possible
+	if c, ok := cfg.(*ConsumerConfig); ok {
+		*c = *NewDefaultConsumerConfig()
+	} else if p, ok := cfg.(*PublisherConfig); ok {
+		*p = *NewDefaultPublisherConfig()
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -1,0 +1,163 @@
+package sdk
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type PublisherConfig struct {
+	BrokerAddrs        []string `yaml:"broker_addrs" json:"broker_addrs"`
+	CurrentBrokerIndex int      `yaml:"-" json:"-"`
+
+	MaxRetries     int `yaml:"max_retries" json:"max_retries"`
+	RetryBackoffMS int `yaml:"retry_backoff_ms" json:"retry_backoff_ms"`
+	AckTimeoutMS   int `yaml:"ack_timeout_ms" json:"ack_timeout_ms"`
+
+	Topic            string `yaml:"topic" json:"topic"`
+	AutoCreateTopics bool   `yaml:"auto_create_topics" json:"auto_create_topics"`
+	Partitions       int    `yaml:"partitions" json:"partitions"`
+
+	LeaderStaleness time.Duration `yaml:"leader_staleness" json:"leader_staleness"`
+
+	PublishDelayMS      int `yaml:"publish_delay_ms" json:"publish_delay_ms"`
+	MaxInflightRequests int `yaml:"max_inflight_requests" json:"max_inflight_requests"`
+	MaxBackoffMS        int `yaml:"max_backoff_ms" json:"max_backoff_ms"`
+	WriteTimeoutMS      int `yaml:"write_timeout_ms" json:"write_timeout_ms"`
+
+	Acks              string `yaml:"acks" json:"acks"`
+	EnableIdempotence bool   `yaml:"enable_idempotence" json:"enable_idempotence"`
+	BatchSize         int    `yaml:"batch_size" json:"batch_size"`
+	BufferSize        int    `yaml:"buffer_size" json:"buffer_size"`
+	LingerMS          int    `yaml:"linger_ms" json:"linger_ms"`
+
+	UseTLS      bool   `yaml:"use_tls" json:"use_tls"`
+	TLSCertPath string `yaml:"tls_cert_path" json:"tls_cert_path"`
+	TLSKeyPath  string `yaml:"tls_key_path" json:"tls_key_path"`
+
+	CompressionType string `yaml:"compression_type" json:"compression.type"` // "none", "gzip", "snappy", "lz4"
+
+	EnableBenchmark bool   `yaml:"enable_benchmark" json:"enable_benchmark"`
+	BenchTopicName  string `yaml:"bench_topic_name" json:"bench_topic_name"`
+	MessageSize     int    `yaml:"benchmark_message_size" json:"benchmark_message_size"`
+	NumMessages     int    `yaml:"num_messages" json:"num_messages"`
+
+	FlushTimeoutMS int `yaml:"flush_timeout_ms" json:"flush_timeout_ms"`
+
+	LogLevel LogLevel `yaml:"log_level" json:"log_level"`
+}
+
+func NewDefaultPublisherConfig() *PublisherConfig {
+	return &PublisherConfig{
+		BrokerAddrs:         []string{"localhost:9000"},
+		MaxRetries:          3,
+		RetryBackoffMS:      100,
+		AckTimeoutMS:        5000,
+		Topic:               "default-topic",
+		Partitions:          1,
+		LeaderStaleness:     30 * time.Second,
+		MaxInflightRequests: 5,
+		BatchSize:           100,
+		BufferSize:          1024,
+		LingerMS:            50,
+		MaxBackoffMS:        2000,
+		WriteTimeoutMS:      5000,
+		FlushTimeoutMS:      30000,
+		Acks:                "1",
+		CompressionType:     "none",
+		LogLevel:            LogLevelInfo,
+	}
+}
+
+type ConsumerMode string
+
+const (
+	ModePolling   ConsumerMode = "polling"
+	ModeStreaming ConsumerMode = "streaming"
+)
+
+type ConsumerConfig struct {
+	BrokerAddrs        []string `yaml:"broker_addrs" json:"broker_addrs"`
+	CurrentBrokerIndex int      `yaml:"-" json:"-"`
+
+	Topic      string `yaml:"topic" json:"topic"`
+	GroupID    string `yaml:"group_id" json:"group_id"`
+	ConsumerID string `yaml:"consumer_id" json:"consumer_id"`
+
+	EnableBenchmark   bool         `yaml:"enable_benchmark" json:"enable_benchmark"`
+	EnableCorrectness bool         `yaml:"enable_correctness" json:"enable_correctness"`
+	NumMessages       int          `yaml:"num_messages" json:"num_messages"`
+	Mode              ConsumerMode `yaml:"mode" json:"mode"`
+
+	WorkerChannelSize int `yaml:"worker_channel_size" json:"worker_channel_size"`
+
+	PollInterval  time.Duration `yaml:"poll_interval" json:"poll_interval"`
+	PollTimeoutMS int           `yaml:"poll_timeout_ms" json:"poll_timeout_ms"`
+	BatchSize     int           `yaml:"batch_size" json:"batch_size"`
+
+	SessionTimeoutMS         int `yaml:"session_timeout_ms" json:"session_timeout_ms"`
+	MaxPollRecords           int `yaml:"max_poll_records" json:"max_poll_records"`
+	MaxConnectRetries        int `yaml:"max_connect_retries" json:"max_connect_retries"`
+	ConnectRetryBackoffMS    int `yaml:"connect_retry_backoff_ms" json:"connect_retry_backoff_ms"`
+	HeartbeatIntervalMS      int `yaml:"heartbeat_interval_ms" json:"heartbeat_interval_ms"`
+	StreamingReadDeadlineMS  int `yaml:"streaming_read_deadline_ms" json:"streaming_read_deadline_ms"`
+	StreamingRetryIntervalMS int `yaml:"streaming_retry_interval_ms" json:"streaming_retry_interval_ms"`
+
+	EnableAutoCommit   bool          `yaml:"enable_auto_commit" json:"enable_auto_commit"`
+	AutoCommitInterval time.Duration `yaml:"auto_commit_interval" json:"auto_commit_interval"`
+
+	MaxCommitRetries      int           `yaml:"max_commit_retries" json:"max_commit_retries"`
+	CommitRetryBackoff    time.Duration `yaml:"commit_retry_backoff" json:"commit_retry_backoff"`
+	CommitRetryMaxBackoff time.Duration `yaml:"commit_retry_max_backoff" json:"commit_retry_max_backoff"`
+
+	StreamingCommitInterval  time.Duration `yaml:"streaming_commit_interval" json:"streaming_commit_interval"`
+	EnableImmediateCommit    bool          `yaml:"enable_immediate_commit" json:"enable_immediate_commit"`
+	StreamingCommitBatchSize int           `yaml:"streaming_commit_batch_size" json:"streaming_commit_batch_size"`
+
+	LeaderStaleness time.Duration `yaml:"leader_staleness" json:"leader_staleness"`
+
+	CompressionType string `yaml:"compression_type" json:"compression.type"` // "none", "gzip", "snappy", "lz4"
+
+	LogLevel LogLevel `yaml:"log_level" json:"log_level"`
+}
+
+func NewDefaultConsumerConfig() *ConsumerConfig {
+	return &ConsumerConfig{
+		BrokerAddrs:              []string{"localhost:9000"},
+		ConsumerID:               "default-consumer",
+		GroupID:                  "default-group",
+		WorkerChannelSize:        1000,
+		PollInterval:             500 * time.Millisecond,
+		PollTimeoutMS:            30000,
+		BatchSize:                100,
+		MaxPollRecords:           500,
+		EnableAutoCommit:         true,
+		AutoCommitInterval:       5 * time.Second,
+		MaxCommitRetries:         5,
+		CommitRetryBackoff:       500 * time.Millisecond,
+		CommitRetryMaxBackoff:    2 * time.Second,
+		StreamingCommitInterval:  1 * time.Second,
+		StreamingCommitBatchSize: 100,
+		SessionTimeoutMS:         30000,
+		HeartbeatIntervalMS:      3000,
+		CompressionType:          "none",
+		LeaderStaleness:          30 * time.Second,
+		StreamingReadDeadlineMS:  300000,
+		StreamingRetryIntervalMS: 1000,
+		Mode:                     ModePolling,
+		LogLevel:                 LogLevelInfo,
+	}
+}
+
+func LoadConfig(path string, cfg interface{}) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if strings.HasSuffix(path, ".json") {
+		return json.Unmarshal(data, cfg)
+	}
+	return yaml.Unmarshal(data, cfg)
+}

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -1,0 +1,857 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type consumerLeaderInfo struct {
+	addr    string
+	updated time.Time
+}
+
+type ConsumerClient struct {
+	ID     string
+	config *ConsumerConfig
+	leader atomic.Pointer[consumerLeaderInfo]
+}
+
+func NewConsumerClient(cfg *ConsumerConfig) *ConsumerClient {
+	c := &ConsumerClient{
+		ID:     uuid.New().String(),
+		config: cfg,
+	}
+	c.leader.Store(&consumerLeaderInfo{addr: "", updated: time.Time{}})
+	return c
+}
+
+func (c *ConsumerClient) UpdateLeader(addr string) {
+	oldInfo := c.leader.Load()
+	if oldInfo.addr != addr {
+		c.leader.Store(&consumerLeaderInfo{
+			addr:    addr,
+			updated: time.Now(),
+		})
+	}
+}
+
+func (c *ConsumerClient) Connect(addr string) (net.Conn, error) {
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	conn, err := dialer.Dial("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("dial failed to %s: %w", addr, err)
+	}
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetNoDelay(true)
+		tcpConn.SetKeepAlive(true)
+		tcpConn.SetKeepAlivePeriod(30 * time.Second)
+		tcpConn.SetReadBuffer(2 * 1024 * 1024)
+		tcpConn.SetWriteBuffer(2 * 1024 * 1024)
+	}
+
+	return conn, nil
+}
+
+func (c *ConsumerClient) ConnectWithFailover() (net.Conn, string, error) {
+	addrs := c.config.BrokerAddrs
+	if len(addrs) == 0 {
+		return nil, "", fmt.Errorf("no broker addresses configured")
+	}
+
+	leaderAddr := ""
+	if info := c.leader.Load(); info != nil && info.addr != "" && time.Since(info.updated) < c.config.LeaderStaleness {
+		leaderAddr = info.addr
+	}
+
+	if leaderAddr != "" {
+		if conn, err := c.Connect(leaderAddr); err == nil {
+			return conn, leaderAddr, nil
+		}
+	}
+
+	var lastErr error
+	for _, addr := range addrs {
+		if addr == leaderAddr {
+			continue
+		}
+		conn, err := c.Connect(addr)
+		if err == nil {
+			c.UpdateLeader(addr)
+			return conn, addr, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		return nil, "", fmt.Errorf("all brokers unreachable: %w", lastErr)
+	}
+	return nil, "", fmt.Errorf("all brokers unreachable")
+}
+
+type Consumer struct {
+	config             *ConsumerConfig
+	client             *ConsumerClient
+	partitionConsumers map[int]*PartitionConsumer
+
+	generation int64
+	memberID   string
+
+	commitConn     net.Conn
+	commitCh       chan commitEntry
+	commitMu       sync.Mutex
+	commitRetryMap map[int]uint64
+
+	currentOffsets map[int]uint64
+	offsetsMu      sync.Mutex
+
+	wg         sync.WaitGroup
+	mainCtx    context.Context
+	mainCancel context.CancelFunc
+
+	rebalancing  int32
+	rebalanceSig chan struct{}
+
+	offsets map[int]uint64
+	doneCh  chan struct{}
+	mu      sync.RWMutex
+
+	hbConn net.Conn
+	hbMu   sync.Mutex
+
+	closed int32
+
+	MessageHandler func(Message) error
+}
+
+type commitEntry struct {
+	partition int
+	offset    uint64
+	respCh    chan error
+}
+
+func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
+	client := NewConsumerClient(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &Consumer{
+		config:             cfg,
+		client:             client,
+		partitionConsumers: make(map[int]*PartitionConsumer),
+		offsets:            make(map[int]uint64),
+		currentOffsets:     make(map[int]uint64),
+		rebalanceSig:       make(chan struct{}, 1),
+		doneCh:             make(chan struct{}),
+		mainCtx:            ctx,
+		mainCancel:         cancel,
+	}
+
+	c.commitCh = make(chan commitEntry, 1024)
+	return c, nil
+}
+
+func (c *Consumer) Start(handler func(Message) error) error {
+	c.MessageHandler = handler
+	gen, mid, assignments, err := c.joinGroupWithRetry()
+	if err != nil {
+		return fmt.Errorf("join group failed: %w", err)
+	}
+	c.generation = gen
+	c.memberID = mid
+
+	if len(assignments) == 0 {
+		assignments, err = c.syncGroup(gen, mid)
+		if err != nil {
+			return fmt.Errorf("sync group failed: %w", err)
+		}
+	}
+
+	LogInfo("✅ Successfully joined topic '%s' for group '%s' with %d partitions: %v (generation=%d, member=%s)",
+		c.config.Topic, c.config.GroupID, len(assignments), assignments, gen, mid)
+
+	c.mu.Lock()
+	c.partitionConsumers = make(map[int]*PartitionConsumer)
+	for _, pid := range assignments {
+		offset, err := c.fetchOffset(pid)
+		if err != nil {
+			logWarn("Failed to fetch offset for P%d: %v", pid, err)
+			offset = 0
+		}
+
+		c.offsets[pid] = offset
+
+		pc := &PartitionConsumer{
+			partitionID:  pid,
+			consumer:     c,
+			fetchOffset:  offset,
+			commitOffset: offset,
+		}
+		c.partitionConsumers[pid] = pc
+	}
+	c.mu.Unlock()
+
+	c.startCommitWorker()
+	go c.rebalanceMonitorLoop()
+
+	if c.config.Mode != ModeStreaming {
+		go c.startConsuming()
+	} else {
+		go c.startStreaming()
+	}
+
+	<-c.mainCtx.Done()
+	return nil
+}
+
+func (c *Consumer) startCommitWorker() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		ticker := time.NewTicker(c.config.AutoCommitInterval)
+		defer ticker.Stop()
+
+		pendingOffsets := make(map[int]uint64)
+		respChannels := make(map[int][]chan error)
+
+		flush := func() {
+			if len(pendingOffsets) > 0 {
+				c.commitBatch(pendingOffsets, respChannels)
+				pendingOffsets = make(map[int]uint64)
+				respChannels = make(map[int][]chan error)
+			}
+		}
+
+		for {
+			select {
+			case entry, ok := <-c.commitCh:
+				if !ok {
+					flush()
+					return
+				}
+
+				if existing, exists := pendingOffsets[entry.partition]; !exists || entry.offset > existing {
+					pendingOffsets[entry.partition] = entry.offset
+				}
+
+				if entry.respCh != nil {
+					respChannels[entry.partition] = append(respChannels[entry.partition], entry.respCh)
+					flush()
+				}
+
+			case <-ticker.C:
+				c.flushOffsets()
+				flush()
+
+			case <-c.doneCh:
+				flush()
+				return
+			}
+		}
+	}()
+}
+
+func (c *Consumer) flushOffsets() {
+	if atomic.LoadInt32(&c.rebalancing) == 1 {
+		return
+	}
+
+	c.offsetsMu.Lock()
+	defer c.offsetsMu.Unlock()
+
+	if len(c.currentOffsets) == 0 {
+		return
+	}
+
+	for pid, offset := range c.currentOffsets {
+		c.mu.RLock()
+		lastCommitted := c.offsets[pid]
+		c.mu.RUnlock()
+
+		if offset > lastCommitted {
+			select {
+			case c.commitCh <- commitEntry{
+				partition: pid,
+				offset:    offset,
+				respCh:    nil,
+			}:
+			default:
+			}
+		}
+	}
+	c.currentOffsets = make(map[int]uint64)
+}
+
+func (c *Consumer) commitBatch(offsets map[int]uint64, respChannels map[int][]chan error) {
+	success := c.sendBatchCommit(offsets)
+
+	for pid, channels := range respChannels {
+		var err error
+		if !success {
+			err = fmt.Errorf("batch commit failed for partition %d", pid)
+		}
+		for _, ch := range channels {
+			if ch != nil {
+				ch <- err
+			}
+		}
+	}
+}
+
+func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
+	c.commitMu.Lock()
+	conn := c.commitConn
+	if conn == nil {
+		newConn, err := c.getLeaderConn()
+		if err != nil {
+			c.commitMu.Unlock()
+			return false
+		}
+		c.commitConn = newConn
+		conn = newConn
+	}
+	c.commitMu.Unlock()
+
+	c.mu.RLock()
+	generation := c.generation
+	memberID := c.memberID
+	c.mu.RUnlock()
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("BATCH_COMMIT topic=%s group=%s generation=%d member=%s ", c.config.Topic, c.config.GroupID, generation, memberID))
+	parts := []string{}
+	for pid, off := range offsets {
+		parts = append(parts, fmt.Sprintf("%d:%d", pid, off))
+	}
+	sb.WriteString(strings.Join(parts, ","))
+
+	if err := WriteWithLength(conn, EncodeMessage("", sb.String())); err != nil {
+		c.commitMu.Lock()
+		if c.commitConn == conn {
+			c.commitConn = nil
+			_ = conn.Close()
+		}
+		c.commitMu.Unlock()
+		return false
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		c.commitMu.Lock()
+		if c.commitConn == conn {
+			c.commitConn = nil
+			_ = conn.Close()
+		}
+		c.commitMu.Unlock()
+		return false
+	}
+
+	respStr := string(resp)
+	if strings.HasPrefix(respStr, "OK") {
+		return true
+	}
+
+	if strings.Contains(respStr, "REBALANCE_REQUIRED") || strings.Contains(respStr, "GEN_MISMATCH") {
+		select {
+		case c.rebalanceSig <- struct{}{}:
+		default:
+		}
+	}
+	return false
+}
+
+func (c *Consumer) getLeaderConn() (net.Conn, error) {
+	conn, _, err := c.client.ConnectWithFailover()
+	return conn, err
+}
+
+func (c *Consumer) rebalanceMonitorLoop() {
+	for {
+		select {
+		case <-c.doneCh:
+			return
+		case <-c.rebalanceSig:
+			c.handleRebalanceSignal()
+		}
+	}
+}
+
+func (c *Consumer) handleRebalanceSignal() {
+	if !atomic.CompareAndSwapInt32(&c.rebalancing, 0, 1) {
+		return
+	}
+	defer atomic.StoreInt32(&c.rebalancing, 0)
+
+	LogInfo("🔄 Rebalance started - Stop existing workers")
+	c.mainCancel()
+
+	c.wg.Wait()
+
+	c.hbMu.Lock()
+	if c.hbConn != nil {
+		_ = c.hbConn.Close()
+		c.hbConn = nil
+	}
+	c.hbMu.Unlock()
+
+	c.commitMu.Lock()
+	if c.commitConn != nil {
+		_ = c.commitConn.Close()
+		c.commitConn = nil
+	}
+	c.commitMu.Unlock()
+
+	c.mu.Lock()
+	for _, pc := range c.partitionConsumers {
+		pc.closeConnection()
+	}
+	c.partitionConsumers = make(map[int]*PartitionConsumer)
+	c.offsets = make(map[int]uint64)
+	c.mu.Unlock()
+
+	c.mainCtx, c.mainCancel = context.WithCancel(context.Background())
+	gen, mid, assignments, err := c.joinGroupWithRetry()
+	if err != nil {
+		logError("Rebalance join failed: %v", err)
+		return
+	}
+
+	if len(assignments) == 0 {
+		assignments, err = c.syncGroup(gen, mid)
+		if err != nil {
+			logError("❌ Rebalance sync failed: %v", err)
+			return
+		}
+	}
+
+	c.mu.Lock()
+	c.generation = gen
+	c.memberID = mid
+
+	for _, pid := range assignments {
+		offset, err := c.fetchOffset(pid)
+		if err != nil {
+			offset = 0
+		}
+
+		pc := &PartitionConsumer{
+			partitionID:  pid,
+			consumer:     c,
+			fetchOffset:  offset,
+			commitOffset: offset,
+		}
+		c.partitionConsumers[pid] = pc
+	}
+	c.mu.Unlock()
+
+	if c.config.Mode != ModeStreaming {
+		go c.startConsuming()
+	} else {
+		go c.startStreaming()
+	}
+}
+
+func (c *Consumer) startConsuming() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.heartbeatLoop()
+	}()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for pid, pc := range c.partitionConsumers {
+		c.wg.Add(1)
+		go func(pid int, pc *PartitionConsumer) {
+			defer c.wg.Done()
+
+			for {
+				select {
+				case <-c.doneCh:
+					return
+				case <-c.mainCtx.Done():
+					return
+				default:
+					pc.pollAndProcess()
+					time.Sleep(c.config.PollInterval)
+				}
+			}
+		}(pid, pc)
+	}
+}
+
+func (c *Consumer) startStreaming() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.heartbeatLoop()
+	}()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, pc := range c.partitionConsumers {
+		c.wg.Add(1)
+		go func(pc *PartitionConsumer) {
+			defer c.wg.Done()
+			pc.startStreamLoop()
+		}(pc)
+	}
+}
+
+func (c *Consumer) joinGroupWithRetry() (int64, string, []int, error) {
+	for i := 0; i < 30; i++ {
+		gen, mid, assignments, err := c.joinGroup()
+		if err == nil {
+			return gen, mid, assignments, nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return 0, "", nil, fmt.Errorf("join group timeout")
+}
+
+func (c *Consumer) joinGroup() (int64, string, []int, error) {
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer conn.Close()
+
+	mID := c.memberID
+	if mID == "" {
+		mID = c.config.ConsumerID
+	}
+
+	joinCmd := fmt.Sprintf("JOIN_GROUP topic=%s group=%s member=%s", c.config.Topic, c.config.GroupID, mID)
+	if err := WriteWithLength(conn, EncodeMessage("", joinCmd)); err != nil {
+		return 0, "", nil, err
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return 0, "", nil, err
+	}
+
+	respStr := string(resp)
+	if !strings.HasPrefix(respStr, "OK") {
+		return 0, "", nil, fmt.Errorf("join failed: %s", respStr)
+	}
+
+	var gen int64
+	var mid string
+	var assigned []int
+
+	parts := strings.Fields(respStr)
+	for _, part := range parts {
+		if strings.HasPrefix(part, "generation=") {
+			fmt.Sscanf(part, "generation=%d", &gen)
+		} else if strings.HasPrefix(part, "member=") {
+			mid = strings.TrimPrefix(part, "member=")
+		}
+	}
+
+	if strings.Contains(respStr, "assignments=") {
+		start := strings.Index(respStr, "[")
+		end := strings.Index(respStr, "]")
+		if start != -1 && end != -1 {
+			partStr := respStr[start+1 : end]
+			for _, p := range strings.Fields(strings.ReplaceAll(partStr, ",", " ")) {
+				pid, _ := strconv.Atoi(p)
+				assigned = append(assigned, pid)
+			}
+		}
+	}
+
+	return gen, mid, assigned, nil
+}
+
+func (c *Consumer) syncGroup(generation int64, memberID string) ([]int, error) {
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	syncCmd := fmt.Sprintf("SYNC_GROUP topic=%s group=%s member=%s generation=%d", c.config.Topic, c.config.GroupID, memberID, generation)
+	if err := WriteWithLength(conn, EncodeMessage("", syncCmd)); err != nil {
+		return nil, err
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	respStr := string(resp)
+	var assigned []int
+	if strings.Contains(respStr, "[") && strings.Contains(respStr, "]") {
+		start := strings.Index(respStr, "[")
+		end := strings.Index(respStr, "]")
+		partitionStr := respStr[start+1 : end]
+		for _, p := range strings.Fields(partitionStr) {
+			var pid int
+			fmt.Sscanf(p, "%d", &pid)
+			assigned = append(assigned, pid)
+		}
+	}
+
+	return assigned, nil
+}
+
+func (c *Consumer) fetchOffset(partition int) (uint64, error) {
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+
+	fetchCmd := fmt.Sprintf("FETCH_OFFSET topic=%s partition=%d group=%s", c.config.Topic, partition, c.config.GroupID)
+	if err := WriteWithLength(conn, EncodeMessage("", fetchCmd)); err != nil {
+		return 0, err
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.ParseUint(strings.TrimSpace(string(resp)), 10, 64)
+}
+
+func (c *Consumer) heartbeatLoop() {
+	ticker := time.NewTicker(time.Duration(c.config.HeartbeatIntervalMS) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.doneCh:
+			return
+		case <-ticker.C:
+			c.hbMu.Lock()
+			conn := c.hbConn
+			if conn == nil {
+				var err error
+				c.hbConn, err = c.getLeaderConn()
+				conn = c.hbConn
+				if err != nil {
+					c.hbMu.Unlock()
+					continue
+				}
+			}
+			c.hbMu.Unlock()
+
+			hb := fmt.Sprintf("HEARTBEAT topic=%s group=%s member=%s generation=%d", c.config.Topic, c.config.GroupID, c.memberID, c.generation)
+			if err := WriteWithLength(conn, EncodeMessage("", hb)); err != nil {
+				c.hbMu.Lock()
+				c.hbConn = nil
+				conn.Close()
+				c.hbMu.Unlock()
+				continue
+			}
+
+			resp, err := ReadWithLength(conn)
+			if err != nil {
+				c.hbMu.Lock()
+				c.hbConn = nil
+				conn.Close()
+				c.hbMu.Unlock()
+				continue
+			}
+
+			respStr := string(resp)
+			if strings.Contains(respStr, "REBALANCE_REQUIRED") || strings.Contains(respStr, "GEN_MISMATCH") {
+				select {
+				case c.rebalanceSig <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}
+}
+
+func (c *Consumer) Close() error {
+	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
+		return nil
+	}
+
+	close(c.doneCh)
+	c.mainCancel()
+	c.wg.Wait()
+
+	return nil
+}
+
+type PartitionConsumer struct {
+	partitionID  int
+	consumer     *Consumer
+	fetchOffset  uint64
+	commitOffset uint64
+	conn         net.Conn
+	mu           sync.Mutex
+	closed       bool
+}
+
+func (pc *PartitionConsumer) ensureConnection() error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	if pc.conn != nil {
+		return nil
+	}
+	conn, err := pc.consumer.getLeaderConn()
+	if err != nil {
+		return err
+	}
+	pc.conn = conn
+	return nil
+}
+
+func (pc *PartitionConsumer) closeConnection() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	if pc.conn != nil {
+		pc.conn.Close()
+		pc.conn = nil
+	}
+}
+
+func (pc *PartitionConsumer) pollAndProcess() {
+	if err := pc.ensureConnection(); err != nil {
+		return
+	}
+
+	c := pc.consumer
+	c.mu.RLock()
+	memberID, generation := c.memberID, c.generation
+	c.mu.RUnlock()
+
+	consumeCmd := fmt.Sprintf("CONSUME topic=%s partition=%d offset=%d group=%s generation=%d member=%s",
+		c.config.Topic, pc.partitionID, atomic.LoadUint64(&pc.fetchOffset), c.config.GroupID, generation, memberID)
+
+	pc.mu.Lock()
+	conn := pc.conn
+	pc.mu.Unlock()
+
+	if err := WriteWithLength(conn, EncodeMessage(c.config.Topic, consumeCmd)); err != nil {
+		pc.closeConnection()
+		return
+	}
+
+	data, err := ReadWithLength(conn)
+	if err != nil {
+		pc.closeConnection()
+		return
+	}
+
+	if len(data) == 0 || strings.HasPrefix(string(data), "ERROR") {
+		return
+	}
+
+	messages, _, _, err := DecodeBatchMessages(data)
+	if err != nil {
+		return
+	}
+
+	if len(messages) > 0 {
+		for _, msg := range messages {
+			if c.MessageHandler != nil {
+				c.MessageHandler(msg)
+			}
+		}
+		lastOffset := messages[len(messages)-1].Offset
+		atomic.StoreUint64(&pc.fetchOffset, lastOffset+1)
+
+		c.offsetsMu.Lock()
+		c.currentOffsets[pc.partitionID] = lastOffset + 1
+		c.offsetsMu.Unlock()
+	}
+}
+
+func (pc *PartitionConsumer) startStreamLoop() {
+	for {
+		select {
+		case <-pc.consumer.doneCh:
+			pc.closeConnection()
+			return
+		default:
+		}
+
+		if atomic.LoadInt32(&pc.consumer.rebalancing) == 1 {
+			pc.closeConnection()
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		if err := pc.ensureConnection(); err != nil {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		c := pc.consumer
+		c.mu.RLock()
+		memberID, generation := c.memberID, c.generation
+		c.mu.RUnlock()
+
+		streamCmd := fmt.Sprintf("STREAM topic=%s partition=%d group=%s offset=%d generation=%d member=%s",
+			c.config.Topic, pc.partitionID, c.config.GroupID, atomic.LoadUint64(&pc.fetchOffset), generation, memberID)
+
+		pc.mu.Lock()
+		conn := pc.conn
+		pc.mu.Unlock()
+
+		if err := WriteWithLength(conn, EncodeMessage("", streamCmd)); err != nil {
+			logError("Failed to send STREAM command: %v", err)
+			pc.closeConnection()
+			time.Sleep(1 * time.Second) // 대기 추가
+			continue
+		}
+
+		LogInfo("📡 Stream request sent for P%d at offset %d", pc.partitionID, atomic.LoadUint64(&pc.fetchOffset))
+
+		for atomic.LoadInt32(&c.rebalancing) != 1 {
+			data, err := ReadWithLength(conn)
+			if err != nil {
+				logError("Stream read error for P%d: %v", pc.partitionID, err)
+				pc.closeConnection()
+				time.Sleep(1 * time.Second)
+				break
+			}
+
+			if len(data) == 0 {
+				continue
+			}
+
+			if strings.HasPrefix(string(data), "ERROR") {
+				logWarn("Stream received ERROR for P%d: %s", pc.partitionID, string(data))
+				time.Sleep(2 * time.Second)
+				break
+			}
+
+			messages, _, _, err := DecodeBatchMessages(data)
+			if err != nil {
+				logError("Failed to decode stream messages for P%d: %v", pc.partitionID, err)
+				continue
+			}
+
+			if len(messages) > 0 {
+				for _, msg := range messages {
+					if c.MessageHandler != nil {
+						c.MessageHandler(msg)
+					}
+				}
+				lastOffset := messages[len(messages)-1].Offset
+				atomic.StoreUint64(&pc.fetchOffset, lastOffset+1)
+
+				c.offsetsMu.Lock()
+				c.currentOffsets[pc.partitionID] = lastOffset + 1
+				c.offsetsMu.Unlock()
+			}
+		}
+	}
+}

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -415,8 +415,8 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 	c.mu.RUnlock()
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("BATCH_COMMIT topic=%s group=%s generation=%d member=%s ",
-		c.config.Topic, c.config.GroupID, generation, memberID))
+	fmt.Fprintf(&sb, "BATCH_COMMIT topic=%s group=%s generation=%d member=%s ",
+		c.config.Topic, c.config.GroupID, generation, memberID)
 	parts := make([]string, 0, len(offsets))
 	for pid, off := range offsets {
 		parts = append(parts, fmt.Sprintf("%d:%d", pid, off))

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,11 +14,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// ─── ConsumerClient ──────────────────────────────────────────────────────────
+
 type consumerLeaderInfo struct {
 	addr    string
 	updated time.Time
 }
 
+// ConsumerClient manages broker connections with leader-aware failover.
 type ConsumerClient struct {
 	ID     string
 	config *ConsumerConfig
@@ -40,9 +44,11 @@ func (c *ConsumerClient) UpdateLeader(addr string) {
 			addr:    addr,
 			updated: time.Now(),
 		})
+		LogDebug("Updated leader: %s", addr)
 	}
 }
 
+// Connect opens a TCP connection to addr with socket tuning applied.
 func (c *ConsumerClient) Connect(addr string) (net.Conn, error) {
 	dialer := net.Dialer{Timeout: 5 * time.Second}
 	conn, err := dialer.Dial("tcp", addr)
@@ -51,16 +57,17 @@ func (c *ConsumerClient) Connect(addr string) (net.Conn, error) {
 	}
 
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
-		tcpConn.SetNoDelay(true)
-		tcpConn.SetKeepAlive(true)
-		tcpConn.SetKeepAlivePeriod(30 * time.Second)
-		tcpConn.SetReadBuffer(2 * 1024 * 1024)
-		tcpConn.SetWriteBuffer(2 * 1024 * 1024)
+		_ = tcpConn.SetNoDelay(true)
+		_ = tcpConn.SetKeepAlive(true)
+		_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
+		_ = tcpConn.SetReadBuffer(2 * 1024 * 1024)
+		_ = tcpConn.SetWriteBuffer(2 * 1024 * 1024)
 	}
 
 	return conn, nil
 }
 
+// ConnectWithFailover tries the cached leader first, then each broker in order.
 func (c *ConsumerClient) ConnectWithFailover() (net.Conn, string, error) {
 	addrs := c.config.BrokerAddrs
 	if len(addrs) == 0 {
@@ -97,6 +104,13 @@ func (c *ConsumerClient) ConnectWithFailover() (net.Conn, string, error) {
 	return nil, "", fmt.Errorf("all brokers unreachable")
 }
 
+type commitEntry struct {
+	partition int
+	offset    uint64
+	respCh    chan error
+}
+
+// Consumer manages group membership, partition assignment, and message delivery.
 type Consumer struct {
 	config             *ConsumerConfig
 	client             *ConsumerClient
@@ -113,7 +127,11 @@ type Consumer struct {
 	currentOffsets map[int]uint64
 	offsetsMu      sync.Mutex
 
-	wg         sync.WaitGroup
+	// wg tracks per-rebalance goroutines (heartbeat, partition workers, runWorkers).
+	wg sync.WaitGroup
+	// commitWg tracks the commit worker (long-lived, survives rebalances).
+	commitWg sync.WaitGroup
+
 	mainCtx    context.Context
 	mainCancel context.CancelFunc
 
@@ -132,12 +150,6 @@ type Consumer struct {
 	MessageHandler func(Message) error
 }
 
-type commitEntry struct {
-	partition int
-	offset    uint64
-	respCh    chan error
-}
-
 func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
 	client := NewConsumerClient(cfg)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -148,6 +160,7 @@ func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
 		partitionConsumers: make(map[int]*PartitionConsumer),
 		offsets:            make(map[int]uint64),
 		currentOffsets:     make(map[int]uint64),
+		commitRetryMap:     make(map[int]uint64),
 		rebalanceSig:       make(chan struct{}, 1),
 		doneCh:             make(chan struct{}),
 		mainCtx:            ctx,
@@ -158,8 +171,15 @@ func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
 	return c, nil
 }
 
+// Done returns a channel that is closed when the consumer is closed.
+func (c *Consumer) Done() <-chan struct{} {
+	return c.doneCh
+}
+
+// Start joins the consumer group, begins consuming, and blocks until Close is called.
 func (c *Consumer) Start(handler func(Message) error) error {
 	c.MessageHandler = handler
+
 	gen, mid, assignments, err := c.joinGroupWithRetry()
 	if err != nil {
 		return fmt.Errorf("join group failed: %w", err)
@@ -174,37 +194,34 @@ func (c *Consumer) Start(handler func(Message) error) error {
 		}
 	}
 
-	LogInfo("✅ Successfully joined topic '%s' for group '%s' with %d partitions: %v (generation=%d, member=%s)",
-		c.config.Topic, c.config.GroupID, len(assignments), assignments, gen, mid)
+	LogInfo("Joined group '%s' on topic '%s': %d partitions %v (gen=%d member=%s)",
+		c.config.GroupID, c.config.Topic, len(assignments), assignments, gen, mid)
 
 	c.mu.Lock()
 	c.partitionConsumers = make(map[int]*PartitionConsumer)
 	for _, pid := range assignments {
 		offset, err := c.fetchOffset(pid)
 		if err != nil {
-			logWarn("Failed to fetch offset for P%d: %v", pid, err)
+			LogWarn("Failed to fetch offset for P%d: %v, starting from 0", pid, err)
 			offset = 0
 		}
-
 		c.offsets[pid] = offset
-
-		pc := &PartitionConsumer{
+		c.partitionConsumers[pid] = &PartitionConsumer{
 			partitionID:  pid,
 			consumer:     c,
 			fetchOffset:  offset,
 			commitOffset: offset,
 		}
-		c.partitionConsumers[pid] = pc
 	}
 	c.mu.Unlock()
 
 	c.startCommitWorker()
 	go c.rebalanceMonitorLoop()
 
-	if c.config.Mode != ModeStreaming {
-		go c.startConsuming()
-	} else {
+	if c.config.Mode == ModeStreaming {
 		go c.startStreaming()
+	} else {
+		go c.startConsuming()
 	}
 
 	<-c.mainCtx.Done()
@@ -212,9 +229,9 @@ func (c *Consumer) Start(handler func(Message) error) error {
 }
 
 func (c *Consumer) startCommitWorker() {
-	c.wg.Add(1)
+	c.commitWg.Add(1)
 	go func() {
-		defer c.wg.Done()
+		defer c.commitWg.Done()
 		ticker := time.NewTicker(c.config.AutoCommitInterval)
 		defer ticker.Stop()
 
@@ -236,11 +253,9 @@ func (c *Consumer) startCommitWorker() {
 					flush()
 					return
 				}
-
 				if existing, exists := pendingOffsets[entry.partition]; !exists || entry.offset > existing {
 					pendingOffsets[entry.partition] = entry.offset
 				}
-
 				if entry.respCh != nil {
 					respChannels[entry.partition] = append(respChannels[entry.partition], entry.respCh)
 					flush()
@@ -249,10 +264,27 @@ func (c *Consumer) startCommitWorker() {
 			case <-ticker.C:
 				c.flushOffsets()
 				flush()
+				c.processRetryQueue()
 
 			case <-c.doneCh:
-				flush()
-				return
+				for {
+					select {
+					case entry, ok := <-c.commitCh:
+						if !ok {
+							flush()
+							return
+						}
+						if existing, exists := pendingOffsets[entry.partition]; !exists || entry.offset > existing {
+							pendingOffsets[entry.partition] = entry.offset
+						}
+						if entry.respCh != nil {
+							respChannels[entry.partition] = append(respChannels[entry.partition], entry.respCh)
+						}
+					default:
+						flush()
+						return
+					}
+				}
 			}
 		}
 	}()
@@ -277,16 +309,43 @@ func (c *Consumer) flushOffsets() {
 
 		if offset > lastCommitted {
 			select {
-			case c.commitCh <- commitEntry{
-				partition: pid,
-				offset:    offset,
-				respCh:    nil,
-			}:
+			case c.commitCh <- commitEntry{partition: pid, offset: offset}:
 			default:
+				LogWarn("commitCh full, dropping auto-commit for P%d offset %d", pid, offset)
 			}
 		}
 	}
 	c.currentOffsets = make(map[int]uint64)
+}
+
+func (c *Consumer) processRetryQueue() {
+	if atomic.LoadInt32(&c.rebalancing) == 1 {
+		return
+	}
+
+	c.commitMu.Lock()
+	if len(c.commitRetryMap) == 0 {
+		c.commitMu.Unlock()
+		return
+	}
+	toRetry := make(map[int]uint64, len(c.commitRetryMap))
+	for p, o := range c.commitRetryMap {
+		toRetry[p] = o
+	}
+	c.commitRetryMap = make(map[int]uint64)
+	c.commitMu.Unlock()
+
+	LogDebug("Retrying failed commits for %d partitions", len(toRetry))
+	if !c.sendBatchCommit(toRetry) {
+		LogError("Retry batch commit failed, re-queuing")
+		c.commitMu.Lock()
+		for p, o := range toRetry {
+			if current, ok := c.commitRetryMap[p]; !ok || o > current {
+				c.commitRetryMap[p] = o
+			}
+		}
+		c.commitMu.Unlock()
+	}
 }
 
 func (c *Consumer) commitBatch(offsets map[int]uint64, respChannels map[int][]chan error) {
@@ -295,6 +354,11 @@ func (c *Consumer) commitBatch(offsets map[int]uint64, respChannels map[int][]ch
 	for pid, channels := range respChannels {
 		var err error
 		if !success {
+			c.commitMu.Lock()
+			if current, ok := c.commitRetryMap[pid]; !ok || offsets[pid] > current {
+				c.commitRetryMap[pid] = offsets[pid]
+			}
+			c.commitMu.Unlock()
 			err = fmt.Errorf("batch commit failed for partition %d", pid)
 		}
 		for _, ch := range channels {
@@ -305,18 +369,44 @@ func (c *Consumer) commitBatch(offsets map[int]uint64, respChannels map[int][]ch
 	}
 }
 
+// validateCommitConn probes the commit connection with a 1ms deadline to detect stale connections.
+func (c *Consumer) validateCommitConn() bool {
+	if c.commitConn == nil {
+		return false
+	}
+	if err := c.commitConn.SetReadDeadline(time.Now().Add(1 * time.Millisecond)); err != nil {
+		_ = c.commitConn.Close()
+		c.commitConn = nil
+		return false
+	}
+	_, err := c.commitConn.Read(make([]byte, 0))
+	if err != nil && !os.IsTimeout(err) {
+		_ = c.commitConn.Close()
+		c.commitConn = nil
+		return false
+	}
+	_ = c.commitConn.SetReadDeadline(time.Time{})
+	return true
+}
+
 func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 	c.commitMu.Lock()
-	conn := c.commitConn
-	if conn == nil {
+	needsNewConn := c.commitConn == nil || !c.validateCommitConn()
+	c.commitMu.Unlock()
+
+	if needsNewConn {
 		newConn, err := c.getLeaderConn()
 		if err != nil {
-			c.commitMu.Unlock()
+			LogError("Batch commit: failed to get connection: %v", err)
 			return false
 		}
+		c.commitMu.Lock()
 		c.commitConn = newConn
-		conn = newConn
+		c.commitMu.Unlock()
 	}
+
+	c.commitMu.Lock()
+	conn := c.commitConn
 	c.commitMu.Unlock()
 
 	c.mu.RLock()
@@ -325,18 +415,20 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 	c.mu.RUnlock()
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("BATCH_COMMIT topic=%s group=%s generation=%d member=%s ", c.config.Topic, c.config.GroupID, generation, memberID))
-	parts := []string{}
+	sb.WriteString(fmt.Sprintf("BATCH_COMMIT topic=%s group=%s generation=%d member=%s ",
+		c.config.Topic, c.config.GroupID, generation, memberID))
+	parts := make([]string, 0, len(offsets))
 	for pid, off := range offsets {
 		parts = append(parts, fmt.Sprintf("%d:%d", pid, off))
 	}
 	sb.WriteString(strings.Join(parts, ","))
 
 	if err := WriteWithLength(conn, EncodeMessage("", sb.String())); err != nil {
+		LogError("Batch commit send failed: %v", err)
 		c.commitMu.Lock()
 		if c.commitConn == conn {
-			c.commitConn = nil
 			_ = conn.Close()
+			c.commitConn = nil
 		}
 		c.commitMu.Unlock()
 		return false
@@ -344,10 +436,11 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 
 	resp, err := ReadWithLength(conn)
 	if err != nil {
+		LogError("Batch commit response failed: %v", err)
 		c.commitMu.Lock()
 		if c.commitConn == conn {
-			c.commitConn = nil
 			_ = conn.Close()
+			c.commitConn = nil
 		}
 		c.commitMu.Unlock()
 		return false
@@ -358,19 +451,374 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 		return true
 	}
 
-	if strings.Contains(respStr, "REBALANCE_REQUIRED") || strings.Contains(respStr, "GEN_MISMATCH") {
+	c.handleLeaderRedirection(respStr)
+
+	if strings.Contains(respStr, "NOT_OWNER") ||
+		strings.Contains(respStr, "GEN_MISMATCH") ||
+		strings.Contains(respStr, "REBALANCE_REQUIRED") {
 		select {
 		case c.rebalanceSig <- struct{}{}:
 		default:
 		}
 	}
+
+	LogError("Batch commit rejected: %s", respStr)
 	return false
 }
 
-func (c *Consumer) getLeaderConn() (net.Conn, error) {
-	conn, _, err := c.client.ConnectWithFailover()
-	return conn, err
+// directCommit sends a single COMMIT_OFFSET without going through the commit channel.
+func (c *Consumer) directCommit(partition int, offset uint64) error {
+	c.mu.RLock()
+	generation := c.generation
+	memberID := c.memberID
+	c.mu.RUnlock()
+
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	commitCmd := fmt.Sprintf("COMMIT_OFFSET topic=%s partition=%d group=%s offset=%d generation=%d member=%s",
+		c.config.Topic, partition, c.config.GroupID, offset, generation, memberID)
+
+	if err := WriteWithLength(conn, EncodeMessage("", commitCmd)); err != nil {
+		return fmt.Errorf("direct commit send: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return fmt.Errorf("direct commit response: %w", err)
+	}
+
+	respStr := string(resp)
+	if strings.Contains(respStr, "ERROR") {
+		if strings.Contains(respStr, "GEN_MISMATCH") {
+			go c.handleRebalanceSignal()
+		}
+		return fmt.Errorf("direct commit error: %s", respStr)
+	}
+	return nil
 }
+
+// handleLeaderRedirection parses a LEADER_IS response and updates the cached leader.
+func (c *Consumer) handleLeaderRedirection(resp string) {
+	if !strings.Contains(resp, "LEADER_IS") {
+		return
+	}
+	fields := strings.Fields(resp)
+	for i, f := range fields {
+		if f == "LEADER_IS" && i+1 < len(fields) {
+			c.client.UpdateLeader(fields[i+1])
+			return
+		}
+	}
+}
+
+// joinGroupWithRetry retries joining with exponential backoff up to 30 attempts.
+func (c *Consumer) joinGroupWithRetry() (int64, string, []int, error) {
+	const maxAttempts = 30
+	bo := newBackoff(1*time.Second, 5*time.Second)
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		gen, mid, assignments, err := c.joinGroup()
+		if err == nil {
+			return gen, mid, assignments, nil
+		}
+
+		LogWarn("Join group attempt %d/%d failed: %v", attempt, maxAttempts, err)
+		if attempt == maxAttempts {
+			break
+		}
+
+		waitDur := bo.duration()
+		select {
+		case <-c.mainCtx.Done():
+			return 0, "", nil, fmt.Errorf("consumer shutting down during join retry")
+		case <-time.After(waitDur):
+		}
+	}
+	return 0, "", nil, fmt.Errorf("failed to join group after %d attempts", maxAttempts)
+}
+
+func (c *Consumer) joinGroup() (int64, string, []int, error) {
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	mID := c.memberID
+	if mID == "" {
+		mID = c.config.ConsumerID
+	}
+
+	joinCmd := fmt.Sprintf("JOIN_GROUP topic=%s group=%s member=%s", c.config.Topic, c.config.GroupID, mID)
+	if err := WriteWithLength(conn, EncodeMessage("", joinCmd)); err != nil {
+		return 0, "", nil, fmt.Errorf("send join: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("read join response: %w", err)
+	}
+
+	respStr := strings.TrimSpace(string(resp))
+	if !strings.HasPrefix(respStr, "OK") {
+		return 0, "", nil, fmt.Errorf("join rejected: %s", respStr)
+	}
+
+	var gen int64
+	var mid string
+	var assigned []int
+
+	for _, part := range strings.Fields(respStr) {
+		if strings.HasPrefix(part, "generation=") {
+			_, _ = fmt.Sscanf(part, "generation=%d", &gen)
+		} else if strings.HasPrefix(part, "member=") {
+			mid = strings.TrimPrefix(part, "member=")
+		}
+	}
+
+	if strings.Contains(respStr, "assignments=") {
+		start := strings.Index(respStr, "[")
+		end := strings.Index(respStr, "]")
+		if start != -1 && end != -1 {
+			partStr := strings.ReplaceAll(respStr[start+1:end], ",", " ")
+			for _, p := range strings.Fields(partStr) {
+				pid, err := strconv.Atoi(strings.TrimSpace(p))
+				if err == nil {
+					assigned = append(assigned, pid)
+				}
+			}
+		}
+	}
+
+	return gen, mid, assigned, nil
+}
+
+func (c *Consumer) syncGroup(generation int64, memberID string) ([]int, error) {
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	syncCmd := fmt.Sprintf("SYNC_GROUP topic=%s group=%s member=%s generation=%d",
+		c.config.Topic, c.config.GroupID, memberID, generation)
+	if err := WriteWithLength(conn, EncodeMessage("", syncCmd)); err != nil {
+		return nil, fmt.Errorf("send sync: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return nil, fmt.Errorf("read sync response: %w", err)
+	}
+
+	respStr := strings.TrimSpace(string(resp))
+	if !strings.HasPrefix(respStr, "OK") {
+		return nil, fmt.Errorf("sync rejected: %s", respStr)
+	}
+
+	c.mu.Lock()
+	c.generation = generation
+	c.memberID = memberID
+	c.mu.Unlock()
+
+	var assigned []int
+	if strings.Contains(respStr, "[") && strings.Contains(respStr, "]") {
+		start := strings.Index(respStr, "[")
+		end := strings.Index(respStr, "]")
+		for _, p := range strings.Fields(respStr[start+1 : end]) {
+			var pid int
+			if _, err := fmt.Sscanf(p, "%d", &pid); err == nil {
+				assigned = append(assigned, pid)
+			}
+		}
+	}
+	return assigned, nil
+}
+
+func (c *Consumer) fetchOffset(partition int) (uint64, error) {
+	if err := c.mainCtx.Err(); err != nil {
+		return 0, err
+	}
+
+	conn, err := c.getLeaderConn()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	fetchCmd := fmt.Sprintf("FETCH_OFFSET topic=%s partition=%d group=%s",
+		c.config.Topic, partition, c.config.GroupID)
+	if err := WriteWithLength(conn, EncodeMessage("", fetchCmd)); err != nil {
+		return 0, fmt.Errorf("fetch offset send: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return 0, fmt.Errorf("fetch offset response: %w", err)
+	}
+
+	respStr := string(resp)
+	if strings.HasPrefix(respStr, "ERROR") {
+		return 0, fmt.Errorf("fetch offset broker error: %s", respStr)
+	}
+
+	offset, err := strconv.ParseUint(strings.TrimSpace(respStr), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid offset response: %s", respStr)
+	}
+	return offset, nil
+}
+
+// ─── Heartbeat ────────────────────────────────────────────────────────────────
+
+func (c *Consumer) heartbeatLoop() {
+	ticker := time.NewTicker(time.Duration(c.config.HeartbeatIntervalMS) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.doneCh:
+			return
+		case <-ticker.C:
+			c.hbMu.Lock()
+			conn := c.hbConn
+			c.hbMu.Unlock()
+
+			if conn == nil {
+				newConn, err := c.getLeaderConn()
+				if err != nil {
+					LogError("Heartbeat: failed to connect: %v", err)
+					continue
+				}
+				c.hbMu.Lock()
+				c.hbConn = newConn
+				conn = newConn
+				c.hbMu.Unlock()
+			}
+
+			_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+			hb := fmt.Sprintf("HEARTBEAT topic=%s group=%s member=%s generation=%d",
+				c.config.Topic, c.config.GroupID, c.memberID, c.generation)
+			if err := WriteWithLength(conn, EncodeMessage("", hb)); err != nil {
+				LogError("Heartbeat send failed: %v", err)
+				c.cleanupHbConn(conn)
+				continue
+			}
+
+			resp, err := ReadWithLength(conn)
+			_ = conn.SetDeadline(time.Time{})
+			if err != nil {
+				LogError("Heartbeat response failed: %v", err)
+				c.cleanupHbConn(conn)
+				continue
+			}
+
+			respStr := string(resp)
+			if strings.Contains(respStr, "REBALANCE_REQUIRED") || strings.Contains(respStr, "GEN_MISMATCH") {
+				LogWarn("Heartbeat: rebalance triggered: %s", respStr)
+				select {
+				case c.rebalanceSig <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}
+}
+
+func (c *Consumer) cleanupHbConn(bad net.Conn) {
+	_ = bad.Close()
+	c.hbMu.Lock()
+	if c.hbConn == bad {
+		c.hbConn = nil
+	}
+	c.hbMu.Unlock()
+}
+
+func (c *Consumer) resetHeartbeatConn() {
+	c.hbMu.Lock()
+	if c.hbConn != nil {
+		_ = c.hbConn.Close()
+		c.hbConn = nil
+	}
+	c.hbMu.Unlock()
+}
+
+// ─── Consume / Stream ─────────────────────────────────────────────────────────
+
+func (c *Consumer) startConsuming() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.heartbeatLoop()
+	}()
+
+	for pid, pc := range c.partitionConsumers {
+		c.wg.Add(1)
+		go func(pid int, pc *PartitionConsumer) {
+			defer c.wg.Done()
+			for {
+				select {
+				case <-c.doneCh:
+					return
+				case <-c.mainCtx.Done():
+					LogInfo("Partition [%d] polling worker stopping", pid)
+					return
+				default:
+					if !c.ownsPartition(pid) {
+						LogWarn("Partition [%d] no longer owned, stopping poller", pid)
+						return
+					}
+					pc.pollAndProcess()
+					select {
+					case <-time.After(c.config.PollInterval):
+					case <-c.mainCtx.Done():
+						return
+					case <-c.doneCh:
+						return
+					}
+				}
+			}
+		}(pid, pc)
+	}
+}
+
+func (c *Consumer) startStreaming() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.heartbeatLoop()
+	}()
+
+	c.mu.RLock()
+	pcs := make([]*PartitionConsumer, 0, len(c.partitionConsumers))
+	for _, pc := range c.partitionConsumers {
+		pcs = append(pcs, pc)
+	}
+	c.mu.RUnlock()
+
+	for _, pc := range pcs {
+		c.wg.Add(1)
+		go func(pc *PartitionConsumer) {
+			defer c.wg.Done()
+			pc.startStreamLoop()
+		}(pc)
+	}
+}
+
+func (c *Consumer) ownsPartition(pid int) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	pc, ok := c.partitionConsumers[pid]
+	return ok && !pc.closed
+}
+
+// ─── Rebalance ────────────────────────────────────────────────────────────────
 
 func (c *Consumer) rebalanceMonitorLoop() {
 	for {
@@ -389,17 +837,117 @@ func (c *Consumer) handleRebalanceSignal() {
 	}
 	defer atomic.StoreInt32(&c.rebalancing, 0)
 
-	LogInfo("🔄 Rebalance started - Stop existing workers")
+	LogInfo("Rebalance started — stopping existing workers")
+
 	c.mainCancel()
 
-	c.wg.Wait()
+	// Drain commitCh for up to 3 seconds concurrently with wg.Wait.
+	drainDone := make(chan struct{})
+	go func() {
+		deadline := time.After(3 * time.Second)
+		for {
+			select {
+			case <-c.commitCh:
+			case <-time.After(100 * time.Millisecond):
+				close(drainDone)
+				return
+			case <-deadline:
+				LogWarn("Rebalance drain timeout, forcing continuation")
+				close(drainDone)
+				return
+			}
+		}
+	}()
 
-	c.hbMu.Lock()
-	if c.hbConn != nil {
-		_ = c.hbConn.Close()
-		c.hbConn = nil
+	c.wg.Wait()
+	<-drainDone
+
+	c.resetHeartbeatConn()
+	c.commitMu.Lock()
+	if c.commitConn != nil {
+		_ = c.commitConn.Close()
+		c.commitConn = nil
 	}
-	c.hbMu.Unlock()
+	c.commitMu.Unlock()
+
+	c.mu.Lock()
+	for _, pc := range c.partitionConsumers {
+		pc.close()
+	}
+	c.partitionConsumers = make(map[int]*PartitionConsumer)
+	c.offsets = make(map[int]uint64)
+	c.mu.Unlock()
+
+	c.mainCtx, c.mainCancel = context.WithCancel(context.Background())
+
+	gen, mid, assignments, err := c.joinGroupWithRetry()
+	if err != nil {
+		LogError("Rebalance join failed: %v", err)
+		return
+	}
+	if len(assignments) == 0 {
+		assignments, err = c.syncGroup(gen, mid)
+		if err != nil {
+			LogError("Rebalance sync failed: %v", err)
+			return
+		}
+	}
+
+	c.mu.Lock()
+	c.generation = gen
+	c.memberID = mid
+	for _, pid := range assignments {
+		offset, err := c.fetchOffset(pid)
+		if err != nil {
+			LogWarn("Rebalance: offset fetch failed for P%d: %v, starting from 0", pid, err)
+			offset = 0
+		}
+		c.partitionConsumers[pid] = &PartitionConsumer{
+			partitionID:  pid,
+			consumer:     c,
+			fetchOffset:  offset,
+			commitOffset: offset,
+		}
+		c.offsets[pid] = offset
+		LogInfo("Rebalance: P%d assigned at offset %d (gen=%d)", pid, offset, gen)
+	}
+	c.mu.Unlock()
+
+	if c.config.Mode == ModeStreaming {
+		go c.startStreaming()
+	} else {
+		go c.startConsuming()
+	}
+
+	LogInfo("Rebalance completed — consuming %d partitions", len(assignments))
+}
+
+// ─── Close ────────────────────────────────────────────────────────────────────
+
+func (c *Consumer) Close() error {
+	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
+		return fmt.Errorf("%w", ErrConsumerClosed)
+	}
+
+	close(c.doneCh)
+	c.wg.Wait()
+	c.mainCancel()
+
+	c.flushOffsets()
+	close(c.commitCh)
+	c.commitWg.Wait()
+
+	// Send LEAVE_GROUP to broker.
+	if c.memberID != "" {
+		if conn, err := c.getLeaderConn(); err == nil {
+			leaveCmd := fmt.Sprintf("LEAVE_GROUP topic=%s group=%s member=%s",
+				c.config.Topic, c.config.GroupID, c.memberID)
+			_ = WriteWithLength(conn, EncodeMessage("", leaveCmd))
+			_ = conn.Close()
+		}
+	}
+
+	c.resetHeartbeatConn()
 
 	c.commitMu.Lock()
 	if c.commitConn != nil {
@@ -410,448 +958,17 @@ func (c *Consumer) handleRebalanceSignal() {
 
 	c.mu.Lock()
 	for _, pc := range c.partitionConsumers {
-		pc.closeConnection()
+		pc.close()
 	}
 	c.partitionConsumers = make(map[int]*PartitionConsumer)
-	c.offsets = make(map[int]uint64)
 	c.mu.Unlock()
-
-	c.mainCtx, c.mainCancel = context.WithCancel(context.Background())
-	gen, mid, assignments, err := c.joinGroupWithRetry()
-	if err != nil {
-		logError("Rebalance join failed: %v", err)
-		return
-	}
-
-	if len(assignments) == 0 {
-		assignments, err = c.syncGroup(gen, mid)
-		if err != nil {
-			logError("❌ Rebalance sync failed: %v", err)
-			return
-		}
-	}
-
-	c.mu.Lock()
-	c.generation = gen
-	c.memberID = mid
-
-	for _, pid := range assignments {
-		offset, err := c.fetchOffset(pid)
-		if err != nil {
-			offset = 0
-		}
-
-		pc := &PartitionConsumer{
-			partitionID:  pid,
-			consumer:     c,
-			fetchOffset:  offset,
-			commitOffset: offset,
-		}
-		c.partitionConsumers[pid] = pc
-	}
-	c.mu.Unlock()
-
-	if c.config.Mode != ModeStreaming {
-		go c.startConsuming()
-	} else {
-		go c.startStreaming()
-	}
-}
-
-func (c *Consumer) startConsuming() {
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
-		c.heartbeatLoop()
-	}()
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	for pid, pc := range c.partitionConsumers {
-		c.wg.Add(1)
-		go func(pid int, pc *PartitionConsumer) {
-			defer c.wg.Done()
-
-			for {
-				select {
-				case <-c.doneCh:
-					return
-				case <-c.mainCtx.Done():
-					return
-				default:
-					pc.pollAndProcess()
-					time.Sleep(c.config.PollInterval)
-				}
-			}
-		}(pid, pc)
-	}
-}
-
-func (c *Consumer) startStreaming() {
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
-		c.heartbeatLoop()
-	}()
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	for _, pc := range c.partitionConsumers {
-		c.wg.Add(1)
-		go func(pc *PartitionConsumer) {
-			defer c.wg.Done()
-			pc.startStreamLoop()
-		}(pc)
-	}
-}
-
-func (c *Consumer) joinGroupWithRetry() (int64, string, []int, error) {
-	for i := 0; i < 30; i++ {
-		gen, mid, assignments, err := c.joinGroup()
-		if err == nil {
-			return gen, mid, assignments, nil
-		}
-		time.Sleep(1 * time.Second)
-	}
-	return 0, "", nil, fmt.Errorf("join group timeout")
-}
-
-func (c *Consumer) joinGroup() (int64, string, []int, error) {
-	conn, err := c.getLeaderConn()
-	if err != nil {
-		return 0, "", nil, err
-	}
-	defer conn.Close()
-
-	mID := c.memberID
-	if mID == "" {
-		mID = c.config.ConsumerID
-	}
-
-	joinCmd := fmt.Sprintf("JOIN_GROUP topic=%s group=%s member=%s", c.config.Topic, c.config.GroupID, mID)
-	if err := WriteWithLength(conn, EncodeMessage("", joinCmd)); err != nil {
-		return 0, "", nil, err
-	}
-
-	resp, err := ReadWithLength(conn)
-	if err != nil {
-		return 0, "", nil, err
-	}
-
-	respStr := string(resp)
-	if !strings.HasPrefix(respStr, "OK") {
-		return 0, "", nil, fmt.Errorf("join failed: %s", respStr)
-	}
-
-	var gen int64
-	var mid string
-	var assigned []int
-
-	parts := strings.Fields(respStr)
-	for _, part := range parts {
-		if strings.HasPrefix(part, "generation=") {
-			fmt.Sscanf(part, "generation=%d", &gen)
-		} else if strings.HasPrefix(part, "member=") {
-			mid = strings.TrimPrefix(part, "member=")
-		}
-	}
-
-	if strings.Contains(respStr, "assignments=") {
-		start := strings.Index(respStr, "[")
-		end := strings.Index(respStr, "]")
-		if start != -1 && end != -1 {
-			partStr := respStr[start+1 : end]
-			for _, p := range strings.Fields(strings.ReplaceAll(partStr, ",", " ")) {
-				pid, _ := strconv.Atoi(p)
-				assigned = append(assigned, pid)
-			}
-		}
-	}
-
-	return gen, mid, assigned, nil
-}
-
-func (c *Consumer) syncGroup(generation int64, memberID string) ([]int, error) {
-	conn, err := c.getLeaderConn()
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-
-	syncCmd := fmt.Sprintf("SYNC_GROUP topic=%s group=%s member=%s generation=%d", c.config.Topic, c.config.GroupID, memberID, generation)
-	if err := WriteWithLength(conn, EncodeMessage("", syncCmd)); err != nil {
-		return nil, err
-	}
-
-	resp, err := ReadWithLength(conn)
-	if err != nil {
-		return nil, err
-	}
-
-	respStr := string(resp)
-	var assigned []int
-	if strings.Contains(respStr, "[") && strings.Contains(respStr, "]") {
-		start := strings.Index(respStr, "[")
-		end := strings.Index(respStr, "]")
-		partitionStr := respStr[start+1 : end]
-		for _, p := range strings.Fields(partitionStr) {
-			var pid int
-			fmt.Sscanf(p, "%d", &pid)
-			assigned = append(assigned, pid)
-		}
-	}
-
-	return assigned, nil
-}
-
-func (c *Consumer) fetchOffset(partition int) (uint64, error) {
-	conn, err := c.getLeaderConn()
-	if err != nil {
-		return 0, err
-	}
-	defer conn.Close()
-
-	fetchCmd := fmt.Sprintf("FETCH_OFFSET topic=%s partition=%d group=%s", c.config.Topic, partition, c.config.GroupID)
-	if err := WriteWithLength(conn, EncodeMessage("", fetchCmd)); err != nil {
-		return 0, err
-	}
-
-	resp, err := ReadWithLength(conn)
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.ParseUint(strings.TrimSpace(string(resp)), 10, 64)
-}
-
-func (c *Consumer) heartbeatLoop() {
-	ticker := time.NewTicker(time.Duration(c.config.HeartbeatIntervalMS) * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-c.doneCh:
-			return
-		case <-ticker.C:
-			c.hbMu.Lock()
-			conn := c.hbConn
-			if conn == nil {
-				var err error
-				c.hbConn, err = c.getLeaderConn()
-				conn = c.hbConn
-				if err != nil {
-					c.hbMu.Unlock()
-					continue
-				}
-			}
-			c.hbMu.Unlock()
-
-			hb := fmt.Sprintf("HEARTBEAT topic=%s group=%s member=%s generation=%d", c.config.Topic, c.config.GroupID, c.memberID, c.generation)
-			if err := WriteWithLength(conn, EncodeMessage("", hb)); err != nil {
-				c.hbMu.Lock()
-				c.hbConn = nil
-				conn.Close()
-				c.hbMu.Unlock()
-				continue
-			}
-
-			resp, err := ReadWithLength(conn)
-			if err != nil {
-				c.hbMu.Lock()
-				c.hbConn = nil
-				conn.Close()
-				c.hbMu.Unlock()
-				continue
-			}
-
-			respStr := string(resp)
-			if strings.Contains(respStr, "REBALANCE_REQUIRED") || strings.Contains(respStr, "GEN_MISMATCH") {
-				select {
-				case c.rebalanceSig <- struct{}{}:
-				default:
-				}
-				return
-			}
-		}
-	}
-}
-
-func (c *Consumer) Close() error {
-	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
-		return nil
-	}
-
-	close(c.doneCh)
-	c.mainCancel()
-	c.wg.Wait()
 
 	return nil
 }
 
-type PartitionConsumer struct {
-	partitionID  int
-	consumer     *Consumer
-	fetchOffset  uint64
-	commitOffset uint64
-	conn         net.Conn
-	mu           sync.Mutex
-	closed       bool
-}
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-func (pc *PartitionConsumer) ensureConnection() error {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-	if pc.conn != nil {
-		return nil
-	}
-	conn, err := pc.consumer.getLeaderConn()
-	if err != nil {
-		return err
-	}
-	pc.conn = conn
-	return nil
-}
-
-func (pc *PartitionConsumer) closeConnection() {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-	if pc.conn != nil {
-		pc.conn.Close()
-		pc.conn = nil
-	}
-}
-
-func (pc *PartitionConsumer) pollAndProcess() {
-	if err := pc.ensureConnection(); err != nil {
-		return
-	}
-
-	c := pc.consumer
-	c.mu.RLock()
-	memberID, generation := c.memberID, c.generation
-	c.mu.RUnlock()
-
-	consumeCmd := fmt.Sprintf("CONSUME topic=%s partition=%d offset=%d group=%s generation=%d member=%s",
-		c.config.Topic, pc.partitionID, atomic.LoadUint64(&pc.fetchOffset), c.config.GroupID, generation, memberID)
-
-	pc.mu.Lock()
-	conn := pc.conn
-	pc.mu.Unlock()
-
-	if err := WriteWithLength(conn, EncodeMessage(c.config.Topic, consumeCmd)); err != nil {
-		pc.closeConnection()
-		return
-	}
-
-	data, err := ReadWithLength(conn)
-	if err != nil {
-		pc.closeConnection()
-		return
-	}
-
-	if len(data) == 0 || strings.HasPrefix(string(data), "ERROR") {
-		return
-	}
-
-	messages, _, _, err := DecodeBatchMessages(data)
-	if err != nil {
-		return
-	}
-
-	if len(messages) > 0 {
-		for _, msg := range messages {
-			if c.MessageHandler != nil {
-				c.MessageHandler(msg)
-			}
-		}
-		lastOffset := messages[len(messages)-1].Offset
-		atomic.StoreUint64(&pc.fetchOffset, lastOffset+1)
-
-		c.offsetsMu.Lock()
-		c.currentOffsets[pc.partitionID] = lastOffset + 1
-		c.offsetsMu.Unlock()
-	}
-}
-
-func (pc *PartitionConsumer) startStreamLoop() {
-	for {
-		select {
-		case <-pc.consumer.doneCh:
-			pc.closeConnection()
-			return
-		default:
-		}
-
-		if atomic.LoadInt32(&pc.consumer.rebalancing) == 1 {
-			pc.closeConnection()
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		if err := pc.ensureConnection(); err != nil {
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		c := pc.consumer
-		c.mu.RLock()
-		memberID, generation := c.memberID, c.generation
-		c.mu.RUnlock()
-
-		streamCmd := fmt.Sprintf("STREAM topic=%s partition=%d group=%s offset=%d generation=%d member=%s",
-			c.config.Topic, pc.partitionID, c.config.GroupID, atomic.LoadUint64(&pc.fetchOffset), generation, memberID)
-
-		pc.mu.Lock()
-		conn := pc.conn
-		pc.mu.Unlock()
-
-		if err := WriteWithLength(conn, EncodeMessage("", streamCmd)); err != nil {
-			logError("Failed to send STREAM command: %v", err)
-			pc.closeConnection()
-			time.Sleep(1 * time.Second) // 대기 추가
-			continue
-		}
-
-		LogInfo("📡 Stream request sent for P%d at offset %d", pc.partitionID, atomic.LoadUint64(&pc.fetchOffset))
-
-		for atomic.LoadInt32(&c.rebalancing) != 1 {
-			data, err := ReadWithLength(conn)
-			if err != nil {
-				logError("Stream read error for P%d: %v", pc.partitionID, err)
-				pc.closeConnection()
-				time.Sleep(1 * time.Second)
-				break
-			}
-
-			if len(data) == 0 {
-				continue
-			}
-
-			if strings.HasPrefix(string(data), "ERROR") {
-				logWarn("Stream received ERROR for P%d: %s", pc.partitionID, string(data))
-				time.Sleep(2 * time.Second)
-				break
-			}
-
-			messages, _, _, err := DecodeBatchMessages(data)
-			if err != nil {
-				logError("Failed to decode stream messages for P%d: %v", pc.partitionID, err)
-				continue
-			}
-
-			if len(messages) > 0 {
-				for _, msg := range messages {
-					if c.MessageHandler != nil {
-						c.MessageHandler(msg)
-					}
-				}
-				lastOffset := messages[len(messages)-1].Offset
-				atomic.StoreUint64(&pc.fetchOffset, lastOffset+1)
-
-				c.offsetsMu.Lock()
-				c.currentOffsets[pc.partitionID] = lastOffset + 1
-				c.offsetsMu.Unlock()
-			}
-		}
-	}
+func (c *Consumer) getLeaderConn() (net.Conn, error) {
+	conn, _, err := c.client.ConnectWithFailover()
+	return conn, err
 }

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -1,0 +1,11 @@
+package sdk
+
+import "errors"
+
+var (
+	ErrProducerClosed   = errors.New("producer closed")
+	ErrConsumerClosed   = errors.New("consumer closed")
+	ErrTopicNotFound    = errors.New("topic not found")
+	ErrInvalidPartition = errors.New("invalid partition")
+	ErrNotLeader        = errors.New("not leader")
+)

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -35,6 +35,13 @@ type PartitionConsumer struct {
 // initWorker lazily starts the per-partition worker goroutine (once).
 func (pc *PartitionConsumer) initWorker() {
 	pc.once.Do(func() {
+		pc.mu.Lock()
+		if pc.closed {
+			pc.mu.Unlock()
+			return
+		}
+		pc.mu.Unlock()
+
 		channelSize := pc.consumer.config.WorkerChannelSize
 		if channelSize <= 0 {
 			channelSize = 1000

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -1,0 +1,557 @@
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// messageBatch groups messages from a single poll/stream response.
+type messageBatch struct {
+	topic    string
+	messages []Message
+}
+
+// PartitionConsumer handles consuming and committing for a single partition.
+type PartitionConsumer struct {
+	partitionID  int
+	consumer     *Consumer
+	fetchOffset  uint64
+	commitOffset uint64
+
+	conn   net.Conn
+	mu     sync.Mutex
+	closed bool
+	bo     *backoff
+
+	dataCh    chan *messageBatch
+	once      sync.Once
+	closeOnce sync.Once
+}
+
+// initWorker lazily starts the per-partition worker goroutine (once).
+func (pc *PartitionConsumer) initWorker() {
+	pc.once.Do(func() {
+		channelSize := pc.consumer.config.WorkerChannelSize
+		if channelSize <= 0 {
+			channelSize = 1000
+		}
+		pc.dataCh = make(chan *messageBatch, channelSize)
+		pc.consumer.wg.Add(1)
+		go pc.runWorker()
+	})
+}
+
+// closeDataCh closes the data channel exactly once.
+func (pc *PartitionConsumer) closeDataCh() {
+	pc.closeOnce.Do(func() {
+		if pc.dataCh != nil {
+			close(pc.dataCh)
+		}
+	})
+}
+
+// runWorker processes batches from dataCh, calls the message handler, and commits offsets.
+func (pc *PartitionConsumer) runWorker() {
+	defer pc.consumer.wg.Done()
+
+	for batch := range pc.dataCh {
+		select {
+		case <-pc.consumer.mainCtx.Done():
+			// Roll back fetchOffset to last committed so the next consumer picks up correctly.
+			pc.consumer.mu.RLock()
+			committed := pc.consumer.offsets[pc.partitionID]
+			pc.consumer.mu.RUnlock()
+			atomic.StoreUint64(&pc.fetchOffset, committed)
+			LogWarn("Partition [%d] worker stopping: context cancelled, rolled back to offset %d", pc.partitionID, committed)
+			continue
+		default:
+		}
+
+		if len(batch.messages) == 0 {
+			continue
+		}
+
+		// Deliver messages to user handler.
+		handler := pc.consumer.MessageHandler
+		if handler != nil {
+			for _, msg := range batch.messages {
+				if err := handler(msg); err != nil {
+					LogError("Partition [%d] handler error at offset %d: %v", pc.partitionID, msg.Offset, err)
+				}
+			}
+		}
+
+		if pc.consumer.mainCtx.Err() != nil {
+			// Ownership lost after handler — skip commit, roll back.
+			pc.consumer.mu.RLock()
+			committed := pc.consumer.offsets[pc.partitionID]
+			pc.consumer.mu.RUnlock()
+			atomic.StoreUint64(&pc.fetchOffset, committed)
+			continue
+		}
+
+		lastOffset := batch.messages[len(batch.messages)-1].Offset
+		commitOffset := lastOffset + 1
+
+		if err := pc.commitOffsetWithRetry(commitOffset); err != nil {
+			LogError("Partition [%d] failed to commit offset %d: %v", pc.partitionID, commitOffset, err)
+		} else {
+			atomic.StoreUint64(&pc.commitOffset, commitOffset)
+
+			pc.consumer.mu.Lock()
+			pc.consumer.offsets[pc.partitionID] = commitOffset
+			pc.consumer.mu.Unlock()
+		}
+	}
+}
+
+// pollAndProcess sends one CONSUME command and pushes the resulting batch to dataCh.
+func (pc *PartitionConsumer) pollAndProcess() {
+	select {
+	case <-pc.consumer.mainCtx.Done():
+		return
+	default:
+	}
+
+	pc.initWorker()
+
+	if err := pc.ensureConnection(); err != nil {
+		LogWarn("Partition [%d] cannot poll: %v", pc.partitionID, err)
+		return
+	}
+
+	pc.mu.Lock()
+	conn := pc.conn
+	currentOffset := atomic.LoadUint64(&pc.fetchOffset)
+	pc.mu.Unlock()
+
+	c := pc.consumer
+	c.mu.RLock()
+	memberID, generation := c.memberID, c.generation
+	c.mu.RUnlock()
+
+	consumeCmd := fmt.Sprintf("CONSUME topic=%s partition=%d offset=%d group=%s generation=%d member=%s",
+		c.config.Topic, pc.partitionID, currentOffset, c.config.GroupID, generation, memberID)
+
+	if err := WriteWithLength(conn, EncodeMessage(c.config.Topic, consumeCmd)); err != nil {
+		LogError("Partition [%d] send CONSUME failed: %v", pc.partitionID, err)
+		pc.closeConnection()
+		return
+	}
+
+	idleTimeout := time.Duration(c.config.StreamingReadDeadlineMS) * time.Millisecond
+	if idleTimeout <= 0 {
+		idleTimeout = 5 * time.Second
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(idleTimeout)); err != nil {
+		pc.closeConnection()
+		return
+	}
+
+	bo := pc.getBackoff()
+	batchData, err := ReadWithLength(conn)
+	_ = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		LogError("Partition [%d] read batch error: %v", pc.partitionID, err)
+		pc.closeConnection()
+		pc.waitWithBackoff(bo)
+		return
+	}
+
+	if pc.handleBrokerError(batchData) || len(batchData) == 0 {
+		pc.waitWithBackoff(bo)
+		return
+	}
+
+	messages, topic, _, err := DecodeBatchMessages(batchData)
+	if err != nil {
+		LogError("Partition [%d] decode error: %v", pc.partitionID, err)
+		return
+	}
+
+	if len(messages) == 0 {
+		return
+	}
+
+	// Offset gap detection
+	firstOffset := messages[0].Offset
+	expectedOffset := atomic.LoadUint64(&pc.fetchOffset)
+	if expectedOffset > 0 && firstOffset > expectedOffset {
+		LogError("Partition [%d] offset gap: expected %d, received %d (missing %d messages)",
+			pc.partitionID, expectedOffset, firstOffset, firstOffset-expectedOffset)
+	}
+
+	newOffset := messages[len(messages)-1].Offset + 1
+	atomic.StoreUint64(&pc.fetchOffset, newOffset)
+	bo.reset()
+
+	select {
+	case pc.dataCh <- &messageBatch{topic: topic, messages: messages}:
+	case <-c.doneCh:
+		pc.closeDataCh()
+	}
+}
+
+// startStreamLoop sends a STREAM command and continuously reads batches until rebalance or close.
+func (pc *PartitionConsumer) startStreamLoop() {
+	pc.initWorker()
+	pid := pc.partitionID
+	c := pc.consumer
+	bo := pc.getBackoff()
+	defer pc.closeDataCh()
+
+	for {
+		select {
+		case <-c.doneCh:
+			pc.closeConnection()
+			return
+		default:
+		}
+
+		if atomic.LoadInt32(&c.rebalancing) == 1 {
+			pc.closeConnection()
+			if !pc.waitWithBackoff(bo) {
+				return
+			}
+			continue
+		}
+
+		if err := pc.ensureConnection(); err != nil {
+			LogWarn("Partition [%d] stream connection failed, retrying: %v", pid, err)
+			if !pc.waitWithBackoff(bo) {
+				return
+			}
+			continue
+		}
+
+		// On reconnect, roll back to the last committed offset to avoid gaps.
+		c.mu.RLock()
+		committed, ok := c.offsets[pid]
+		c.mu.RUnlock()
+		if ok {
+			atomic.StoreUint64(&pc.fetchOffset, committed)
+			LogInfo("Partition [%d] reconnected, rolling back to committed offset %d", pid, committed)
+		}
+
+		pc.mu.Lock()
+		conn := pc.conn
+		currentOffset := atomic.LoadUint64(&pc.fetchOffset)
+		pc.mu.Unlock()
+
+		c.mu.RLock()
+		memberID, generation := c.memberID, c.generation
+		c.mu.RUnlock()
+
+		streamCmd := fmt.Sprintf("STREAM topic=%s partition=%d group=%s offset=%d generation=%d member=%s",
+			c.config.Topic, pid, c.config.GroupID, currentOffset, generation, memberID)
+
+		if err := WriteWithLength(conn, EncodeMessage("", streamCmd)); err != nil {
+			LogError("Partition [%d] STREAM send failed: %v", pid, err)
+			pc.closeConnection()
+			if !pc.waitWithBackoff(bo) {
+				return
+			}
+			continue
+		}
+
+		LogInfo("Partition [%d] streaming from offset %d", pid, currentOffset)
+
+		idleTimeout := time.Duration(c.config.StreamingReadDeadlineMS) * time.Millisecond
+		if idleTimeout <= 0 {
+			idleTimeout = 5 * time.Minute
+		}
+
+		for atomic.LoadInt32(&c.rebalancing) != 1 {
+			if err := conn.SetReadDeadline(time.Now().Add(idleTimeout)); err != nil {
+				pc.closeConnection()
+				break
+			}
+
+			batchData, err := ReadWithLength(conn)
+			if err != nil {
+				if ne, ok := err.(net.Error); ok && ne.Timeout() {
+					continue // idle timeout — retry read
+				}
+				LogError("Partition [%d] stream read error: %v", pid, err)
+				pc.closeConnection()
+				if !pc.waitWithBackoff(bo) {
+					return
+				}
+				break
+			}
+
+			if len(batchData) == 0 || pc.handleBrokerError(batchData) {
+				if !pc.waitWithBackoff(bo) {
+					return
+				}
+				continue
+			}
+
+			messages, topic, _, err := DecodeBatchMessages(batchData)
+			if err != nil {
+				LogError("Partition [%d] stream decode error: %v", pid, err)
+				if !pc.waitWithBackoff(bo) {
+					return
+				}
+				continue
+			}
+
+			if len(messages) == 0 {
+				bo.reset()
+				select {
+				case <-time.After(100 * time.Millisecond):
+				case <-c.doneCh:
+					return
+				case <-c.mainCtx.Done():
+					return
+				}
+				continue
+			}
+
+			lastOffset := messages[len(messages)-1].Offset
+			atomic.StoreUint64(&pc.fetchOffset, lastOffset+1)
+			bo.reset()
+
+			select {
+			case pc.dataCh <- &messageBatch{topic: topic, messages: messages}:
+			case <-c.doneCh:
+				return
+			}
+		}
+	}
+}
+
+// ensureConnection establishes a connection to the broker with retries and backoff.
+func (pc *PartitionConsumer) ensureConnection() error {
+	if pc.consumer.mainCtx.Err() != nil {
+		return fmt.Errorf("consumer shutting down")
+	}
+
+	pc.mu.Lock()
+	if pc.conn != nil {
+		pc.mu.Unlock()
+		return nil
+	}
+	if pc.closed {
+		pc.mu.Unlock()
+		return fmt.Errorf("%w", ErrConsumerClosed)
+	}
+	pc.mu.Unlock()
+
+	bo := pc.getBackoff()
+	maxRetries := pc.consumer.config.MaxConnectRetries
+	if maxRetries <= 0 {
+		maxRetries = 5
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		pc.mu.Lock()
+		if pc.closed {
+			pc.mu.Unlock()
+			return fmt.Errorf("%w", ErrConsumerClosed)
+		}
+		pc.mu.Unlock()
+
+		conn, _, connectErr := pc.consumer.client.ConnectWithFailover()
+		if connectErr == nil {
+			pc.mu.Lock()
+			if pc.closed {
+				_ = conn.Close()
+				pc.mu.Unlock()
+				return fmt.Errorf("%w", ErrConsumerClosed)
+			}
+			pc.conn = conn
+			pc.mu.Unlock()
+			return nil
+		}
+
+		lastErr = connectErr
+		waitDur := bo.duration()
+		LogWarn("Partition [%d] connect failed (attempt %d/%d): %v, retrying in %v",
+			pc.partitionID, attempt+1, maxRetries, connectErr, waitDur)
+
+		if !pc.waitDuration(waitDur) {
+			return fmt.Errorf("connection aborted by shutdown")
+		}
+	}
+	return fmt.Errorf("partition [%d] failed to connect after %d retries: %w", pc.partitionID, maxRetries, lastErr)
+}
+
+// handleBrokerError returns true if data is a recognised broker error string.
+func (pc *PartitionConsumer) handleBrokerError(data []byte) bool {
+	respStr := string(data)
+	if !strings.HasPrefix(respStr, "ERROR") {
+		return false
+	}
+
+	LogWarn("Partition [%d] broker error: %s", pc.partitionID, respStr)
+
+	if strings.Contains(respStr, "NOT_LEADER") {
+		pc.consumer.handleLeaderRedirection(respStr)
+	}
+
+	if strings.Contains(respStr, "GEN_MISMATCH") || strings.Contains(respStr, "REBALANCE_REQUIRED") {
+		pc.close()
+		go pc.consumer.handleRebalanceSignal()
+		return true
+	}
+
+	pc.closeConnection()
+	return true
+}
+
+// commitOffsetWithRetry tries the commit channel first, falling back to directCommit if full.
+func (pc *PartitionConsumer) commitOffsetWithRetry(offset uint64) error {
+	maxRetries := pc.consumer.config.MaxCommitRetries
+	if maxRetries <= 0 {
+		maxRetries = 5
+	}
+
+	minBO := pc.consumer.config.CommitRetryBackoff
+	maxBO := pc.consumer.config.CommitRetryMaxBackoff
+	bo := newBackoff(minBO, maxBO)
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if pc.consumer.mainCtx.Err() != nil {
+			return fmt.Errorf("commit cancelled: consumer context done")
+		}
+
+		resultCh := make(chan error, 1)
+		err := func() error {
+			select {
+			case pc.consumer.commitCh <- commitEntry{
+				partition: pc.partitionID,
+				offset:    offset,
+				respCh:    resultCh,
+			}:
+				timer := time.NewTimer(5 * time.Second)
+				defer timer.Stop()
+				select {
+				case err := <-resultCh:
+					return err
+				case <-pc.consumer.mainCtx.Done():
+					return fmt.Errorf("commit cancelled during wait")
+				case <-timer.C:
+					return fmt.Errorf("commit timeout")
+				}
+			default:
+				LogWarn("Partition [%d] commitCh full, falling back to directCommit", pc.partitionID)
+				return pc.consumer.directCommit(pc.partitionID, offset)
+			}
+		}()
+
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+		LogError("Partition [%d] commit attempt %d/%d failed: %v", pc.partitionID, attempt+1, maxRetries, err)
+
+		if !pc.waitWithBackoff(bo) {
+			return fmt.Errorf("commit aborted by shutdown")
+		}
+	}
+
+	return fmt.Errorf("commit failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+func (pc *PartitionConsumer) getBackoff() *backoff {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.bo == nil {
+		minDur := time.Duration(pc.consumer.config.ConnectRetryBackoffMS) * time.Millisecond
+		if minDur < 200*time.Millisecond {
+			minDur = 200 * time.Millisecond
+		}
+		pc.bo = newBackoff(minDur, 30*time.Second)
+	}
+	return pc.bo
+}
+
+func (pc *PartitionConsumer) waitWithBackoff(bo *backoff) bool {
+	d := bo.duration()
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-pc.consumer.mainCtx.Done():
+		return false
+	case <-pc.consumer.doneCh:
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func (pc *PartitionConsumer) waitDuration(d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-pc.consumer.mainCtx.Done():
+		return false
+	case <-pc.consumer.doneCh:
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func (pc *PartitionConsumer) PrintConsumedMessage(batch *messageBatch) {
+	if len(batch.messages) == 0 {
+		return
+	}
+	LogInfo("Partition [%d] batch received: topic='%s', count=%d", pc.partitionID, batch.topic, len(batch.messages))
+
+	limit := 5
+	if len(batch.messages) < limit {
+		limit = len(batch.messages)
+	}
+	for i := 0; i < limit; i++ {
+		msg := batch.messages[i]
+		payload := msg.Payload
+		if len(payload) > 50 {
+			payload = payload[:50] + "..."
+		}
+		if msg.Key == "" {
+			LogInfo("  msg[%d]: payload='%s'", i, payload)
+		} else {
+			LogInfo("  msg[%d]: key=%s payload='%s'", i, msg.Key, payload)
+		}
+	}
+	if len(batch.messages) > 5 {
+		LogInfo("  ... and %d more messages.", len(batch.messages)-5)
+	}
+}
+
+// close marks the consumer as closed and closes the connection and data channel.
+func (pc *PartitionConsumer) close() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.closed {
+		return
+	}
+	pc.closed = true
+	if pc.conn != nil {
+		_ = pc.conn.Close()
+		pc.conn = nil
+	}
+	pc.closeDataCh()
+}
+
+// closeConnection drops the current connection without marking the consumer closed.
+func (pc *PartitionConsumer) closeConnection() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.conn != nil {
+		_ = pc.conn.Close()
+		pc.conn = nil
+	}
+}

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -316,12 +316,15 @@ func (p *Producer) nextPartition() int {
 }
 
 func (p *Producer) CreateTopic(topic string, partitions int) error {
+	if len(p.config.BrokerAddrs) == 0 {
+		return fmt.Errorf("no broker addresses available")
+	}
 	brokerAddr := p.config.BrokerAddrs[0]
 	conn, err := net.Dial("tcp", brokerAddr)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	createCmd := fmt.Sprintf("CREATE topic=%s partitions=%d", topic, partitions)
 	cmdBytes := EncodeMessage("admin", createCmd)

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -77,10 +77,18 @@ func (pc *ProducerClient) connectPartitionLocked(idx int, addr string) error {
 			return fmt.Errorf("TLS dial to %s failed: %w", addr, err)
 		}
 	} else {
-		conn, err = net.Dial("tcp", addr)
+		conn, err = net.DialTimeout("tcp", addr, 5*time.Second)
 		if err != nil {
 			return fmt.Errorf("TCP dial to %s failed: %w", addr, err)
 		}
+	}
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true)
+		_ = tcpConn.SetKeepAlive(true)
+		_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
+		_ = tcpConn.SetReadBuffer(2 * 1024 * 1024)
+		_ = tcpConn.SetWriteBuffer(2 * 1024 * 1024)
 	}
 
 	var currentConns []net.Conn
@@ -279,8 +287,7 @@ func NewProducer(cfg *PublisherConfig) (*Producer, error) {
 	}
 
 	if err := p.CreateTopic(cfg.Topic, cfg.Partitions); err != nil {
-		logError("failed to create topic '%s': %v", cfg.Topic, err)
-		// We might still continue if AutoCreateTopics is true on broker, but better to fail early if explicit create fails
+		LogError("failed to create topic '%s': %v", cfg.Topic, err)
 	}
 
 	connectedCount := 0
@@ -288,7 +295,7 @@ func NewProducer(cfg *PublisherConfig) (*Producer, error) {
 		p.buffers[i] = newPartitionBuffer()
 		brokerAddr := p.client.selectBroker()
 		if err := p.client.ConnectPartition(i, brokerAddr); err != nil {
-			logError("Failed to connect partition %d: %v", i, err)
+			LogError("Failed to connect partition %d: %v", i, err)
 		} else {
 			connectedCount++
 		}
@@ -336,9 +343,10 @@ func (p *Producer) CreateTopic(topic string, partitions int) error {
 	return nil
 }
 
+// Send enqueues payload for delivery and returns the assigned sequence number.
 func (p *Producer) Send(payload string) (uint64, error) {
 	if atomic.LoadInt32(&p.closed) == 1 {
-		return 0, fmt.Errorf("producer closed")
+		return 0, fmt.Errorf("send: %w", ErrProducerClosed)
 	}
 
 	p.closeMu.Lock()
@@ -350,7 +358,7 @@ func (p *Producer) Send(payload string) (uint64, error) {
 	defer buf.mu.Unlock()
 
 	if buf.closed {
-		return 0, fmt.Errorf("partition %d buffer is closed", part)
+		return 0, fmt.Errorf("partition %d buffer closed: %w", part, ErrProducerClosed)
 	}
 
 	if len(buf.msgs) >= p.config.BufferSize {
@@ -369,6 +377,11 @@ func (p *Producer) Send(payload string) (uint64, error) {
 	buf.cond.Signal()
 
 	return seqNum, nil
+}
+
+// PublishMessage is an alias for Send, for compatibility with test/publisher.
+func (p *Producer) PublishMessage(payload string) (uint64, error) {
+	return p.Send(payload)
 }
 
 func (p *Producer) partitionSender(part int) {
@@ -485,7 +498,7 @@ func (p *Producer) sendBatch(part int, batch []Message) {
 
 	data, err := EncodeBatchMessages(p.config.Topic, part, p.config.Acks, p.config.EnableIdempotence, batch)
 	if err != nil {
-		logError("encode batch failed: %v", err)
+		LogError("encode batch failed: %v", err)
 		p.cleanupBatchState(part, batchID)
 		p.handleSendFailure(part, batch)
 		return
@@ -493,7 +506,7 @@ func (p *Producer) sendBatch(part int, batch []Message) {
 
 	payload, err := CompressMessage(data, p.config.CompressionType)
 	if err != nil {
-		logError("compress batch failed: %v", err)
+		LogError("compress batch failed: %v", err)
 		p.cleanupBatchState(part, batchID)
 		p.handleSendFailure(part, batch)
 		return
@@ -501,7 +514,7 @@ func (p *Producer) sendBatch(part int, batch []Message) {
 
 	ackResp, err := p.sendWithRetry(payload, part)
 	if err != nil {
-		logError("send failed: %v", err)
+		LogError("send failed: %v", err)
 		p.cleanupBatchState(part, batchID)
 		p.handleSendFailure(part, batch)
 		return
@@ -518,7 +531,7 @@ func (p *Producer) sendBatch(part int, batch []Message) {
 		p.partitionSentMus[part].Unlock()
 		p.markBatchAckedByID(part, batchID, len(batch))
 	case "PARTIAL":
-		logWarn("Partial success for batch %s", batchID)
+		LogWarn("Partial success for batch %s", batchID)
 		p.cleanupBatchState(part, batchID)
 		p.handlePartialFailure(part, batch, ackResp)
 	default:
@@ -681,19 +694,33 @@ func (p *Producer) markBatchAckedByID(part int, batchID string, batchLen int) {
 }
 
 func (p *Producer) parseAckResponse(resp []byte) (*AckResponse, error) {
+	respStr := string(resp)
+	// Handle plain-text error prefix from some broker versions
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return nil, fmt.Errorf("broker error: %s", strings.TrimSpace(respStr))
+	}
+
 	var ackResp AckResponse
 	if err := json.Unmarshal(resp, &ackResp); err != nil {
 		return nil, fmt.Errorf("invalid ack format: %w", err)
 	}
 
-	if ackResp.Leader != "" {
-		if ackResp.Leader != p.client.GetLeaderAddr() {
-			p.client.UpdateLeader(ackResp.Leader)
-		}
+	if ackResp.Leader != "" && ackResp.Leader != p.client.GetLeaderAddr() {
+		p.client.UpdateLeader(ackResp.Leader)
 	}
 
 	if ackResp.Status == "ERROR" {
 		return &ackResp, fmt.Errorf("broker error: %s", ackResp.ErrorMsg)
+	}
+
+	// Validate epoch and ProducerID for idempotent producers (BUG-02 fix)
+	if p.config.EnableIdempotence {
+		if ackResp.ProducerID == "" {
+			return nil, fmt.Errorf("incomplete ack: missing ProducerID")
+		}
+		if ackResp.ProducerEpoch != p.client.Epoch {
+			return nil, fmt.Errorf("epoch mismatch: expected %d, got %d", p.client.Epoch, ackResp.ProducerEpoch)
+		}
 	}
 
 	return &ackResp, nil
@@ -715,8 +742,7 @@ func (p *Producer) Flush() {
 	for time.Now().Before(deadline) {
 		allClear := true
 		for part := 0; part < p.partitions; part++ {
-			inFlight := atomic.LoadInt32(&p.inFlight[part])
-			if inFlight > 0 {
+			if atomic.LoadInt32(&p.inFlight[part]) > 0 {
 				allClear = false
 				break
 			}
@@ -728,6 +754,117 @@ func (p *Producer) Flush() {
 
 		time.Sleep(10 * time.Millisecond)
 	}
+
+	LogWarn("Flush timeout after %v", timeout)
+}
+
+// FlushBenchmark waits until all expectedTotal messages are acknowledged or timeout expires.
+func (p *Producer) FlushBenchmark(expectedTotal int) {
+	for _, buf := range p.buffers {
+		buf.mu.Lock()
+		buf.cond.Broadcast()
+		buf.mu.Unlock()
+	}
+
+	timeout := time.Duration(p.config.FlushTimeoutMS) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	start := time.Now()
+
+	for time.Now().Before(deadline) {
+		allInFlightClear := true
+		for part := 0; part < p.partitions; part++ {
+			if atomic.LoadInt32(&p.inFlight[part]) > 0 {
+				LogDebug("Partition %d still has in-flight messages", part)
+				allInFlightClear = false
+				break
+			}
+		}
+
+		if allInFlightClear {
+			ackedSoFar := p.GetUniqueAckCount()
+			totalPending := 0
+			for part := 0; part < p.partitions; part++ {
+				p.partitionBatchMus[part].Lock()
+				totalPending += len(p.partitionBatchStates[part])
+				p.partitionBatchMus[part].Unlock()
+			}
+
+			if ackedSoFar >= expectedTotal && totalPending == 0 {
+				LogInfo("FlushBenchmark completed — all %d messages acknowledged (%.3fs)", expectedTotal, time.Since(start).Seconds())
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	LogWarn("FlushBenchmark timeout after %v. Only %d/%d messages acknowledged.", timeout, p.GetUniqueAckCount(), expectedTotal)
+}
+
+// VerifySentSequences checks that exactly expectedCount unique sequences were acknowledged.
+func (p *Producer) VerifySentSequences(expectedCount int) error {
+	totalSent := 0
+	for part := 0; part < p.partitions; part++ {
+		p.partitionSentMus[part].Lock()
+		totalSent += len(p.partitionSentSeqs[part])
+		p.partitionSentMus[part].Unlock()
+	}
+
+	if totalSent != expectedCount {
+		return fmt.Errorf("expected %d messages sent, got %d", expectedCount, totalSent)
+	}
+
+	LogInfo("All %d sequences sent successfully across all partitions", expectedCount)
+	return nil
+}
+
+// GetPartitionStats returns per-partition batch timing statistics.
+func (p *Producer) GetPartitionStats() []PartitionStat {
+	p.bmMu.Lock()
+	defer p.bmMu.Unlock()
+
+	stats := make([]PartitionStat, 0, p.partitions)
+	for part := 0; part < p.partitions; part++ {
+		count := p.bmTotalCount[part]
+		totalTime := p.bmTotalTime[part]
+		var avg time.Duration
+		if count > 0 {
+			avg = totalTime / time.Duration(count)
+		}
+		stats = append(stats, PartitionStat{
+			PartitionID: part,
+			BatchCount:  count,
+			AvgDuration: avg,
+		})
+	}
+	return stats
+}
+
+// GetLatencies returns a copy of all recorded batch latencies.
+func (p *Producer) GetLatencies() []time.Duration {
+	p.bmMu.Lock()
+	defer p.bmMu.Unlock()
+
+	res := make([]time.Duration, len(p.bmLatencies))
+	copy(res, p.bmLatencies)
+	return res
+}
+
+// GetUniqueAckCount returns the number of uniquely acknowledged messages.
+func (p *Producer) GetUniqueAckCount() int {
+	return int(p.uniqueCount.Load())
+}
+
+// GetAttemptsCount returns total number of messages attempted (including retries).
+func (p *Producer) GetAttemptsCount() int {
+	return int(p.attemptsCount.Load())
+}
+
+// GetPartitionCount returns the configured partition count.
+func (p *Producer) GetPartitionCount() int {
+	return p.partitions
 }
 
 func (p *Producer) batchStateGC() {
@@ -748,6 +885,7 @@ func (p *Producer) batchStateGC() {
 					}
 
 					if !st.Acked && st.SentTime.Before(staleCutoff) {
+						LogWarn("GC: Dropping unacked stale batch: %s", id)
 						delete(p.partitionBatchStates[part], id)
 					}
 				}

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -1,0 +1,783 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const defaultLeaderStalenessThreshold = 30 * time.Second
+
+type leaderInfo struct {
+	addr    string
+	updated time.Time
+}
+
+type ProducerClient struct {
+	ID               string
+	globalSeqNum     atomic.Uint64
+	partitionSeqNums sync.Map // int -> *atomic.Uint64
+
+	Epoch  int64
+	mu     sync.RWMutex
+	conns  atomic.Pointer[[]net.Conn]
+	config *PublisherConfig
+
+	leader atomic.Pointer[leaderInfo]
+}
+
+func NewProducerClient(config *PublisherConfig) *ProducerClient {
+	pc := &ProducerClient{
+		ID:     uuid.New().String(),
+		Epoch:  time.Now().UnixNano(),
+		config: config,
+	}
+
+	pc.leader.Store(&leaderInfo{
+		addr:    "",
+		updated: time.Time{},
+	})
+
+	return pc
+}
+
+func (pc *ProducerClient) NextSeqNum(partition int) uint64 {
+	if !pc.config.EnableIdempotence {
+		return pc.globalSeqNum.Add(1)
+	}
+
+	val, _ := pc.partitionSeqNums.LoadOrStore(partition, &atomic.Uint64{})
+	return val.(*atomic.Uint64).Add(1)
+}
+
+func (pc *ProducerClient) connectPartitionLocked(idx int, addr string) error {
+	if idx < 0 {
+		return fmt.Errorf("invalid partition index: %d", idx)
+	}
+
+	var conn net.Conn
+	var err error
+
+	if pc.config.UseTLS {
+		var cert tls.Certificate
+		cert, err = tls.LoadX509KeyPair(pc.config.TLSCertPath, pc.config.TLSKeyPath)
+		if err != nil {
+			return fmt.Errorf("load TLS cert: %w", err)
+		}
+		conn, err = tls.Dial("tcp", addr, &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12})
+		if err != nil {
+			return fmt.Errorf("TLS dial to %s failed: %w", addr, err)
+		}
+	} else {
+		conn, err = net.Dial("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("TCP dial to %s failed: %w", addr, err)
+		}
+	}
+
+	var currentConns []net.Conn
+	if ptr := pc.conns.Load(); ptr != nil {
+		currentConns = *ptr
+	}
+
+	newSize := idx + 1
+	if len(currentConns) > newSize {
+		newSize = len(currentConns)
+	}
+
+	tmp := make([]net.Conn, newSize)
+	copy(tmp, currentConns)
+	tmp[idx] = conn
+
+	pc.conns.Store(&tmp)
+	return nil
+}
+
+func (pc *ProducerClient) GetConn(part int) net.Conn {
+	ptr := pc.conns.Load()
+	if ptr == nil {
+		return nil
+	}
+	conns := *ptr
+	if part >= 0 && part < len(conns) {
+		return conns[part]
+	}
+	return nil
+}
+
+func (pc *ProducerClient) Close() error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	ptr := pc.conns.Swap(nil)
+	if ptr == nil {
+		return nil
+	}
+
+	conns := *ptr
+	for i, c := range conns {
+		if c != nil {
+			_ = c.Close()
+			conns[i] = nil
+		}
+	}
+
+	return nil
+}
+
+func (pc *ProducerClient) GetLeaderAddr() string {
+	info := pc.leader.Load()
+	if info == nil || info.addr == "" {
+		return ""
+	}
+	return info.addr
+}
+
+func (pc *ProducerClient) UpdateLeader(leaderAddr string) {
+	old := pc.leader.Load()
+	if old != nil && old.addr == leaderAddr {
+		return
+	}
+
+	pc.leader.Store(&leaderInfo{
+		addr:    leaderAddr,
+		updated: time.Now(),
+	})
+}
+
+func (pc *ProducerClient) selectBroker() string {
+	if pc.config == nil || len(pc.config.BrokerAddrs) == 0 {
+		return ""
+	}
+
+	info := pc.leader.Load()
+	if info != nil && info.addr != "" && time.Since(info.updated) < defaultLeaderStalenessThreshold {
+		return info.addr
+	}
+
+	return pc.config.BrokerAddrs[0]
+}
+
+func (pc *ProducerClient) ConnectPartition(idx int, addr string) error {
+	if addr == "" {
+		addr = pc.selectBroker()
+	}
+	if addr == "" {
+		return fmt.Errorf("no broker address available for partition %d", idx)
+	}
+
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	return pc.connectPartitionLocked(idx, addr)
+}
+
+func (pc *ProducerClient) ReconnectPartition(idx int, addr string) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	oldPtr := pc.conns.Load()
+	if oldPtr != nil {
+		conns := *oldPtr
+		if idx < len(conns) && conns[idx] != nil {
+			_ = conns[idx].Close()
+		}
+	}
+
+	return pc.connectPartitionLocked(idx, addr)
+}
+
+type BatchState struct {
+	BatchID     string
+	StartSeqNum uint64
+	EndSeqNum   uint64
+	Partition   int
+	SentTime    time.Time
+	Acked       bool
+}
+
+type partitionBuffer struct {
+	mu     sync.Mutex
+	msgs   []Message
+	cond   *sync.Cond
+	closed bool
+}
+
+func newPartitionBuffer() *partitionBuffer {
+	p := &partitionBuffer{
+		msgs: make([]Message, 0),
+	}
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+type Producer struct {
+	config *PublisherConfig
+	client *ProducerClient
+
+	partitions int
+	buffers    []*partitionBuffer
+
+	sendersWG sync.WaitGroup
+
+	rr       uint32
+	inFlight []int32
+
+	partitionSentMus  []sync.Mutex
+	partitionSentSeqs []map[uint64]struct{}
+
+	ackedCount    atomic.Uint64
+	uniqueCount   atomic.Uint64
+	attemptsCount atomic.Uint64
+
+	partitionBatchStates []map[string]*BatchState
+	partitionBatchMus    []sync.Mutex
+	gcTicker             *time.Ticker
+
+	done    chan struct{}
+	closed  int32
+	closeMu sync.Mutex
+
+	bmMu         sync.Mutex
+	bmTotalTime  map[int]time.Duration
+	bmTotalCount map[int]int
+	bmLatencies  []time.Duration
+}
+
+func NewProducer(cfg *PublisherConfig) (*Producer, error) {
+	p := &Producer{
+		config:       cfg,
+		client:       NewProducerClient(cfg),
+		partitions:   cfg.Partitions,
+		buffers:      make([]*partitionBuffer, cfg.Partitions),
+		done:         make(chan struct{}),
+		bmTotalTime:  make(map[int]time.Duration),
+		bmTotalCount: make(map[int]int),
+		bmLatencies:  make([]time.Duration, 0),
+		inFlight:     make([]int32, cfg.Partitions),
+		gcTicker:     time.NewTicker(1 * time.Minute),
+	}
+
+	p.partitionSentSeqs = make([]map[uint64]struct{}, cfg.Partitions)
+	p.partitionSentMus = make([]sync.Mutex, cfg.Partitions)
+	for i := 0; i < cfg.Partitions; i++ {
+		p.partitionSentSeqs[i] = make(map[uint64]struct{})
+	}
+
+	p.partitionBatchStates = make([]map[string]*BatchState, cfg.Partitions)
+	p.partitionBatchMus = make([]sync.Mutex, cfg.Partitions)
+	for i := 0; i < cfg.Partitions; i++ {
+		p.partitionBatchStates[i] = make(map[string]*BatchState)
+	}
+
+	if err := p.CreateTopic(cfg.Topic, cfg.Partitions); err != nil {
+		logError("failed to create topic '%s': %v", cfg.Topic, err)
+		// We might still continue if AutoCreateTopics is true on broker, but better to fail early if explicit create fails
+	}
+
+	connectedCount := 0
+	for i := 0; i < cfg.Partitions; i++ {
+		p.buffers[i] = newPartitionBuffer()
+		brokerAddr := p.client.selectBroker()
+		if err := p.client.ConnectPartition(i, brokerAddr); err != nil {
+			logError("Failed to connect partition %d: %v", i, err)
+		} else {
+			connectedCount++
+		}
+		p.sendersWG.Add(1)
+		go p.partitionSender(i)
+	}
+	if connectedCount == 0 {
+		return nil, fmt.Errorf("failed to connect to any partition")
+	}
+
+	go p.batchStateGC()
+	return p, nil
+}
+
+func (p *Producer) nextPartition() int {
+	idx := int((atomic.AddUint32(&p.rr, 1) - 1) % uint32(p.partitions))
+	return idx
+}
+
+func (p *Producer) CreateTopic(topic string, partitions int) error {
+	brokerAddr := p.config.BrokerAddrs[0]
+	conn, err := net.Dial("tcp", brokerAddr)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer conn.Close()
+
+	createCmd := fmt.Sprintf("CREATE topic=%s partitions=%d", topic, partitions)
+	cmdBytes := EncodeMessage("admin", createCmd)
+
+	if err := WriteWithLength(conn, cmdBytes); err != nil {
+		return fmt.Errorf("send command: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if strings.Contains(string(resp), "ERROR:") {
+		return fmt.Errorf("broker error: %s", string(resp))
+	}
+
+	LogInfo("create topic %s partition %d", topic, partitions)
+	return nil
+}
+
+func (p *Producer) Send(payload string) (uint64, error) {
+	if atomic.LoadInt32(&p.closed) == 1 {
+		return 0, fmt.Errorf("producer closed")
+	}
+
+	p.closeMu.Lock()
+	part := p.nextPartition()
+	buf := p.buffers[part]
+	p.closeMu.Unlock()
+
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	if buf.closed {
+		return 0, fmt.Errorf("partition %d buffer is closed", part)
+	}
+
+	if len(buf.msgs) >= p.config.BufferSize {
+		return 0, fmt.Errorf("partition %d buffer full", part)
+	}
+
+	seqNum := p.client.NextSeqNum(part)
+	bm := Message{
+		SeqNum:     seqNum,
+		Payload:    payload,
+		ProducerID: p.client.ID,
+		Epoch:      p.client.Epoch,
+	}
+
+	buf.msgs = append(buf.msgs, bm)
+	buf.cond.Signal()
+
+	return seqNum, nil
+}
+
+func (p *Producer) partitionSender(part int) {
+	defer p.sendersWG.Done()
+
+	buf := p.buffers[part]
+	linger := time.Duration(p.config.LingerMS) * time.Millisecond
+
+	timer := time.NewTimer(linger)
+	defer timer.Stop()
+
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+
+	for {
+		buf.mu.Lock()
+
+		for len(buf.msgs) == 0 && !buf.closed && atomic.LoadInt32(&p.closed) == 0 {
+			buf.cond.Wait()
+		}
+
+		if (buf.closed || atomic.LoadInt32(&p.closed) == 1) && len(buf.msgs) == 0 {
+			buf.mu.Unlock()
+			return
+		}
+
+		var batch []Message
+		if len(buf.msgs) >= p.config.BatchSize {
+			batch = p.extract(buf)
+			buf.mu.Unlock()
+		} else {
+			buf.mu.Unlock()
+			timer.Reset(linger)
+
+			select {
+			case <-timer.C:
+				buf.mu.Lock()
+				if len(buf.msgs) > 0 {
+					batch = p.extractAny(buf)
+				}
+				buf.mu.Unlock()
+			case <-p.done:
+				return
+			}
+		}
+
+		if len(batch) > 0 {
+			p.sendBatch(part, batch)
+		}
+	}
+}
+
+func (p *Producer) extract(buf *partitionBuffer) []Message {
+	if len(buf.msgs) == 0 {
+		return nil
+	}
+
+	n := p.config.BatchSize
+	if len(buf.msgs) < n {
+		n = len(buf.msgs)
+	}
+
+	batch := make([]Message, n)
+	copy(batch, buf.msgs[:n])
+	buf.msgs = buf.msgs[n:]
+
+	return batch
+}
+
+func (p *Producer) extractAny(buf *partitionBuffer) []Message {
+	if len(buf.msgs) == 0 {
+		return nil
+	}
+
+	n := len(buf.msgs)
+	batch := make([]Message, n)
+	copy(batch, buf.msgs[:n])
+	buf.msgs = buf.msgs[:0]
+
+	return batch
+}
+
+func (p *Producer) sendBatch(part int, batch []Message) {
+	if len(batch) == 0 {
+		return
+	}
+
+	atomic.AddInt32(&p.inFlight[part], 1)
+	defer atomic.AddInt32(&p.inFlight[part], -1)
+
+	var batchStart, batchEnd uint64
+	if len(batch) > 0 {
+		batchStart = batch[0].SeqNum
+		batchEnd = batch[len(batch)-1].SeqNum
+	}
+
+	shortID := p.client.ID[:8]
+	batchID := fmt.Sprintf("%s-%d-p%d-%d-%d", shortID, p.client.Epoch, part, batchStart, batchEnd)
+
+	p.partitionBatchMus[part].Lock()
+	p.partitionBatchStates[part][batchID] = &BatchState{
+		BatchID:     batchID,
+		StartSeqNum: batchStart,
+		EndSeqNum:   batchEnd,
+		Partition:   part,
+		SentTime:    time.Now(),
+		Acked:       false,
+	}
+	p.partitionBatchMus[part].Unlock()
+
+	data, err := EncodeBatchMessages(p.config.Topic, part, p.config.Acks, p.config.EnableIdempotence, batch)
+	if err != nil {
+		logError("encode batch failed: %v", err)
+		p.cleanupBatchState(part, batchID)
+		p.handleSendFailure(part, batch)
+		return
+	}
+
+	payload, err := CompressMessage(data, p.config.CompressionType)
+	if err != nil {
+		logError("compress batch failed: %v", err)
+		p.cleanupBatchState(part, batchID)
+		p.handleSendFailure(part, batch)
+		return
+	}
+
+	ackResp, err := p.sendWithRetry(payload, part)
+	if err != nil {
+		logError("send failed: %v", err)
+		p.cleanupBatchState(part, batchID)
+		p.handleSendFailure(part, batch)
+		return
+	}
+
+	p.attemptsCount.Add(uint64(len(batch)))
+
+	switch ackResp.Status {
+	case "OK":
+		p.partitionSentMus[part].Lock()
+		for _, m := range batch {
+			p.partitionSentSeqs[part][m.SeqNum] = struct{}{}
+		}
+		p.partitionSentMus[part].Unlock()
+		p.markBatchAckedByID(part, batchID, len(batch))
+	case "PARTIAL":
+		logWarn("Partial success for batch %s", batchID)
+		p.cleanupBatchState(part, batchID)
+		p.handlePartialFailure(part, batch, ackResp)
+	default:
+		p.cleanupBatchState(part, batchID)
+	}
+}
+
+func (p *Producer) cleanupBatchState(part int, batchID string) {
+	p.partitionBatchMus[part].Lock()
+	delete(p.partitionBatchStates[part], batchID)
+	p.partitionBatchMus[part].Unlock()
+}
+
+func (p *Producer) handleSendFailure(part int, batch []Message) {
+	if len(batch) == 0 {
+		return
+	}
+
+	buf := p.buffers[part]
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	p.partitionSentMus[part].Lock()
+	var retryBatch []Message
+	for _, msg := range batch {
+		if _, exists := p.partitionSentSeqs[part][msg.SeqNum]; !exists {
+			msg.Retry = true
+			retryBatch = append(retryBatch, msg)
+		}
+	}
+	p.partitionSentMus[part].Unlock()
+
+	allMsgs := append(buf.msgs, retryBatch...)
+	sort.Slice(allMsgs, func(i, j int) bool {
+		if allMsgs[i].Retry && !allMsgs[j].Retry {
+			return true
+		}
+		if !allMsgs[i].Retry && allMsgs[j].Retry {
+			return false
+		}
+		return allMsgs[i].SeqNum < allMsgs[j].SeqNum
+	})
+
+	buf.msgs = allMsgs
+	buf.cond.Signal()
+}
+
+func (p *Producer) handlePartialFailure(part int, batch []Message, ackResp *AckResponse) {
+	lastSuccessSeq := ackResp.SeqEnd
+
+	buf := p.buffers[part]
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	var retryBatch []Message
+	for _, msg := range batch {
+		if msg.SeqNum > lastSuccessSeq {
+			retryBatch = append(retryBatch, msg)
+		}
+	}
+
+	if len(retryBatch) > 0 {
+		allMsgs := append(buf.msgs, retryBatch...)
+		sort.Slice(allMsgs, func(i, j int) bool {
+			return allMsgs[i].SeqNum < allMsgs[j].SeqNum
+		})
+		buf.msgs = allMsgs
+		buf.cond.Signal()
+	}
+}
+
+func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error) {
+	maxAttempts := p.config.MaxRetries + 1
+	backoff := p.config.RetryBackoffMS
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		conn := p.client.GetConn(part)
+		if conn == nil {
+			brokerAddr := p.client.selectBroker()
+			if err := p.client.ReconnectPartition(part, brokerAddr); err != nil {
+				lastErr = fmt.Errorf("reconnect failed: %w", err)
+				time.Sleep(time.Duration(backoff) * time.Millisecond)
+				backoff = min(backoff*2, p.config.MaxBackoffMS)
+				continue
+			}
+			conn = p.client.GetConn(part)
+			if conn == nil {
+				lastErr = fmt.Errorf("no connection after reconnect")
+				time.Sleep(time.Duration(backoff) * time.Millisecond)
+				backoff = min(backoff*2, p.config.MaxBackoffMS)
+				continue
+			}
+		}
+
+		if err := conn.SetWriteDeadline(time.Now().Add(time.Duration(p.config.WriteTimeoutMS) * time.Millisecond)); err != nil {
+			lastErr = fmt.Errorf("set write deadline failed: %w", err)
+			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			backoff = min(backoff*2, p.config.MaxBackoffMS)
+			continue
+		}
+
+		if err := WriteWithLength(conn, payload); err != nil {
+			lastErr = fmt.Errorf("write failed: %w", err)
+			brokerAddr := p.client.selectBroker()
+			_ = p.client.ReconnectPartition(part, brokerAddr)
+			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			backoff = min(backoff*2, p.config.MaxBackoffMS)
+			continue
+		}
+
+		if p.config.Acks == "0" {
+			return &AckResponse{Status: "OK"}, nil
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(time.Duration(p.config.AckTimeoutMS) * time.Millisecond))
+		resp, err := ReadWithLength(conn)
+		_ = conn.SetReadDeadline(time.Time{})
+
+		if err != nil {
+			lastErr = fmt.Errorf("read ack failed: %w", err)
+			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			backoff = min(backoff*2, p.config.MaxBackoffMS)
+			continue
+		}
+
+		ackResp, err := p.parseAckResponse(resp)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		return ackResp, nil
+	}
+	return nil, lastErr
+}
+
+func (p *Producer) markBatchAckedByID(part int, batchID string, batchLen int) {
+	p.partitionBatchMus[part].Lock()
+	state, ok := p.partitionBatchStates[part][batchID]
+	if !ok || state.Acked {
+		p.partitionBatchMus[part].Unlock()
+		return
+	}
+
+	state.Acked = true
+	p.uniqueCount.Add(uint64(batchLen))
+
+	delete(p.partitionBatchStates[part], batchID)
+	p.partitionBatchMus[part].Unlock()
+
+	p.ackedCount.Store(state.EndSeqNum)
+
+	elapsed := time.Since(state.SentTime)
+	p.bmMu.Lock()
+	p.bmTotalCount[part] += 1
+	p.bmTotalTime[part] += elapsed
+	p.bmLatencies = append(p.bmLatencies, elapsed)
+	p.bmMu.Unlock()
+}
+
+func (p *Producer) parseAckResponse(resp []byte) (*AckResponse, error) {
+	var ackResp AckResponse
+	if err := json.Unmarshal(resp, &ackResp); err != nil {
+		return nil, fmt.Errorf("invalid ack format: %w", err)
+	}
+
+	if ackResp.Leader != "" {
+		if ackResp.Leader != p.client.GetLeaderAddr() {
+			p.client.UpdateLeader(ackResp.Leader)
+		}
+	}
+
+	if ackResp.Status == "ERROR" {
+		return &ackResp, fmt.Errorf("broker error: %s", ackResp.ErrorMsg)
+	}
+
+	return &ackResp, nil
+}
+
+func (p *Producer) Flush() {
+	for _, buf := range p.buffers {
+		buf.mu.Lock()
+		buf.cond.Broadcast()
+		buf.mu.Unlock()
+	}
+
+	timeout := time.Duration(p.config.FlushTimeoutMS) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		allClear := true
+		for part := 0; part < p.partitions; part++ {
+			inFlight := atomic.LoadInt32(&p.inFlight[part])
+			if inFlight > 0 {
+				allClear = false
+				break
+			}
+		}
+
+		if allClear {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (p *Producer) batchStateGC() {
+	for {
+		select {
+		case <-p.gcTicker.C:
+			now := time.Now()
+			ackedCutoff := now.Add(-1 * time.Minute)
+			staleCutoff := now.Add(-5 * time.Minute)
+
+			for part := 0; part < p.partitions; part++ {
+				p.partitionBatchMus[part].Lock()
+
+				for id, st := range p.partitionBatchStates[part] {
+					if st.Acked && st.SentTime.Before(ackedCutoff) {
+						delete(p.partitionBatchStates[part], id)
+						continue
+					}
+
+					if !st.Acked && st.SentTime.Before(staleCutoff) {
+						delete(p.partitionBatchStates[part], id)
+					}
+				}
+				p.partitionBatchMus[part].Unlock()
+			}
+		case <-p.done:
+			return
+		}
+	}
+}
+
+func (p *Producer) Close() {
+	p.closeMu.Lock()
+	if atomic.LoadInt32(&p.closed) == 1 {
+		p.closeMu.Unlock()
+		return
+	}
+	atomic.StoreInt32(&p.closed, 1)
+	close(p.done)
+
+	for _, buf := range p.buffers {
+		buf.mu.Lock()
+		buf.closed = true
+		buf.cond.Broadcast()
+		buf.mu.Unlock()
+	}
+	p.closeMu.Unlock()
+
+	p.gcTicker.Stop()
+	p.sendersWG.Wait()
+
+	_ = p.client.Close()
+}

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -683,7 +683,25 @@ func (p *Producer) markBatchAckedByID(part int, batchID string, batchLen int) {
 	delete(p.partitionBatchStates[part], batchID)
 	p.partitionBatchMus[part].Unlock()
 
-	p.ackedCount.Store(state.EndSeqNum)
+	// Atomic max update for ackedCount
+	for {
+		current := p.ackedCount.Load()
+		if state.EndSeqNum <= current {
+			break
+		}
+		if p.ackedCount.CompareAndSwap(current, state.EndSeqNum) {
+			break
+		}
+	}
+
+	// Prune sent sequences below the highest acked to prevent memory leak
+	p.partitionSentMus[part].Lock()
+	for seq := range p.partitionSentSeqs[part] {
+		if seq <= state.EndSeqNum {
+			delete(p.partitionSentSeqs[part], seq)
+		}
+	}
+	p.partitionSentMus[part].Unlock()
 
 	elapsed := time.Since(state.SentTime)
 	p.bmMu.Lock()
@@ -897,11 +915,11 @@ func (p *Producer) batchStateGC() {
 	}
 }
 
-func (p *Producer) Close() {
+func (p *Producer) Close() error {
 	p.closeMu.Lock()
 	if atomic.LoadInt32(&p.closed) == 1 {
 		p.closeMu.Unlock()
-		return
+		return nil
 	}
 	atomic.StoreInt32(&p.closed, 1)
 	close(p.done)
@@ -917,5 +935,5 @@ func (p *Producer) Close() {
 	p.gcTicker.Stop()
 	p.sendersWG.Wait()
 
-	_ = p.client.Close()
+	return p.client.Close()
 }

--- a/sdk/protocol.go
+++ b/sdk/protocol.go
@@ -1,0 +1,319 @@
+package sdk
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/pierrec/lz4/v4"
+	snappy "github.com/segmentio/kafka-go/compress/snappy/go-xerial-snappy"
+)
+
+const MaxMessageSize = 64 * 1024 * 1024 // 64MB
+
+// EncodeMessage serializes topic and payload into bytes.
+func EncodeMessage(topic string, payload string) []byte {
+	topicBytes := []byte(topic)
+	payloadBytes := []byte(payload)
+	data := make([]byte, 2+len(topicBytes)+len(payloadBytes))
+	binary.BigEndian.PutUint16(data[:2], uint16(len(topicBytes)))
+	copy(data[2:2+len(topicBytes)], topicBytes)
+	copy(data[2+len(topicBytes):], payloadBytes)
+	return data
+}
+
+func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent bool, msgs []Message) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write([]byte{0xBA, 0x7C})
+
+	write := func(v any) error {
+		if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
+			return fmt.Errorf("encode value failed: %w", err)
+		}
+		return nil
+	}
+
+	topicBytes := []byte(topic)
+	if len(topicBytes) > 0xFFFF {
+		return nil, fmt.Errorf("topic too long: %d bytes", len(topicBytes))
+	}
+	if err := write(uint16(len(topicBytes))); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(topicBytes); err != nil {
+		return nil, fmt.Errorf("write topic bytes failed: %w", err)
+	}
+
+	if err := write(int32(partition)); err != nil {
+		return nil, err
+	}
+
+	acksBytes := []byte(acks)
+	if len(acksBytes) > 0xFF {
+		return nil, fmt.Errorf("acks value too long: %d bytes", len(acksBytes))
+	}
+	if err := write(uint8(len(acksBytes))); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(acksBytes); err != nil {
+		return nil, fmt.Errorf("write acks bytes failed: %w", err)
+	}
+
+	if err := write(isIdempotent); err != nil {
+		return nil, err
+	}
+
+	var batchStart, batchEnd uint64
+	if len(msgs) > 0 {
+		batchStart = msgs[0].SeqNum
+		batchEnd = msgs[len(msgs)-1].SeqNum
+	}
+	if err := write(batchStart); err != nil {
+		return nil, err
+	}
+	if err := write(batchEnd); err != nil {
+		return nil, err
+	}
+
+	if err := write(int32(len(msgs))); err != nil {
+		return nil, err
+	}
+
+	for _, m := range msgs {
+		if err := write(m.Offset); err != nil {
+			return nil, err
+		}
+
+		if err := write(m.SeqNum); err != nil {
+			return nil, err
+		}
+
+		producerIDBytes := []byte(m.ProducerID)
+		if len(producerIDBytes) > 0xFFFF {
+			return nil, fmt.Errorf("producerID too long: %d bytes", len(producerIDBytes))
+		}
+		if err := write(uint16(len(producerIDBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(producerIDBytes); err != nil {
+			return nil, err
+		}
+
+		keyBytes := []byte(m.Key)
+		if len(keyBytes) > 0xFFFF {
+			return nil, fmt.Errorf("key too long: %d bytes", len(keyBytes))
+		}
+		if err := write(uint16(len(keyBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(keyBytes); err != nil {
+			return nil, err
+		}
+
+		if err := write(m.Epoch); err != nil {
+			return nil, err
+		}
+
+		payloadBytes := []byte(m.Payload)
+		if err := write(uint32(len(payloadBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(payloadBytes); err != nil {
+			return nil, fmt.Errorf("write payload bytes failed: %w", err)
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// WriteWithLength writes data with a 4-byte length prefix.
+func WriteWithLength(conn net.Conn, data []byte) error {
+	if len(data) > MaxMessageSize {
+		return fmt.Errorf("data size %d exceeds maximum %d", len(data), MaxMessageSize)
+	}
+
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))
+	buf := append(lenBuf, data...)
+	if _, err := conn.Write(buf); err != nil {
+		return fmt.Errorf("write message: %w", err)
+	}
+	return nil
+}
+
+// ReadWithLength reads data with a 4-byte length prefix.
+func ReadWithLength(conn net.Conn) ([]byte, error) {
+	lenBuf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, lenBuf); err != nil {
+		return nil, fmt.Errorf("read length: %w", err)
+	}
+	length := binary.BigEndian.Uint32(lenBuf)
+	if length > MaxMessageSize {
+		return nil, fmt.Errorf("message size %d exceeds maximum %d", length, MaxMessageSize)
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	return buf, nil
+}
+
+// CompressMessage compresses a message if enabled
+func CompressMessage(data []byte, compressionType string) ([]byte, error) {
+	switch compressionType {
+	case "gzip":
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		if _, err := gw.Write(data); err != nil {
+			return nil, err
+		}
+		if err := gw.Close(); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+
+	case "snappy":
+		return snappy.Encode(data), nil
+
+	case "lz4":
+		var buf bytes.Buffer
+		zw := lz4.NewWriter(&buf)
+		if _, err := zw.Write(data); err != nil {
+			return nil, err
+		}
+		if err := zw.Close(); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+
+	case "none", "":
+		return data, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported compression type: %s", compressionType)
+	}
+}
+
+// DecompressMessage decompresses a message if enabled
+func DecompressMessage(data []byte, compressionType string) ([]byte, error) {
+	switch compressionType {
+	case "gzip":
+		gr, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		defer gr.Close()
+		return io.ReadAll(gr)
+
+	case "snappy":
+		return snappy.Decode(data)
+
+	case "lz4":
+		reader := lz4.NewReader(bytes.NewReader(data))
+		return io.ReadAll(reader)
+
+	case "none", "":
+		return data, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported compression type: %s", compressionType)
+	}
+}
+
+// DecodeBatchMessages decodes a batch encoded by EncodeBatchMessages
+func DecodeBatchMessages(data []byte) ([]Message, string, int, error) {
+	if len(data) < 2 {
+		return nil, "", 0, fmt.Errorf("data too short")
+	}
+
+	reader := bytes.NewReader(data)
+
+	var magic uint16
+	if err := binary.Read(reader, binary.BigEndian, &magic); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read magic number: %w", err)
+	}
+	if magic != 0xBA7C {
+		return nil, "", 0, fmt.Errorf("invalid magic number: %x", magic)
+	}
+
+	var topicLen uint16
+	if err := binary.Read(reader, binary.BigEndian, &topicLen); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read topic length: %w", err)
+	}
+	topicBytes := make([]byte, topicLen)
+	if _, err := io.ReadFull(reader, topicBytes); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read topic bytes: %w", err)
+	}
+
+	var partition int32
+	if err := binary.Read(reader, binary.BigEndian, &partition); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read partition: %w", err)
+	}
+
+	var acksLen uint8
+	if err := binary.Read(reader, binary.BigEndian, &acksLen); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read acks length: %w", err)
+	}
+	acksBytes := make([]byte, acksLen)
+	if _, err := io.ReadFull(reader, acksBytes); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read acks bytes: %w", err)
+	}
+
+	var isIdempotent bool
+	if err := binary.Read(reader, binary.BigEndian, &isIdempotent); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read isIdempotent: %w", err)
+	}
+
+	var batchStart, batchEnd uint64
+	if err := binary.Read(reader, binary.BigEndian, &batchStart); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read batch start: %w", err)
+	}
+	if err := binary.Read(reader, binary.BigEndian, &batchEnd); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read batch end: %w", err)
+	}
+
+	var msgCount int32
+	if err := binary.Read(reader, binary.BigEndian, &msgCount); err != nil {
+		return nil, "", 0, fmt.Errorf("failed to read message count: %w", err)
+	}
+
+	messages := make([]Message, 0, msgCount)
+	for i := 0; i < int(msgCount); i++ {
+		var m Message
+		if err := binary.Read(reader, binary.BigEndian, &m.Offset); err != nil {
+			return nil, "", 0, err
+		}
+		if err := binary.Read(reader, binary.BigEndian, &m.SeqNum); err != nil {
+			return nil, "", 0, err
+		}
+
+		var pIdLen uint16
+		binary.Read(reader, binary.BigEndian, &pIdLen)
+		pIdBytes := make([]byte, pIdLen)
+		io.ReadFull(reader, pIdBytes)
+		m.ProducerID = string(pIdBytes)
+
+		var keyLen uint16
+		binary.Read(reader, binary.BigEndian, &keyLen)
+		keyBytes := make([]byte, keyLen)
+		io.ReadFull(reader, keyBytes)
+		m.Key = string(keyBytes)
+
+		binary.Read(reader, binary.BigEndian, &m.Epoch)
+
+		var payloadLen uint32
+		binary.Read(reader, binary.BigEndian, &payloadLen)
+		payloadBytes := make([]byte, payloadLen)
+		io.ReadFull(reader, payloadBytes)
+		m.Payload = string(payloadBytes)
+
+		messages = append(messages, m)
+	}
+
+	return messages, string(topicBytes), int(partition), nil
+}
+
+

--- a/sdk/protocol.go
+++ b/sdk/protocol.go
@@ -207,7 +207,7 @@ func DecompressMessage(data []byte, compressionType string) ([]byte, error) {
 		}
 		res, err := io.ReadAll(gr)
 		if err != nil {
-			gr.Close()
+			_ = gr.Close()
 			return nil, err
 		}
 		if err := gr.Close(); err != nil {

--- a/sdk/protocol.go
+++ b/sdk/protocol.go
@@ -284,30 +284,44 @@ func DecodeBatchMessages(data []byte) ([]Message, string, int, error) {
 	for i := 0; i < int(msgCount); i++ {
 		var m Message
 		if err := binary.Read(reader, binary.BigEndian, &m.Offset); err != nil {
-			return nil, "", 0, err
+			return nil, "", 0, fmt.Errorf("read offset[%d]: %w", i, err)
 		}
 		if err := binary.Read(reader, binary.BigEndian, &m.SeqNum); err != nil {
-			return nil, "", 0, err
+			return nil, "", 0, fmt.Errorf("read seqnum[%d]: %w", i, err)
 		}
 
 		var pIdLen uint16
-		binary.Read(reader, binary.BigEndian, &pIdLen)
+		if err := binary.Read(reader, binary.BigEndian, &pIdLen); err != nil {
+			return nil, "", 0, fmt.Errorf("read producerID length[%d]: %w", i, err)
+		}
 		pIdBytes := make([]byte, pIdLen)
-		io.ReadFull(reader, pIdBytes)
+		if _, err := io.ReadFull(reader, pIdBytes); err != nil {
+			return nil, "", 0, fmt.Errorf("read producerID[%d]: %w", i, err)
+		}
 		m.ProducerID = string(pIdBytes)
 
 		var keyLen uint16
-		binary.Read(reader, binary.BigEndian, &keyLen)
+		if err := binary.Read(reader, binary.BigEndian, &keyLen); err != nil {
+			return nil, "", 0, fmt.Errorf("read key length[%d]: %w", i, err)
+		}
 		keyBytes := make([]byte, keyLen)
-		io.ReadFull(reader, keyBytes)
+		if _, err := io.ReadFull(reader, keyBytes); err != nil {
+			return nil, "", 0, fmt.Errorf("read key[%d]: %w", i, err)
+		}
 		m.Key = string(keyBytes)
 
-		binary.Read(reader, binary.BigEndian, &m.Epoch)
+		if err := binary.Read(reader, binary.BigEndian, &m.Epoch); err != nil {
+			return nil, "", 0, fmt.Errorf("read epoch[%d]: %w", i, err)
+		}
 
 		var payloadLen uint32
-		binary.Read(reader, binary.BigEndian, &payloadLen)
+		if err := binary.Read(reader, binary.BigEndian, &payloadLen); err != nil {
+			return nil, "", 0, fmt.Errorf("read payload length[%d]: %w", i, err)
+		}
 		payloadBytes := make([]byte, payloadLen)
-		io.ReadFull(reader, payloadBytes)
+		if _, err := io.ReadFull(reader, payloadBytes); err != nil {
+			return nil, "", 0, fmt.Errorf("read payload[%d]: %w", i, err)
+		}
 		m.Payload = string(payloadBytes)
 
 		messages = append(messages, m)

--- a/sdk/protocol.go
+++ b/sdk/protocol.go
@@ -205,15 +205,26 @@ func DecompressMessage(data []byte, compressionType string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer gr.Close()
-		return io.ReadAll(gr)
+		res, err := io.ReadAll(gr)
+		if err != nil {
+			gr.Close()
+			return nil, err
+		}
+		if err := gr.Close(); err != nil {
+			return nil, err
+		}
+		return res, nil
 
 	case "snappy":
 		return snappy.Decode(data)
 
 	case "lz4":
 		reader := lz4.NewReader(bytes.NewReader(data))
-		return io.ReadAll(reader)
+		res, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("lz4 read all: %w", err)
+		}
+		return res, nil
 
 	case "none", "":
 		return data, nil

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -1,6 +1,9 @@
 package sdk
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Message represents a single message
 type Message struct {
@@ -30,4 +33,11 @@ type AckResponse struct {
 	SeqEnd        uint64 `json:"seq_end"`
 	Leader        string `json:"leader,omitempty"`
 	ErrorMsg      string `json:"error,omitempty"`
+}
+
+// PartitionStat holds per-partition benchmark statistics for a producer.
+type PartitionStat struct {
+	PartitionID int
+	BatchCount  int
+	AvgDuration time.Duration
 }

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -1,0 +1,33 @@
+package sdk
+
+import "fmt"
+
+// Message represents a single message
+type Message struct {
+	Offset     uint64
+	ProducerID string
+	SeqNum     uint64
+	Payload    string
+	Key        string // optional: partition routing key
+	Epoch      int64
+
+	RetryCount int
+	Retry      bool
+}
+
+func (m Message) String() string {
+	return fmt.Sprintf("Message { ID: %s-%d, Payload:%s, Offset:%d, Key:%s, Epoch:%d, RetryCount:%d }",
+		m.ProducerID, m.SeqNum, m.Payload, m.Offset, m.Key, m.Epoch, m.RetryCount)
+}
+
+// AckResponse represents the broker's response to a produce request
+type AckResponse struct {
+	Status        string `json:"status"`
+	LastOffset    uint64 `json:"last_offset"`
+	ProducerEpoch int64  `json:"producer_epoch"`
+	ProducerID    string `json:"producer_id"`
+	SeqStart      uint64 `json:"seq_start"`
+	SeqEnd        uint64 `json:"seq_end"`
+	Leader        string `json:"leader,omitempty"`
+	ErrorMsg      string `json:"error,omitempty"`
+}

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -1,0 +1,51 @@
+package sdk
+
+import (
+	"log"
+	"os"
+	"sync/atomic"
+)
+
+type LogLevel int32
+
+const (
+	LogLevelDebug LogLevel = iota
+	LogLevelInfo
+	LogLevelWarn
+	LogLevelError
+)
+
+var currentLevel atomic.Int32
+
+func SetLogLevel(level LogLevel) {
+	currentLevel.Store(int32(level))
+}
+
+func LogDebug(format string, v ...interface{}) {
+	if currentLevel.Load() <= int32(LogLevelDebug) {
+		log.Printf("[DEBUG] "+format, v...)
+	}
+}
+
+func LogInfo(format string, v ...interface{}) {
+	if currentLevel.Load() <= int32(LogLevelInfo) {
+		log.Printf("[INFO] "+format, v...)
+	}
+}
+
+func logWarn(format string, v ...interface{}) {
+	if currentLevel.Load() <= int32(LogLevelWarn) {
+		log.Printf("[WARN] "+format, v...)
+	}
+}
+
+func logError(format string, v ...interface{}) {
+	if currentLevel.Load() <= int32(LogLevelError) {
+		log.Printf("[ERROR] "+format, v...)
+	}
+}
+
+func LogFatal(format string, v ...interface{}) {
+	log.Printf("[FATAL] "+format, v...)
+	os.Exit(1)
+}

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -33,13 +33,13 @@ func LogInfo(format string, v ...interface{}) {
 	}
 }
 
-func logWarn(format string, v ...interface{}) {
+func LogWarn(format string, v ...interface{}) {
 	if currentLevel.Load() <= int32(LogLevelWarn) {
 		log.Printf("[WARN] "+format, v...)
 	}
 }
 
-func logError(format string, v ...interface{}) {
+func LogError(format string, v ...interface{}) {
 	if currentLevel.Load() <= int32(LogLevelError) {
 		log.Printf("[ERROR] "+format, v...)
 	}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

## Context
1. The SDK is designed for general application development, supporting both polling and streaming modes.
2. Bug Fixes:
- **Panic**: Added a default heartbeat interval to the consumer configuration.
- **Generation Mismatch**: Fixed an issue where the broker ignored the client's generation parameter.
- **Connection EOF**: Resolved a bug where the broker prematurely terminated the connection loop during streaming.
- **Protocol Corruption**: Fixed data interleaving issues between real-time broadcasts and polling-based streaming by unifying the data path.

## Key Changes
- Fixed a panic caused by a missing heartbeat interval.
- Fixed session (generation) validation logic and connection management when the broker processes `STREAM` commands.
- Optimized real-time broadcast logic to prevent data corruption during streaming transmission.
 
Checklist:

- [ ] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing).
- [ ] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [ ] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [ ] A brief description of why this PR is necessary or what problem it solves is included.