### PR TITLE
feat: add navtive event-sourcing support

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -48,7 +49,7 @@ func main() {
 	}
 
 	tm := topic.NewTopicManager(cfg, dm, smAdapter)
-	cd := coordinator.NewCoordinator(cfg, tm)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
 	tm.SetCoordinator(cd)
 
 	// Static consumer groups

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
@@ -49,7 +51,9 @@ func main() {
 	}
 
 	tm := topic.NewTopicManager(cfg, dm, smAdapter)
-	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	cd := coordinator.NewCoordinator(ctx, cfg, tm)
 	tm.SetCoordinator(cd)
 
 	// Static consumer groups

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -29,7 +30,7 @@ func main() {
 		os.Exit(1)
 	}
 	tm := topic.NewTopicManager(cfg, dm, smAdapter)
-	cd := coordinator.NewCoordinator(cfg, tm)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
 	tm.SetCoordinator(cd)
 
 	ctx := controller.NewClientContext("default-group", 0)

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -1,0 +1,580 @@
+# Cursus Wire Protocol Specification
+
+> Version: 1.0
+> Target audience: SDK implementors (C++, Java, Python, Go)
+
+---
+
+## 1. Transport Layer
+
+### TCP Connection
+
+| Property | Value |
+|----------|-------|
+| Transport | TCP (IPv4/IPv6) |
+| Default port | 9000 (configurable) |
+| TLS | Optional, TLS 1.2+ required when enabled |
+| Health check | HTTP GET `/health` on port 9080 (configurable) |
+| Max concurrent connections | 1000 |
+| Idle timeout | 5 seconds (server re-reads on timeout, does NOT disconnect) |
+
+### Connection Lifecycle
+
+```
+Client              Broker
+  |--- TCP connect --->|
+  |                    | (worker assigned)
+  |--- command/batch ->| (length-prefixed frame)
+  |<-- response -------|
+  |--- command ------->|
+  |<-- response -------|
+  |    ...             |
+  |--- EXIT ---------->| (or close socket)
+```
+
+A single TCP connection handles all commands sequentially. For parallel operations, open multiple connections.
+
+---
+
+## 2. Framing
+
+Every message (request and response) uses a **4-byte Big Endian length prefix**.
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                    Body Length (uint32 BE)                     |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
+|                     Body (N bytes)                            |
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+- **Max body size**: 64 MB (`67,108,864` bytes)
+- **Byte order**: Big Endian (network order) throughout the protocol
+- Length field does NOT include itself (only body size)
+
+### Compression
+
+Body may be compressed before framing. Algorithm is configured per-broker (not negotiated per-connection).
+
+| Algorithm | ID |
+|-----------|----|
+| none | `""` or `"none"` |
+| gzip | `"gzip"` |
+| snappy | `"snappy"` (xerial format) |
+| lz4 | `"lz4"` |
+
+```
+Send:  body → compress(body) → [4-byte len][compressed body]
+Recv:  [4-byte len][compressed body] → decompress → body
+```
+
+---
+
+## 3. Message Types
+
+The broker distinguishes two message types by inspecting the first 2 bytes of the body:
+
+| Magic | Type | Format |
+|-------|------|--------|
+| `0xBA 0x7C` | Binary batch | Structured binary (Section 5) |
+| Other | Text command | UTF-8 string (Section 4) |
+
+---
+
+## 4. Text Commands
+
+### Encoding
+
+Text commands use an optional topic+payload envelope:
+
+```
+ 0                   1
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|      Topic Length (uint16 BE) |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|        Topic (T bytes)        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|     Command Payload (UTF-8)   |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+Alternatively, raw command strings (without the topic envelope) are accepted if they match a known command keyword.
+
+### Parameter Parsing Rules
+
+- Parameters use `key=value` syntax, separated by whitespace
+- **Parameter order is flexible** — the broker parses key=value pairs regardless of order
+- The `message=` parameter is special: it captures the entire remainder of the line
+- Command names are case-insensitive
+
+### Command Reference
+
+#### Topic Management
+
+**CREATE**
+```
+CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [replication_factor=<N>]
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| partitions | No | 4 | Number of partitions |
+| idempotent | No | false | Enable producer dedup |
+| replication_factor | No | 3 | Replica count (distributed mode) |
+
+Response: `Topic '<name>' now has <N> partitions`
+
+**DELETE**
+```
+DELETE topic=<name>
+```
+Response: `Topic '<name>' deleted`
+
+**LIST**
+```
+LIST
+```
+Response: `topic1, topic2, topic3` or `(no topics)`
+
+**DESCRIBE**
+```
+DESCRIBE topic=<name>
+```
+Response (JSON):
+```json
+{
+  "topic": "mytopic",
+  "partitions": [
+    {
+      "id": 0,
+      "leader": "broker-1:9000",
+      "replicas": ["broker-1", "broker-2"],
+      "isr": ["broker-1", "broker-2"],
+      "leo": 1024,
+      "hwm": 1020
+    }
+  ]
+}
+```
+
+#### Publishing
+
+**PUBLISH**
+```
+PUBLISH topic=<name> acks=<0|1|-1|all> producerId=<id> message=<text> [seqNum=<N>] [epoch=<N>] [isIdempotent=<true|false>]
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Target topic |
+| acks | No | 1 | Durability level |
+| producerId | Yes | - | Unique producer ID |
+| message | Yes | - | Message payload (captures rest of line) |
+| seqNum | No | 0 | Sequence number (for idempotent mode) |
+| epoch | No | 0 | Producer epoch |
+| isIdempotent | No | false | Enable dedup for this message |
+
+Response (JSON — `AckResponse`):
+```json
+{
+  "status": "OK",
+  "last_offset": 42,
+  "producer_id": "producer-1",
+  "producer_epoch": 0,
+  "seq_start": 1,
+  "seq_end": 1,
+  "leader": "broker-1:9000"
+}
+```
+
+**Acks Semantics**:
+
+| Value | Behavior |
+|-------|----------|
+| `0` | Fire-and-forget. Broker returns `OK` immediately |
+| `1` | Leader writes to local disk, then responds |
+| `-1` / `all` | Leader waits for `min_in_sync_replicas` acknowledgments |
+
+#### Consumer Group Coordination
+
+**JOIN_GROUP**
+```
+JOIN_GROUP topic=<name> group=<name> member=<id>
+```
+Response: `OK generation=<N> member=<actual-id> assignments=[0,1,2]`
+
+> Broker appends a random 4-digit suffix to the member ID.
+> e.g., `member=consumer-1` → actual ID `consumer-1-8374`
+
+**SYNC_GROUP**
+```
+SYNC_GROUP topic=<name> group=<name> member=<actual-id>
+```
+Response: `OK assignments=[0,1,2]`
+
+**LEAVE_GROUP**
+```
+LEAVE_GROUP topic=<name> group=<name> member=<actual-id>
+```
+Response: `Left group '<name>'`
+
+**HEARTBEAT**
+```
+HEARTBEAT topic=<name> group=<name> member=<actual-id> [generation=<N>]
+```
+Response: `OK`
+
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| group | Yes | - | Consumer group name |
+| member | Yes | - | Consumer member ID (with suffix) |
+| generation | No | - | Current generation number (for future validation) |
+
+Recommended interval: 3 seconds. Server session timeout: configurable (default ~30s).
+
+**GROUP_STATUS**
+```
+GROUP_STATUS group=<name>
+```
+Response (JSON):
+```json
+{
+  "group_name": "mygroup",
+  "topic_name": "mytopic",
+  "state": "Stable",
+  "generation": 3,
+  "member_count": 2,
+  "partition_count": 4,
+  "members": [
+    {
+      "member_id": "consumer-1-8374",
+      "last_heartbeat": "2025-01-01T00:00:00Z",
+      "assignments": [0, 1]
+    }
+  ],
+  "last_rebalance": "2025-01-01T00:00:00Z"
+}
+```
+
+#### Consuming
+
+**CONSUME** (single poll)
+```
+CONSUME topic=<name> partition=<N> offset=<N> member=<id> group=<name> [autoOffsetReset=<earliest|latest>] [batch=<N>] [wait_ms=<N>]
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name (supports `*` and `?` wildcards) |
+| partition | Yes | - | Partition ID |
+| offset | Yes | - | Starting offset |
+| member | Yes | - | Consumer member ID |
+| group | No | default-group | Consumer group |
+| autoOffsetReset | No | earliest | `earliest` (0) or `latest` (HWM) |
+| batch | No | 8192 | Max messages per poll |
+| wait_ms | No | 0 | Long-poll timeout in ms |
+
+Response: Binary batch frame (Section 5)
+
+**STREAM** (continuous push)
+```
+STREAM topic=<name> partition=<N> member=<id> group=<name> [batch=<N>]
+```
+
+Opens a continuous stream. Server pushes binary batches at ~100ms intervals. Connection stays open until client disconnects.
+
+Keepalive: Server sends `[00 00 00 00]` (4 zero bytes as length prefix) when no messages are available.
+
+#### Offset Management
+
+**FETCH_OFFSET**
+```
+FETCH_OFFSET topic=<name> partition=<N> group=<name>
+```
+Response: `<offset>` (plain integer) or `0` if not found
+
+**COMMIT_OFFSET**
+```
+COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N>
+```
+Response: `OK`
+
+**BATCH_COMMIT**
+```
+BATCH_COMMIT topic=<name> group=<name> member=<id> generation=<N> P<partition>:<offset>,P<partition>:<offset>,...
+```
+Example: `BATCH_COMMIT topic=t1 group=g1 member=m1 generation=3 P0:100,P1:200,P2:150`
+
+Response: `OK batched=<N>`
+
+> The `P` prefix before partition numbers is required.
+
+#### Event Sourcing Commands
+
+These commands are available only on topics created with `event_sourcing=true`.
+
+**APPEND_STREAM**
+```
+APPEND_STREAM topic=<name> key=<aggregate_key> version=<N> event_type=<type> [schema_version=<N>] [metadata=<json>] message=<payload>
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Event-sourcing-enabled topic |
+| key | Yes | - | Aggregate ID (determines partition routing) |
+| version | Yes | - | Expected next version (must equal current version + 1) |
+| event_type | No | "" | Event type name (e.g., `OrderCreated`) |
+| schema_version | No | 1 | Schema version for upcasting |
+| metadata | No | "" | Arbitrary JSON metadata |
+| message | Yes | - | Event payload (captures rest of line) |
+
+Success response: `OK version=<N> offset=<N> partition=<N>`
+
+Error responses:
+- `ERROR: version_conflict current=<N> expected=<N>` — optimistic concurrency failure
+- `ERROR: topic '<name>' is not event-sourcing enabled` — topic not created with `event_sourcing=true`
+
+**READ_STREAM**
+```
+READ_STREAM topic=<name> key=<aggregate_key> [from_version=<N>]
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+| from_version | No | 1 (or snapshot version + 1 if snapshot exists) | Starting version |
+
+Response: Two length-prefixed frames sent sequentially.
+
+Frame 1 — JSON envelope:
+```json
+{
+  "topic": "orders",
+  "key": "order-123",
+  "partition": 2,
+  "count": 5,
+  "snapshot": {"version": 500, "payload": "..."}
+}
+```
+
+The `snapshot` field is included only when a snapshot exists at or after `from_version`. `count` reflects the number of events in Frame 2 (not including the snapshot).
+
+Frame 2 — Binary batch (standard 0xBA7C format) containing the events. If no events exist after the snapshot, the batch has message count 0.
+
+**STREAM_VERSION**
+```
+STREAM_VERSION topic=<name> key=<aggregate_key>
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+
+Response: Plain integer (e.g., `6`). Returns `0` if the aggregate does not exist.
+
+**SAVE_SNAPSHOT**
+```
+SAVE_SNAPSHOT topic=<name> key=<aggregate_key> version=<N> message=<payload>
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+| version | Yes | - | Aggregate version this snapshot represents (must be <= current version) |
+| message | Yes | - | Serialized aggregate state (captures rest of line) |
+
+Success response: `OK version=<N> partition=<N>`
+
+Error response: `ERROR: snapshot version <N> exceeds stream version <N>`
+
+**READ_SNAPSHOT**
+```
+READ_SNAPSHOT topic=<name> key=<aggregate_key>
+```
+| Param | Required | Default | Description |
+|-------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+
+Success response (JSON):
+```json
+{"version": 500, "payload": "..."}
+```
+
+Not found response: `NULL`
+
+---
+
+## 5. Binary Batch Format
+
+### Header
+
+```
+Offset  Size  Type     Field
+------  ----  -------  --------------------------------
+0       2     uint16   Magic (0xBA7C)
+2       2     uint16   Topic name length (T)
+4       T     string   Topic name (UTF-8)
+4+T     4     int32    Partition ID
+8+T     1     uint8    Acks string length (A)
+9+T     A     string   Acks value ("0", "1", "-1", "all")
+9+T+A   1     uint8    IsIdempotent (0x00 or 0x01)
+10+T+A  8     uint64   Batch start sequence number
+18+T+A  8     uint64   Batch end sequence number
+26+T+A  4     int32    Message count (M)
+30+T+A  ...   Message  M message records follow
+```
+
+### Message Record
+
+```
+Offset  Size  Type     Field
+------  ----  -------  --------------------------------
+0       8     uint64   Offset (0 on send, assigned by broker)
+8       8     uint64   Sequence number
+16      2     uint16   ProducerID length (P)
+18      P     string   ProducerID (UTF-8)
+18+P    2     uint16   Key length (K)
+20+P    K     string   Partition key (UTF-8, optional)
+20+P+K  8     int64    Epoch
+28+P+K  4     uint32   Payload length (L)
+32+P+K  L     bytes    Payload
+```
+
+### Batch Response
+
+Server responds with the same binary batch format (for CONSUME) or JSON `AckResponse` (for PUBLISH).
+
+---
+
+## 6. Consumer Group Protocol
+
+### Lifecycle
+
+```
+1. JOIN_GROUP   → receive generation, member ID, initial assignments
+2. SYNC_GROUP   → receive confirmed partition assignments
+3. Loop:
+   a. HEARTBEAT      (every 3s)
+   b. CONSUME/STREAM (fetch messages)
+   c. COMMIT_OFFSET  (periodically)
+4. LEAVE_GROUP  → graceful exit
+```
+
+### Rebalancing
+
+Rebalance is triggered when:
+- A new consumer joins
+- An existing consumer leaves or times out
+- Partitions are added to the topic
+
+Detection:
+- HEARTBEAT returns `ERROR` or generation changes
+- CONSUME returns ownership validation failure
+
+Client action:
+1. Stop consuming
+2. Commit current offsets
+3. Re-execute JOIN_GROUP → SYNC_GROUP
+4. Resume consuming with new assignments
+
+### Offset Resolution Priority
+
+```
+1. Saved offset from coordinator (via FETCH_OFFSET)
+2. Explicit offset from request parameter
+3. autoOffsetReset = "latest" → partition HWM
+4. autoOffsetReset = "earliest" → 0
+```
+
+---
+
+## 7. Error Handling
+
+### Error Response Format
+
+```
+ERROR: <description>
+```
+
+### Error Codes
+
+| Error | Cause | Client Action |
+|-------|-------|---------------|
+| `topic '<X>' does not exist` | Topic not created | CREATE topic first |
+| `PARTITION_NOT_FOUND <N>` | Invalid partition ID | Check DESCRIBE for valid IDs |
+| `TOPIC_NOT_FOUND <X>` | Topic not found | CREATE topic first |
+| `NOT_AUTHORIZED_FOR_PARTITION <T>:<P>` | Not partition leader | Redirect to correct leader |
+| `NOT_LEADER LEADER_IS <addr>` | Not Raft leader | Reconnect to specified address |
+| `group_not_found: <X>` | Group not registered | JOIN_GROUP or REGISTER_GROUP |
+| `topic_not_assigned_to_group` | Topic mismatch | Verify group registration |
+| `generation mismatch` | Stale generation | Re-join group |
+| `not partition owner` | Assignment changed | Re-join group |
+| `no_valid_offsets` | BATCH_COMMIT parse failure | Check format: `P<N>:<offset>` |
+| `version_conflict current=N expected=N` | Optimistic concurrency failure | Reload aggregate and retry |
+| `topic '<X>' is not event-sourcing enabled` | ES command on non-ES topic | CREATE topic with `event_sourcing=true` |
+| `snapshot version N exceeds stream version N` | Invalid snapshot version | Use version <= current stream version |
+
+### Leader Redirect
+
+In distributed mode, if a request reaches a non-leader broker:
+
+```
+ERROR: NOT_LEADER LEADER_IS 192.168.1.10:9000
+```
+
+Client should reconnect to the specified address and retry.
+
+---
+
+## 8. Idempotent Producer
+
+### Enable
+
+Set `isIdempotent=true` on PUBLISH or in binary batch header.
+
+### Requirements
+
+- Each message must have a unique `(producerId, seqNum)` pair
+- `seqNum` must be monotonically increasing per producer
+- `seqNum` = 0 disables dedup for that message
+- Broker rejects duplicates silently (returns OK)
+
+### Sequence Tracking
+
+- Broker tracks last seen sequence per `(producerId)` per partition
+- State survives across batches but not broker restarts (tracked in memory + FSM for distributed)
+- Producer state expires after 30 minutes of inactivity
+
+---
+
+## 9. SDK Implementation Checklist
+
+### Required
+
+- [ ] TCP connection with length-prefixed framing (4-byte BE)
+- [ ] Binary batch encoding/decoding (0xBA7C magic)
+- [ ] Text command formatting
+- [ ] JSON response parsing (AckResponse, DESCRIBE, GROUP_STATUS)
+- [ ] Consumer group lifecycle (JOIN → SYNC → HEARTBEAT → CONSUME → COMMIT)
+- [ ] Error response parsing
+- [ ] Leader redirect handling
+
+### Recommended
+
+- [ ] TLS 1.2+ support
+- [ ] Compression (gzip/snappy/lz4)
+- [ ] Connection pooling
+- [ ] Exponential backoff on reconnect
+- [ ] Async offset commits (BATCH_COMMIT)
+- [ ] Idempotent producer with sequence numbers
+- [ ] Wildcard topic subscription
+- [ ] Stream mode (continuous push)
+- [ ] Read/write buffer tuning (2MB recommended)
+- [ ] Event sourcing: APPEND_STREAM with optimistic concurrency
+- [ ] Event sourcing: READ_STREAM two-frame response parsing
+- [ ] Event sourcing: Snapshot save/read
+- [ ] Event sourcing: Auto-snapshot after N events (recommended: 500)

--- a/docs/user-guide/event-sourcing.md
+++ b/docs/user-guide/event-sourcing.md
@@ -1,0 +1,472 @@
+# Event Sourcing
+
+## Overview
+
+Event sourcing is a persistence pattern where state changes are captured as an immutable, append-only sequence of domain events. Instead of storing only the current state, the system stores every event that led to it. The current state is derived by replaying events from the beginning (or from a snapshot).
+
+Cursus provides native event sourcing support at the broker level. Aggregates are modeled as key-based logical streams within existing topics. The broker handles stream indexing, optimistic concurrency control, and snapshot management. Projections and schema evolution remain the responsibility of client applications.
+
+### Why Native Support Matters
+
+Without broker-level support, applications must implement concurrency control, version tracking, and stream indexing on top of a general-purpose message log. This leads to duplicated effort across SDKs and introduces race conditions that are difficult to resolve without coordination at the storage layer. By moving these concerns into the broker, Cursus guarantees linearizable writes per aggregate and eliminates an entire class of concurrency bugs.
+
+### Design Principles
+
+- **Reuse existing primitives.** Events are stored as regular messages in the append-only partition log. Consumer groups, replication, retention, and all existing features apply without modification.
+- **Opt-in per topic.** The `event_sourcing=true` flag on CREATE enables event sourcing behavior. Non-event-sourcing topics are completely unaffected.
+- **Broker owns storage, SDK owns domain logic.** The broker handles versioning, indexing, and snapshots. Schema evolution (upcasting) is the SDK's responsibility.
+
+---
+
+## Quick Start
+
+### 1. Create an Event-Sourcing Topic
+
+```
+CREATE topic=orders partitions=4 event_sourcing=true
+```
+
+Response:
+
+```
+Topic 'orders' now has 4 partitions
+```
+
+The `event_sourcing=true` flag tells the broker to maintain a per-partition stream index for aggregate-level version tracking.
+
+### 2. Append Events
+
+Append events to an aggregate stream using `APPEND_STREAM`. The `key` parameter is the aggregate ID, and `version` is the expected next version (optimistic concurrency).
+
+```
+APPEND_STREAM topic=orders key=order-123 version=1 event_type=OrderCreated message={"customer":"alice","total":49.98}
+```
+
+Response:
+
+```
+OK version=1 offset=0 partition=2
+```
+
+Append a second event:
+
+```
+APPEND_STREAM topic=orders key=order-123 version=2 event_type=ItemAdded message={"sku":"GADGET-7","qty":1}
+```
+
+Response:
+
+```
+OK version=2 offset=1 partition=2
+```
+
+### 3. Check Stream Version
+
+```
+STREAM_VERSION topic=orders key=order-123
+```
+
+Response:
+
+```
+2
+```
+
+Returns `0` if the aggregate does not exist.
+
+### 4. Read a Stream
+
+`READ_STREAM` returns all events for an aggregate. The response consists of two length-prefixed frames: a JSON envelope followed by a binary batch containing the events.
+
+```
+READ_STREAM topic=orders key=order-123
+```
+
+Frame 1 (JSON envelope):
+
+```json
+{
+  "topic": "orders",
+  "key": "order-123",
+  "partition": 2,
+  "count": 2
+}
+```
+
+Frame 2: Binary batch in standard 0xBA7C format containing the two events.
+
+To read events starting from a specific version:
+
+```
+READ_STREAM topic=orders key=order-123 from_version=2
+```
+
+---
+
+## Optimistic Concurrency
+
+Every `APPEND_STREAM` call includes a `version` parameter that specifies the expected next version of the aggregate. The broker checks this against the current version before writing.
+
+### Version Semantics
+
+| version value | Meaning |
+|---------------|---------|
+| `1` | Expect this to be a new aggregate (current version must be 0) |
+| `N` | Expect the current version to be `N-1` |
+
+The broker rejects the write if the expected version does not match:
+
+```
+APPEND_STREAM topic=orders key=order-123 version=2 event_type=ItemAdded message={"sku":"X"}
+```
+
+If the current version is already 3:
+
+```
+ERROR: version_conflict current=3 expected=2
+```
+
+### Handling VERSION_CONFLICT
+
+The standard pattern for handling conflicts is optimistic retry:
+
+1. Reload the aggregate by reading the stream again.
+2. Re-apply the domain command against the updated state.
+3. Re-attempt the append with the correct version.
+4. Repeat up to a maximum retry count (3 is recommended).
+
+```
+// Pseudocode
+for retries := 0; retries < 3; retries++ {
+    aggregate := loadFromStream("orders", "order-123")
+    newEvent  := aggregate.handle(command)
+    result    := appendStream("orders", "order-123", aggregate.version+1, newEvent)
+    if result.ok {
+        break
+    }
+    // VERSION_CONFLICT: loop retries with fresh state
+}
+```
+
+Two concurrent writers for the same aggregate are serialized by the broker. Exactly one succeeds; the other receives VERSION_CONFLICT and must retry.
+
+---
+
+## Snapshots
+
+As the number of events in a stream grows, replaying all events on every load becomes expensive. Snapshots solve this by persisting the aggregate state at a specific version. On subsequent reads, the broker returns the snapshot plus only the events that occurred after it.
+
+### Saving a Snapshot
+
+```
+SAVE_SNAPSHOT topic=orders key=order-123 version=3 message={"customer":"alice","items":[...],"total":69.97,"status":"shipped"}
+```
+
+Response:
+
+```
+OK version=3 partition=2
+```
+
+Constraints:
+- The `version` must be less than or equal to the current stream version.
+- A new snapshot for the same aggregate overwrites the previous one.
+
+### Reading a Snapshot
+
+```
+READ_SNAPSHOT topic=orders key=order-123
+```
+
+Response (JSON):
+
+```json
+{
+  "version": 3,
+  "payload": "{\"customer\":\"alice\",\"items\":[...],\"total\":69.97,\"status\":\"shipped\"}"
+}
+```
+
+If no snapshot exists, the response is:
+
+```
+NULL
+```
+
+### Automatic Use in READ_STREAM
+
+When a snapshot exists, `READ_STREAM` automatically uses it. The JSON envelope includes the snapshot, and the binary batch contains only events after the snapshot version:
+
+```
+READ_STREAM topic=orders key=order-123
+```
+
+Frame 1:
+
+```json
+{
+  "topic": "orders",
+  "key": "order-123",
+  "partition": 2,
+  "count": 2,
+  "snapshot": {
+    "version": 3,
+    "payload": "..."
+  }
+}
+```
+
+Frame 2: Binary batch with events at versions 4 and 5 only.
+
+### Snapshot Frequency Recommendation
+
+Save a snapshot every 500 events. This keeps aggregate load times bounded while avoiding excessive snapshot writes. SDKs should implement auto-snapshot logic:
+
+```
+// Pseudocode
+if aggregate.version % 500 == 0 {
+    saveSnapshot(topic, key, aggregate.version, serialize(aggregate))
+}
+```
+
+### Snapshot Locality
+
+In distributed mode, snapshots are stored locally on each node. They are not replicated. If a node lacks a snapshot, it replays events from version 1. This is by design: snapshots are a performance optimization, not a correctness requirement.
+
+---
+
+## Schema Evolution
+
+Events are immutable. Once written, their payload never changes. Schema evolution is handled at read time by the client application.
+
+### Event Type and Schema Version
+
+Each event carries two fields for schema management:
+
+| Field | Description |
+|-------|-------------|
+| `event_type` | The event type name (e.g., `OrderCreated`, `ItemAdded`) |
+| `schema_version` | An integer version for the event's schema (default: 1) |
+
+Example:
+
+```
+APPEND_STREAM topic=orders key=order-123 version=4 event_type=OrderCreated schema_version=2 message={"customer":"alice","email":"alice@example.com","total":49.98}
+```
+
+### Upcasting in the SDK
+
+When reading a stream, the SDK should check each event's `schema_version` and transform older schemas to the current version. This process is called upcasting.
+
+```
+// Pseudocode: upcaster chain
+func upcast(eventType string, schemaVersion int, payload map[string]any) map[string]any {
+    if eventType == "OrderCreated" && schemaVersion == 1 {
+        // v1 -> v2: add email field with default
+        payload["email"] = "unknown"
+        schemaVersion = 2
+    }
+    return payload
+}
+```
+
+Register upcasters per event type in the SDK. When `readStream` returns events, apply the upcaster chain before passing events to the domain model.
+
+---
+
+## Projections
+
+Cursus does not provide a built-in projection engine. Instead, projections are built using the existing `CONSUME` and `STREAM` commands with consumer groups.
+
+### Pattern
+
+1. Create a consumer group on the event-sourcing topic.
+2. Consume events using `CONSUME` or `STREAM` (continuous push mode).
+3. For each event, update the read model (database, cache, search index).
+4. Commit offsets after processing.
+
+```
+JOIN_GROUP topic=orders group=order-projections member=projector-1
+CONSUME topic=orders partition=0 offset=0 member=projector-1-8374 group=order-projections
+```
+
+Because event-sourcing topics are regular Cursus topics, all consumer group features work: rebalancing, offset management, wildcard subscriptions, and batch commits.
+
+### Multiple Projections
+
+Different consumer groups can maintain independent projections of the same event stream:
+
+- `order-summary-projection` -- updates a summary dashboard
+- `order-search-projection` -- indexes orders into a search engine
+- `order-analytics-projection` -- feeds an analytics pipeline
+
+Each group tracks its own offsets and processes events independently.
+
+---
+
+## Command Reference
+
+### APPEND_STREAM
+
+Append an event to an aggregate stream with optimistic concurrency control.
+
+```
+APPEND_STREAM topic=<name> key=<aggregate_key> version=<N> event_type=<type> [schema_version=<N>] [metadata=<json>] message=<payload>
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| topic | Yes | - | Event-sourcing-enabled topic |
+| key | Yes | - | Aggregate ID (used for partition routing) |
+| version | Yes | - | Expected next version (must equal current + 1) |
+| event_type | No | "" | Event type name |
+| schema_version | No | 1 | Schema version for upcasting |
+| metadata | No | "" | Arbitrary JSON metadata |
+| message | Yes | - | Event payload (captures rest of line) |
+
+Success response:
+
+```
+OK version=<N> offset=<N> partition=<N>
+```
+
+Error responses:
+
+```
+ERROR: version_conflict current=<N> expected=<N>
+ERROR: topic '<name>' does not exist
+ERROR: topic '<name>' is not event-sourcing enabled
+```
+
+### READ_STREAM
+
+Read events from an aggregate stream. Returns two length-prefixed frames.
+
+```
+READ_STREAM topic=<name> key=<aggregate_key> [from_version=<N>]
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+| from_version | No | 1 (or snapshot version + 1) | Starting version |
+
+Frame 1 -- JSON envelope:
+
+```json
+{
+  "topic": "...",
+  "key": "...",
+  "partition": 0,
+  "count": 5,
+  "snapshot": {"version": 500, "payload": "..."}
+}
+```
+
+The `snapshot` field is present only when a snapshot exists at or after `from_version`.
+
+Frame 2 -- Binary batch (0xBA7C format) containing the events.
+
+### STREAM_VERSION
+
+Get the current version of an aggregate stream.
+
+```
+STREAM_VERSION topic=<name> key=<aggregate_key>
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+
+Response: Plain integer (e.g., `3`). Returns `0` if the aggregate does not exist.
+
+### SAVE_SNAPSHOT
+
+Save an aggregate snapshot at a specific version.
+
+```
+SAVE_SNAPSHOT topic=<name> key=<aggregate_key> version=<N> message=<payload>
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+| version | Yes | - | Version this snapshot represents (must be <= current version) |
+| message | Yes | - | Serialized aggregate state (captures rest of line) |
+
+Success response:
+
+```
+OK version=<N> partition=<N>
+```
+
+Error responses:
+
+```
+ERROR: snapshot version <N> exceeds stream version <N>
+ERROR: topic '<name>' does not exist
+```
+
+### READ_SNAPSHOT
+
+Read the latest snapshot for an aggregate.
+
+```
+READ_SNAPSHOT topic=<name> key=<aggregate_key>
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| topic | Yes | - | Topic name |
+| key | Yes | - | Aggregate ID |
+
+Success response (JSON):
+
+```json
+{"version": 500, "payload": "..."}
+```
+
+Not found response:
+
+```
+NULL
+```
+
+---
+
+## Best Practices
+
+### Aggregate Design
+
+- **One stream per aggregate instance.** Use the aggregate ID as the `key`. For example, each order gets its own stream keyed by `order-<uuid>`.
+- **Keep events small.** Store only what changed, not the full state. State reconstruction is the job of the aggregate's `apply` method.
+- **Use descriptive event type names.** `OrderCreated`, `ItemAdded`, `PaymentReceived` -- not `Update` or `Change`.
+- **Include causation and correlation IDs in metadata.** This enables tracing command-to-event chains across aggregates.
+
+### Snapshot Frequency
+
+- Save a snapshot every 500 events as a starting point.
+- Adjust based on aggregate load time requirements. If aggregates rarely exceed 100 events, snapshots may not be necessary.
+- Never skip snapshots entirely for high-traffic aggregates. Without snapshots, loading an aggregate with 100,000 events requires replaying all of them.
+
+### Partition Key Choice
+
+- The `key` field determines partition routing. All events for the same aggregate always land on the same partition.
+- Choose keys with good cardinality. UUIDs work well. Sequential integers can cause hot partitions if the hash distribution is poor.
+- If you need cross-aggregate ordering guarantees, use a shared key (e.g., `customer-<id>`). But note this means all aggregates with that key share a single partition, which limits write throughput.
+
+### Concurrency and Retries
+
+- Always use optimistic concurrency (the `version` parameter). Appending without version checks defeats the purpose of event sourcing.
+- Limit retries to 3 attempts. If a write still fails after 3 retries, the aggregate is under heavy contention. Consider redesigning the aggregate boundaries.
+- In systems with eventual consistency, prefer idempotent event handlers over exactly-once delivery guarantees.
+
+### Projections
+
+- Use separate consumer groups for each projection. This allows independent progress and failure isolation.
+- Projections should be rebuildable. If a projection gets corrupted, reset its consumer group offsets to zero and replay from the beginning.
+- For time-sensitive projections, use `STREAM` (continuous push mode) instead of polling with `CONSUME`.

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -12,7 +12,6 @@ import (
 
 func main() {
 	cfg := sdk.NewDefaultConsumerConfig()
-	// Try loading from current dir, then parent dir
 	if err := sdk.LoadConfig("config.yaml", cfg); err != nil {
 		if err := sdk.LoadConfig("../config.yaml", cfg); err != nil {
 			log.Printf("Config file not found or invalid, using defaults: %v", err)

--- a/examples/event-sourcing/main.go
+++ b/examples/event-sourcing/main.go
@@ -92,21 +92,30 @@ func main() {
 
 	// 3. Add items
 	fmt.Println("[Command] AddItem (Mechanical Keyboard)")
-	r, _ = store.Append(orderID, 2, &sdk.Event{
+	r, err = store.Append(orderID, 2, &sdk.Event{
 		Type: "ItemAdded",
 		Payload: toJSON(ItemAdded{SKU: "KB-MX01", Name: "Mechanical Keyboard", Qty: 1, Price: 89.99}),
 	})
+	if err != nil {
+		log.Fatalf("  failed: %v", err)
+	}
 	fmt.Printf("  -> version=%d\n", r.Version)
 
 	fmt.Println("[Command] AddItem (USB-C Cable x3)")
-	r, _ = store.Append(orderID, 3, &sdk.Event{
+	r, err = store.Append(orderID, 3, &sdk.Event{
 		Type: "ItemAdded",
 		Payload: toJSON(ItemAdded{SKU: "CBL-UC3", Name: "USB-C Cable", Qty: 3, Price: 9.99}),
 	})
+	if err != nil {
+		log.Fatalf("  failed: %v", err)
+	}
 	fmt.Printf("  -> version=%d\n\n", r.Version)
 
 	// 4. Check version
-	ver, _ := store.StreamVersion(orderID)
+	ver, err := store.StreamVersion(orderID)
+	if err != nil {
+		log.Fatalf("StreamVersion failed: %v", err)
+	}
 	fmt.Printf("[Query] StreamVersion = %d\n\n", ver)
 
 	// 5. Version conflict demo
@@ -119,10 +128,13 @@ func main() {
 
 	// 6. Ship order
 	fmt.Println("[Command] ShipOrder")
-	r, _ = store.Append(orderID, 4, &sdk.Event{
+	r, err = store.Append(orderID, 4, &sdk.Event{
 		Type: "OrderShipped",
 		Payload: toJSON(OrderShipped{Carrier: "FedEx", Tracking: "TRK-98765"}),
 	})
+	if err != nil {
+		log.Fatalf("  failed: %v", err)
+	}
 	fmt.Printf("  -> version=%d\n\n", r.Version)
 
 	// 7. Save snapshot (aggregate state at version 4)
@@ -146,7 +158,10 @@ func main() {
 
 	// 8. Read snapshot back
 	fmt.Println("[Query] ReadSnapshot")
-	snap, _ := store.ReadSnapshot(orderID)
+	snap, err := store.ReadSnapshot(orderID)
+	if err != nil {
+		log.Fatalf("ReadSnapshot failed: %v", err)
+	}
 	if snap != nil {
 		var order Order
 		_ = json.Unmarshal([]byte(snap.Payload), &order)
@@ -160,14 +175,20 @@ func main() {
 
 	// 9. Append after snapshot
 	fmt.Println("[Command] PartialRefund")
-	r, _ = store.Append(orderID, 5, &sdk.Event{
+	r, err = store.Append(orderID, 5, &sdk.Event{
 		Type: "PartialRefund",
 		Payload: toJSON(PartialRefund{SKU: "CBL-UC3", Amount: 9.99, Reason: "defective"}),
 	})
+	if err != nil {
+		log.Fatalf("  failed: %v", err)
+	}
 	fmt.Printf("  -> version=%d\n\n", r.Version)
 
 	// 10. Final state
-	finalVer, _ := store.StreamVersion(orderID)
+	finalVer, err := store.StreamVersion(orderID)
+	if err != nil {
+		log.Fatalf("StreamVersion failed: %v", err)
+	}
 	fmt.Printf("[Result] Order '%s' — %d events, snapshot at v4, current v%d\n", orderID, finalVer, finalVer)
 	fmt.Println()
 	fmt.Println("=== Example Complete ===")

--- a/examples/event-sourcing/main.go
+++ b/examples/event-sourcing/main.go
@@ -1,173 +1,174 @@
 package main
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
-	"net"
 	"os"
-	"strings"
+
+	"github.com/cursus-io/cursus/sdk"
 )
 
-const brokerAddr = "localhost:9000"
+
+type OrderCreated struct {
+	OrderID  string `json:"order_id"`
+	Customer string `json:"customer"`
+}
+
+type ItemAdded struct {
+	SKU   string  `json:"sku"`
+	Name  string  `json:"name"`
+	Qty   int     `json:"qty"`
+	Price float64 `json:"price"`
+}
+
+type OrderShipped struct {
+	Carrier  string `json:"carrier"`
+	Tracking string `json:"tracking"`
+}
+
+type PartialRefund struct {
+	SKU    string  `json:"sku"`
+	Amount float64 `json:"amount"`
+	Reason string  `json:"reason"`
+}
+
+// --- Order Aggregate (for snapshot) ---
+
+type Order struct {
+	ID       string            `json:"id"`
+	Customer string            `json:"customer"`
+	Items    map[string]Item   `json:"items"`
+	Total    float64           `json:"total"`
+	Status   string            `json:"status"`
+	Tracking string            `json:"tracking,omitempty"`
+}
+
+type Item struct {
+	Name  string  `json:"name"`
+	Qty   int     `json:"qty"`
+	Price float64 `json:"price"`
+}
+
+func toJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
 
 func main() {
-	conn, err := net.Dial("tcp", brokerAddr)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to connect to broker at %s: %v\n", brokerAddr, err)
-		os.Exit(1)
+	addr := "localhost:9000"
+	if len(os.Args) > 1 {
+		addr = os.Args[1]
 	}
-	defer func() { _ = conn.Close() }()
 
-	fmt.Println("=== Cursus Event Sourcing Example ===")
-	fmt.Printf("Connected to broker at %s\n\n", brokerAddr)
+	store := sdk.NewEventStore(addr, "orders", "order-service")
+	defer func() { _ = store.Close() }()
 
-	fmt.Println("--- Step 1: Create event-sourcing topic ---")
-	resp := sendCommand(conn, "", "CREATE topic=orders partitions=4 event_sourcing=true")
-	fmt.Printf("Response: %s\n\n", resp)
-
-	fmt.Println("--- Step 2: Append first event (OrderCreated) ---")
-	orderID := "order-12345"
-	eventPayload := `{"order_id":"order-12345","customer":"alice","items":[{"sku":"WIDGET-1","qty":2}],"total":49.98}`
-
-	cmd := fmt.Sprintf(
-		"APPEND_STREAM topic=orders key=%s version=1 event_type=OrderCreated message=%s",
-		orderID, eventPayload,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response: %s\n\n", resp)
-
-	fmt.Println("--- Step 3: Append second event (ItemAdded) ---")
-
-	eventPayload2 := `{"sku":"GADGET-7","qty":1,"price":19.99}`
-	cmd = fmt.Sprintf(
-		"APPEND_STREAM topic=orders key=%s version=2 event_type=ItemAdded message=%s",
-		orderID, eventPayload2,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response: %s\n\n", resp)
-
-	fmt.Println("--- Step 4: Append third event (OrderShipped) ---")
-	eventPayload3 := `{"tracking_number":"TRK-98765","carrier":"FedEx"}`
-	cmd = fmt.Sprintf(
-		"APPEND_STREAM topic=orders key=%s version=3 event_type=OrderShipped message=%s",
-		orderID, eventPayload3,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response: %s\n\n", resp)
-
-	fmt.Println("--- Step 5: Check stream version ---")
-	cmd = fmt.Sprintf("STREAM_VERSION topic=orders key=%s", orderID)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Current version of '%s': %s\n\n", orderID, resp)
-
-	fmt.Println("--- Step 6: Demonstrate version conflict ---")
-	fmt.Println("Attempting to append with stale version=2 (current is 3)...")
-
-	conflictPayload := `{"note":"this should fail"}`
-	cmd = fmt.Sprintf(
-		"APPEND_STREAM topic=orders key=%s version=2 event_type=StaleEvent message=%s",
-		orderID, conflictPayload,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response (expected error): %s\n\n", resp)
-
-	fmt.Println("--- Step 7: Save a snapshot at version 3 ---")
-	snapshotPayload := `{"order_id":"order-12345","customer":"alice","items":[{"sku":"WIDGET-1","qty":2},{"sku":"GADGET-7","qty":1}],"total":69.97,"status":"shipped","tracking":"TRK-98765"}`
-	cmd = fmt.Sprintf(
-		"SAVE_SNAPSHOT topic=orders key=%s version=3 message=%s",
-		orderID, snapshotPayload,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response: %s\n\n", resp)
-
-	fmt.Println("--- Step 8: Read snapshot ---")
-	cmd = fmt.Sprintf("READ_SNAPSHOT topic=orders key=%s", orderID)
-	resp = sendCommand(conn, "", cmd)
-	prettyPrintJSON("Snapshot", resp)
+	fmt.Println("=== Order Aggregate — Event Sourcing Example ===")
 	fmt.Println()
 
-	fmt.Println("--- Step 9: Append events after snapshot ---")
-	eventPayload4 := `{"refund_amount":19.99,"reason":"defective item"}`
-	cmd = fmt.Sprintf(
-		"APPEND_STREAM topic=orders key=%s version=4 event_type=PartialRefund message=%s",
-		orderID, eventPayload4,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response: %s\n\n", resp)
-
-	eventPayload5 := `{"new_total":49.98}`
-	cmd = fmt.Sprintf(
-		"APPEND_STREAM topic=orders key=%s version=5 event_type=TotalRecalculated message=%s",
-		orderID, eventPayload5,
-	)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Response: %s\n\n", resp)
-
-	fmt.Println("--- Step 10: Verify final stream version ---")
-	cmd = fmt.Sprintf("STREAM_VERSION topic=orders key=%s", orderID)
-	resp = sendCommand(conn, "", cmd)
-	fmt.Printf("Final version of '%s': %s\n\n", orderID, resp)
-
-	fmt.Println("=== Example Complete ===")
-}
-
-// sendCommand sends a text command to the broker using length-prefixed framing
-// with the topic+payload envelope, then reads and returns the response.
-//
-// Framing: [4-byte BE length][body]
-// Body (topic envelope): [topicLen:2][topic][payload]
-//
-// If topic is empty, topicLen is 0 and the body is just [0x00 0x00][payload].
-func sendCommand(conn net.Conn, topicName, command string) string {
-	// [topicLen:2][topic][command]
-	topicBytes := []byte(topicName)
-	cmdBytes := []byte(command)
-	bodyLen := 2 + len(topicBytes) + len(cmdBytes)
-
-	body := make([]byte, bodyLen)
-	binary.BigEndian.PutUint16(body[0:2], uint16(len(topicBytes)))
-	copy(body[2:], topicBytes)
-	copy(body[2+len(topicBytes):], cmdBytes)
-
-	// Write length prefix + body.
-	frame := make([]byte, 4+bodyLen)
-	binary.BigEndian.PutUint32(frame[0:4], uint32(bodyLen))
-	copy(frame[4:], body)
-
-	if _, err := conn.Write(frame); err != nil {
-		log.Fatalf("Failed to send command: %v", err)
+	// 1. Create topic
+	if err := store.CreateTopic(4); err != nil {
+		log.Fatalf("CreateTopic: %v", err)
 	}
+	fmt.Println("[Topic] 'orders' created (4 partitions, event_sourcing=true)")
+	fmt.Println()
 
-	// Read response: [4-byte BE length][response body]
-	var respLen uint32
-	if err := binary.Read(conn, binary.BigEndian, &respLen); err != nil {
-		log.Fatalf("Failed to read response length: %v", err)
-	}
+	orderID := "order-1001"
 
-	respBody := make([]byte, respLen)
-	if _, err := io.ReadFull(conn, respBody); err != nil {
-		log.Fatalf("Failed to read response body: %v", err)
-	}
-
-	return string(respBody)
-}
-
-// prettyPrintJSON attempts to format a JSON string with indentation.
-// If the input is not valid JSON, it prints the raw string.
-func prettyPrintJSON(label, s string) {
-	s = strings.TrimSpace(s)
-	var obj interface{}
-	if err := json.Unmarshal([]byte(s), &obj); err != nil {
-		fmt.Printf("%s: %s\n", label, s)
-		return
-	}
-	pretty, err := json.MarshalIndent(obj, "  ", "  ")
+	// 2. Create order
+	fmt.Println("[Command] CreateOrder")
+	r, err := store.Append(orderID, 1, &sdk.Event{
+		Type: "OrderCreated",
+		Payload: toJSON(OrderCreated{
+			OrderID:  orderID,
+			Customer: "Alice Kim",
+		}),
+	})
 	if err != nil {
-		fmt.Printf("%s: %s\n", label, s)
-		return
+		log.Fatalf("  failed: %v", err)
 	}
-	fmt.Printf("%s:\n  %s\n", label, string(pretty))
+	fmt.Printf("  -> version=%d offset=%d\n\n", r.Version, r.Offset)
+
+	// 3. Add items
+	fmt.Println("[Command] AddItem (Mechanical Keyboard)")
+	r, _ = store.Append(orderID, 2, &sdk.Event{
+		Type: "ItemAdded",
+		Payload: toJSON(ItemAdded{SKU: "KB-MX01", Name: "Mechanical Keyboard", Qty: 1, Price: 89.99}),
+	})
+	fmt.Printf("  -> version=%d\n", r.Version)
+
+	fmt.Println("[Command] AddItem (USB-C Cable x3)")
+	r, _ = store.Append(orderID, 3, &sdk.Event{
+		Type: "ItemAdded",
+		Payload: toJSON(ItemAdded{SKU: "CBL-UC3", Name: "USB-C Cable", Qty: 3, Price: 9.99}),
+	})
+	fmt.Printf("  -> version=%d\n\n", r.Version)
+
+	// 4. Check version
+	ver, _ := store.StreamVersion(orderID)
+	fmt.Printf("[Query] StreamVersion = %d\n\n", ver)
+
+	// 5. Version conflict demo
+	fmt.Println("[Command] AddItem with stale version (expecting conflict)")
+	_, err = store.Append(orderID, 2, &sdk.Event{
+		Type:    "ItemAdded",
+		Payload: toJSON(ItemAdded{SKU: "STALE", Name: "Should Fail", Qty: 1, Price: 0}),
+	})
+	fmt.Printf("  -> expected error: %v\n\n", err)
+
+	// 6. Ship order
+	fmt.Println("[Command] ShipOrder")
+	r, _ = store.Append(orderID, 4, &sdk.Event{
+		Type: "OrderShipped",
+		Payload: toJSON(OrderShipped{Carrier: "FedEx", Tracking: "TRK-98765"}),
+	})
+	fmt.Printf("  -> version=%d\n\n", r.Version)
+
+	// 7. Save snapshot (aggregate state at version 4)
+	fmt.Println("[Snapshot] Saving aggregate state at version 4")
+	snapshot := Order{
+		ID:       orderID,
+		Customer: "Alice Kim",
+		Items: map[string]Item{
+			"KB-MX01": {Name: "Mechanical Keyboard", Qty: 1, Price: 89.99},
+			"CBL-UC3": {Name: "USB-C Cable", Qty: 3, Price: 9.99},
+		},
+		Total:    119.96,
+		Status:   "shipped",
+		Tracking: "TRK-98765",
+	}
+	if err := store.SaveSnapshot(orderID, 4, toJSON(snapshot)); err != nil {
+		log.Fatalf("  failed: %v", err)
+	}
+	fmt.Println("  -> saved")
+	fmt.Println()
+
+	// 8. Read snapshot back
+	fmt.Println("[Query] ReadSnapshot")
+	snap, _ := store.ReadSnapshot(orderID)
+	if snap != nil {
+		var order Order
+		_ = json.Unmarshal([]byte(snap.Payload), &order)
+		fmt.Printf("  version  : %d\n", snap.Version)
+		fmt.Printf("  customer : %s\n", order.Customer)
+		fmt.Printf("  items    : %d\n", len(order.Items))
+		fmt.Printf("  total    : $%.2f\n", order.Total)
+		fmt.Printf("  status   : %s\n", order.Status)
+	}
+	fmt.Println()
+
+	// 9. Append after snapshot
+	fmt.Println("[Command] PartialRefund")
+	r, _ = store.Append(orderID, 5, &sdk.Event{
+		Type: "PartialRefund",
+		Payload: toJSON(PartialRefund{SKU: "CBL-UC3", Amount: 9.99, Reason: "defective"}),
+	})
+	fmt.Printf("  -> version=%d\n\n", r.Version)
+
+	// 10. Final state
+	finalVer, _ := store.StreamVersion(orderID)
+	fmt.Printf("[Result] Order '%s' — %d events, snapshot at v4, current v%d\n", orderID, finalVer, finalVer)
+	fmt.Println()
+	fmt.Println("=== Example Complete ===")
 }

--- a/examples/event-sourcing/main.go
+++ b/examples/event-sourcing/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+)
+
+const brokerAddr = "localhost:9000"
+
+func main() {
+	conn, err := net.Dial("tcp", brokerAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to connect to broker at %s: %v\n", brokerAddr, err)
+		os.Exit(1)
+	}
+	defer func() { _ = conn.Close() }()
+
+	fmt.Println("=== Cursus Event Sourcing Example ===")
+	fmt.Printf("Connected to broker at %s\n\n", brokerAddr)
+
+	fmt.Println("--- Step 1: Create event-sourcing topic ---")
+	resp := sendCommand(conn, "", "CREATE topic=orders partitions=4 event_sourcing=true")
+	fmt.Printf("Response: %s\n\n", resp)
+
+	fmt.Println("--- Step 2: Append first event (OrderCreated) ---")
+	orderID := "order-12345"
+	eventPayload := `{"order_id":"order-12345","customer":"alice","items":[{"sku":"WIDGET-1","qty":2}],"total":49.98}`
+
+	cmd := fmt.Sprintf(
+		"APPEND_STREAM topic=orders key=%s version=1 event_type=OrderCreated message=%s",
+		orderID, eventPayload,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response: %s\n\n", resp)
+
+	fmt.Println("--- Step 3: Append second event (ItemAdded) ---")
+
+	eventPayload2 := `{"sku":"GADGET-7","qty":1,"price":19.99}`
+	cmd = fmt.Sprintf(
+		"APPEND_STREAM topic=orders key=%s version=2 event_type=ItemAdded message=%s",
+		orderID, eventPayload2,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response: %s\n\n", resp)
+
+	fmt.Println("--- Step 4: Append third event (OrderShipped) ---")
+	eventPayload3 := `{"tracking_number":"TRK-98765","carrier":"FedEx"}`
+	cmd = fmt.Sprintf(
+		"APPEND_STREAM topic=orders key=%s version=3 event_type=OrderShipped message=%s",
+		orderID, eventPayload3,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response: %s\n\n", resp)
+
+	fmt.Println("--- Step 5: Check stream version ---")
+	cmd = fmt.Sprintf("STREAM_VERSION topic=orders key=%s", orderID)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Current version of '%s': %s\n\n", orderID, resp)
+
+	fmt.Println("--- Step 6: Demonstrate version conflict ---")
+	fmt.Println("Attempting to append with stale version=2 (current is 3)...")
+
+	conflictPayload := `{"note":"this should fail"}`
+	cmd = fmt.Sprintf(
+		"APPEND_STREAM topic=orders key=%s version=2 event_type=StaleEvent message=%s",
+		orderID, conflictPayload,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response (expected error): %s\n\n", resp)
+
+	fmt.Println("--- Step 7: Save a snapshot at version 3 ---")
+	snapshotPayload := `{"order_id":"order-12345","customer":"alice","items":[{"sku":"WIDGET-1","qty":2},{"sku":"GADGET-7","qty":1}],"total":69.97,"status":"shipped","tracking":"TRK-98765"}`
+	cmd = fmt.Sprintf(
+		"SAVE_SNAPSHOT topic=orders key=%s version=3 message=%s",
+		orderID, snapshotPayload,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response: %s\n\n", resp)
+
+	fmt.Println("--- Step 8: Read snapshot ---")
+	cmd = fmt.Sprintf("READ_SNAPSHOT topic=orders key=%s", orderID)
+	resp = sendCommand(conn, "", cmd)
+	prettyPrintJSON("Snapshot", resp)
+	fmt.Println()
+
+	fmt.Println("--- Step 9: Append events after snapshot ---")
+	eventPayload4 := `{"refund_amount":19.99,"reason":"defective item"}`
+	cmd = fmt.Sprintf(
+		"APPEND_STREAM topic=orders key=%s version=4 event_type=PartialRefund message=%s",
+		orderID, eventPayload4,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response: %s\n\n", resp)
+
+	eventPayload5 := `{"new_total":49.98}`
+	cmd = fmt.Sprintf(
+		"APPEND_STREAM topic=orders key=%s version=5 event_type=TotalRecalculated message=%s",
+		orderID, eventPayload5,
+	)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Response: %s\n\n", resp)
+
+	fmt.Println("--- Step 10: Verify final stream version ---")
+	cmd = fmt.Sprintf("STREAM_VERSION topic=orders key=%s", orderID)
+	resp = sendCommand(conn, "", cmd)
+	fmt.Printf("Final version of '%s': %s\n\n", orderID, resp)
+
+	fmt.Println("=== Example Complete ===")
+}
+
+// sendCommand sends a text command to the broker using length-prefixed framing
+// with the topic+payload envelope, then reads and returns the response.
+//
+// Framing: [4-byte BE length][body]
+// Body (topic envelope): [topicLen:2][topic][payload]
+//
+// If topic is empty, topicLen is 0 and the body is just [0x00 0x00][payload].
+func sendCommand(conn net.Conn, topicName, command string) string {
+	// [topicLen:2][topic][command]
+	topicBytes := []byte(topicName)
+	cmdBytes := []byte(command)
+	bodyLen := 2 + len(topicBytes) + len(cmdBytes)
+
+	body := make([]byte, bodyLen)
+	binary.BigEndian.PutUint16(body[0:2], uint16(len(topicBytes)))
+	copy(body[2:], topicBytes)
+	copy(body[2+len(topicBytes):], cmdBytes)
+
+	// Write length prefix + body.
+	frame := make([]byte, 4+bodyLen)
+	binary.BigEndian.PutUint32(frame[0:4], uint32(bodyLen))
+	copy(frame[4:], body)
+
+	if _, err := conn.Write(frame); err != nil {
+		log.Fatalf("Failed to send command: %v", err)
+	}
+
+	// Read response: [4-byte BE length][response body]
+	var respLen uint32
+	if err := binary.Read(conn, binary.BigEndian, &respLen); err != nil {
+		log.Fatalf("Failed to read response length: %v", err)
+	}
+
+	respBody := make([]byte, respLen)
+	if _, err := io.ReadFull(conn, respBody); err != nil {
+		log.Fatalf("Failed to read response body: %v", err)
+	}
+
+	return string(respBody)
+}
+
+// prettyPrintJSON attempts to format a JSON string with indentation.
+// If the input is not valid JSON, it prints the raw string.
+func prettyPrintJSON(label, s string) {
+	s = strings.TrimSpace(s)
+	var obj interface{}
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		fmt.Printf("%s: %s\n", label, s)
+		return
+	}
+	pretty, err := json.MarshalIndent(obj, "  ", "  ")
+	if err != nil {
+		fmt.Printf("%s: %s\n", label, s)
+		return
+	}
+	fmt.Printf("%s:\n  %s\n", label, string(pretty))
+}

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -10,7 +10,6 @@ import (
 
 func main() {
 	cfg := sdk.NewDefaultPublisherConfig()
-	// Try loading from current dir, then parent dir
 	if err := sdk.LoadConfig("config.yaml", cfg); err != nil {
 		if err := sdk.LoadConfig("../config.yaml", cfg); err != nil {
 			log.Printf("Config file not found or invalid, using defaults: %v", err)

--- a/pkg/cluster/client/client.go
+++ b/pkg/cluster/client/client.go
@@ -75,7 +75,7 @@ func (c *TCPClusterClient) sendHeartbeat(peers []string, nodeID, localAddr strin
 			if err != nil {
 				return
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			// Set a write deadline to prevent goroutine buildup on slow connections
 			_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
@@ -141,7 +141,7 @@ func (c *TCPClusterClient) sendJoinCommand(ctx context.Context, addr, nodeID, lo
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Set connection deadlines based on the context's remaining time
 	if deadline, ok := ctx.Deadline(); ok {

--- a/pkg/cluster/client/client_test.go
+++ b/pkg/cluster/client/client_test.go
@@ -35,7 +35,7 @@ func TestJoinCluster_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	addr := ln.Addr().String()
 	_, portStr, _ := net.SplitHostPort(addr)
@@ -47,7 +47,7 @@ func TestJoinCluster_Success(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 			// Read length
 			lenBuf := make([]byte, 4)
@@ -82,7 +82,7 @@ func TestJoinCluster_Fail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	addr := ln.Addr().String()
 	_, portStr, _ := net.SplitHostPort(addr)
@@ -114,7 +114,7 @@ func TestJoinCluster_Fail(t *testing.T) {
 			binary.BigEndian.PutUint32(respLenBuf, uint32(len(respData)))
 			_, _ = conn.Write(respLenBuf)
 			_, _ = conn.Write(respData)
-			conn.Close()
+			_ = conn.Close()
 		}
 	}()
 
@@ -134,7 +134,7 @@ func TestStartHeartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	addr := ln.Addr().String()
 	_, portStr, _ := net.SplitHostPort(addr)
@@ -147,7 +147,7 @@ func TestStartHeartbeat(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		received <- true
 	}()
 

--- a/pkg/cluster/controller/controller.go
+++ b/pkg/cluster/controller/controller.go
@@ -15,19 +15,51 @@ import (
 	"github.com/hashicorp/raft"
 )
 
-type RaftManager interface {
+// LeaderChecker provides leadership status queries.
+type LeaderChecker interface {
 	IsLeader() bool
 	GetLeaderAddress() string
-	ApplyCommand(prefix string, data []byte) error
 	LeaderCh() <-chan bool
-	GetFSM() *fsm.BrokerFSM
-	GetConfiguration() raft.ConfigurationFuture
-	ReplicateWithQuorum(topic string, partition int, msg types.Message, minISR int, isIdempotent bool, sequenceScope string) (types.AckResponse, error)
-	ReplicateBatchWithQuorum(topic string, partition int, messages []types.Message, minISR int, acks string, isIdempotent bool, sequenceScope string) (types.AckResponse, error)
+}
+
+// CommandApplier applies commands to the Raft log.
+type CommandApplier interface {
+	ApplyCommand(prefix string, data []byte) error
 	ApplyResponse(prefix string, data []byte, timeout time.Duration) (types.AckResponse, error)
+}
+
+// MembershipManager handles cluster membership changes.
+type MembershipManager interface {
 	AddVoter(id string, addr string) error
 	RemoveServer(id string) error
+	GetConfiguration() raft.ConfigurationFuture
+}
+
+// FSMAccessor provides access to the finite state machine.
+type FSMAccessor interface {
+	GetFSM() *fsm.BrokerFSM
+}
+
+// Replicator handles message replication with quorum.
+type Replicator interface {
+	ReplicateWithQuorum(topic string, partition int, msg types.Message, minISR int, isIdempotent bool, sequenceScope string) (types.AckResponse, error)
+	ReplicateBatchWithQuorum(topic string, partition int, messages []types.Message, minISR int, acks string, isIdempotent bool, sequenceScope string) (types.AckResponse, error)
+}
+
+// ISRProvider provides access to the ISR manager.
+type ISRProvider interface {
 	GetISRManager() replication.ISRManagerInterface
+}
+
+// RaftManager is the composite interface for full Raft functionality.
+// Individual components should depend on the narrowest sub-interface they need.
+type RaftManager interface {
+	LeaderChecker
+	CommandApplier
+	MembershipManager
+	FSMAccessor
+	Replicator
+	ISRProvider
 }
 
 type ClusterController struct {

--- a/pkg/cluster/controller/controller_ext_test.go
+++ b/pkg/cluster/controller/controller_ext_test.go
@@ -85,7 +85,7 @@ func TestClusterController_Basic(t *testing.T) {
 		cc.SetLocalProcessor(lp)
 		assert.Equal(t, lp, cc.Router.localProcessor)
 
-		cc.SetLocalProcessor(nil) // Should ignore with warning
+		cc.SetLocalProcessor(nil) // should ignore with warning
 		assert.Equal(t, lp, cc.Router.localProcessor)
 	})
 }
@@ -127,13 +127,13 @@ func TestClusterRouter_Forwarding(t *testing.T) {
 
 	t.Run("ForwardToPartitionLeader - Remote Leader", func(t *testing.T) {
 		rm.isLeader = false
-		rm.mockFSM = fsm.NewBrokerFSM(nil, nil, nil)
+		rm.mockFSM = fsm.NewBrokerFSM(nil, nil)
 
-		// Register a remote broker
+		// register a remote broker
 		brokerJSON := `{"id":"node2","addr":"127.0.0.1:9002","status":"active"}`
 		rm.mockFSM.Apply(&raft.Log{Data: append([]byte("REGISTER:"), []byte(brokerJSON)...), Index: 1})
 
-		// Set partition leader to that broker
+		// set partition leader to that broker
 		metaJSON := `{"leader":"node2"}`
 		rm.mockFSM.Apply(&raft.Log{Data: append([]byte("PARTITION:topic1-0:"), []byte(metaJSON)...), Index: 2})
 

--- a/pkg/cluster/controller/discovery.go
+++ b/pkg/cluster/controller/discovery.go
@@ -69,7 +69,11 @@ func (sd *serviceDiscovery) Register() error {
 
 func (sd *serviceDiscovery) Deregister() error {
 	payload := map[string]string{"id": sd.brokerID}
-	data, _ := json.Marshal(payload)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		util.Error("Failed to marshal payload: %v", err)
+		return fmt.Errorf("marshal payload: %w", err)
+	}
 	if err := sd.rm.ApplyCommand("DEREGISTER", data); err != nil {
 		util.Error("Failed to deregister broker %s: %v", sd.brokerID, err)
 		return err
@@ -140,7 +144,11 @@ func (sd *serviceDiscovery) RemoveNode(nodeID string) (string, error) {
 	}
 
 	payload := map[string]string{"id": nodeID}
-	data, _ := json.Marshal(payload)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		util.Error("Failed to marshal payload: %v", err)
+		return leaderAddr, fmt.Errorf("marshal payload: %w", err)
+	}
 	if err := sd.rm.ApplyCommand("DEREGISTER", data); err != nil {
 		util.Error("DEREGISTER failed after RemoveServer. FSM contains stale node info: id=%s err=%v", nodeID, err)
 		return leaderAddr, fmt.Errorf("DEREGISTER failed: %w", err)
@@ -150,7 +158,7 @@ func (sd *serviceDiscovery) RemoveNode(nodeID string) (string, error) {
 }
 
 func (sd *serviceDiscovery) StartReconciler(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(10 * time.Second)
 	go func() {
 		defer ticker.Stop()
 		util.Debug("reconciler started for broker %s", sd.brokerID)
@@ -191,7 +199,11 @@ func (sd *serviceDiscovery) Reconcile() {
 		if _, exists := raftMap[b.ID]; !exists {
 			util.Warn("Node %s found in FSM but missing in Raft. Cleaning up...", b.ID)
 			payload := map[string]string{"id": b.ID}
-			data, _ := json.Marshal(payload)
+			data, err := json.Marshal(payload)
+			if err != nil {
+				util.Error("Failed to marshal payload: %v", err)
+				continue
+			}
 			if err := sd.rm.ApplyCommand("DEREGISTER", data); err != nil {
 				util.Error("Failed to apply DEREGISTER for node %s: %v", b.ID, err)
 			} else {

--- a/pkg/cluster/controller/discovery_test.go
+++ b/pkg/cluster/controller/discovery_test.go
@@ -65,9 +65,10 @@ func (m *ComprehensiveMockRaftManager) GetFSM() *fsm.BrokerFSM {
 func (m *ComprehensiveMockRaftManager) ApplyCommand(prefix string, data []byte) error {
 	args := m.Called(prefix, data)
 	if args.Error(0) == nil {
-		if prefix == "REGISTER" {
+		switch prefix {
+		case "REGISTER":
 			m.mockFSM.Apply(&raft.Log{Data: append([]byte("REGISTER:"), data...), Index: 1})
-		} else if prefix == "DEREGISTER" {
+		case "DEREGISTER":
 			m.mockFSM.Apply(&raft.Log{Data: append([]byte("DEREGISTER:"), data...), Index: 2})
 		}
 	}
@@ -114,7 +115,7 @@ func (m *ComprehensiveMockRaftManager) ApplyResponse(prefix string, data []byte,
 
 func TestServiceDiscovery_RegisterDeregister(t *testing.T) {
 	rm := new(ComprehensiveMockRaftManager)
-	rm.mockFSM = fsm.NewBrokerFSM(nil, nil, nil)
+	rm.mockFSM = fsm.NewBrokerFSM(nil, nil)
 	sd := NewServiceDiscovery(rm, "node1", "localhost:9001")
 
 	t.Run("Register Success", func(t *testing.T) {
@@ -142,7 +143,7 @@ func TestServiceDiscovery_RegisterDeregister(t *testing.T) {
 
 func TestServiceDiscovery_NodeOperations(t *testing.T) {
 	rm := new(ComprehensiveMockRaftManager)
-	rm.mockFSM = fsm.NewBrokerFSM(nil, nil, nil)
+	rm.mockFSM = fsm.NewBrokerFSM(nil, nil)
 	sd := NewServiceDiscovery(rm, "node1", "localhost:9001")
 
 	t.Run("AddNode - Not Leader", func(t *testing.T) {
@@ -203,7 +204,7 @@ func TestServiceDiscovery_Heartbeat(t *testing.T) {
 
 func TestServiceDiscovery_DiscoverBrokers(t *testing.T) {
 	rm := new(ComprehensiveMockRaftManager)
-	rm.mockFSM = fsm.NewBrokerFSM(nil, nil, nil)
+	rm.mockFSM = fsm.NewBrokerFSM(nil, nil)
 	sd := NewServiceDiscovery(rm, "node1", "localhost:9001")
 
 	// Register two brokers directly in FSM
@@ -217,7 +218,7 @@ func TestServiceDiscovery_DiscoverBrokers(t *testing.T) {
 
 func TestServiceDiscovery_RemoveNode_NotLeader(t *testing.T) {
 	rm := new(ComprehensiveMockRaftManager)
-	rm.mockFSM = fsm.NewBrokerFSM(nil, nil, nil)
+	rm.mockFSM = fsm.NewBrokerFSM(nil, nil)
 	rm.isLeader = false
 	sd := NewServiceDiscovery(rm, "node1", "localhost:9001")
 

--- a/pkg/cluster/controller/router_test.go
+++ b/pkg/cluster/controller/router_test.go
@@ -68,7 +68,7 @@ func TestClusterRouter_LocalProcess(t *testing.T) {
 }
 
 func TestClusterRouter_FindCoordinator(t *testing.T) {
-	mockFSM := fsm.NewBrokerFSM(nil, nil, nil)
+	mockFSM := fsm.NewBrokerFSM(nil, nil)
 	// Add some brokers
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"node1\",\"addr\":\"localhost:7001\",\"status\":\"active\"}")})
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"node2\",\"addr\":\"localhost:7002\",\"status\":\"active\"}")})
@@ -107,7 +107,7 @@ func TestClusterRouter_FindCoordinator(t *testing.T) {
 }
 
 func TestClusterRouter_FindCoordinator_CacheRebuild(t *testing.T) {
-	mockFSM := fsm.NewBrokerFSM(nil, nil, nil)
+	mockFSM := fsm.NewBrokerFSM(nil, nil)
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"n1\",\"addr\":\"localhost:7001\",\"status\":\"active\"}")})
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"n2\",\"addr\":\"localhost:7002\",\"status\":\"active\"}")})
 
@@ -136,7 +136,7 @@ func TestClusterRouter_FindCoordinator_CacheRebuild(t *testing.T) {
 }
 
 func TestClusterRouter_FindCoordinator_NoActiveBrokers(t *testing.T) {
-	mockFSM := fsm.NewBrokerFSM(nil, nil, nil)
+	mockFSM := fsm.NewBrokerFSM(nil, nil)
 	rm := &MockRaftManager{isLeader: true, mockFSM: mockFSM}
 	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000)
 
@@ -157,7 +157,7 @@ func TestClusterRouter_FindCoordinator_NilFSM(t *testing.T) {
 }
 
 func TestClusterRouter_ForwardToCoordinator_Local(t *testing.T) {
-	mockFSM := fsm.NewBrokerFSM(nil, nil, nil)
+	mockFSM := fsm.NewBrokerFSM(nil, nil)
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"n1\",\"addr\":\"localhost:7001\",\"status\":\"active\"}")})
 
 	processor := &MockLocalProcessor{}
@@ -178,7 +178,7 @@ func TestClusterRouter_ForwardToCoordinator_Local(t *testing.T) {
 }
 
 func TestClusterRouter_ForwardToPartitionLeader_Local(t *testing.T) {
-	mockFSM := fsm.NewBrokerFSM(nil, nil, nil)
+	mockFSM := fsm.NewBrokerFSM(nil, nil)
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"n1\",\"addr\":\"localhost:7001\",\"status\":\"active\"}")})
 
 	// Create a topic with 1 partition, leader = n1

--- a/pkg/cluster/replication/fsm/fsm.go
+++ b/pkg/cluster/replication/fsm/fsm.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cursus-io/cursus/pkg/coordinator"
-	"github.com/cursus-io/cursus/pkg/disk"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
@@ -49,19 +48,17 @@ type BrokerFSM struct {
 	producerState     map[string]map[int]map[string]int64 // Topic -> Partition -> ProducerID -> LastSeq
 	applied           uint64
 
-	dm *disk.DiskManager
 	tm *topic.TopicManager
 	cd *coordinator.Coordinator
 }
 
-func NewBrokerFSM(dm *disk.DiskManager, tm *topic.TopicManager, cd *coordinator.Coordinator) *BrokerFSM {
+func NewBrokerFSM(tm *topic.TopicManager, cd *coordinator.Coordinator) *BrokerFSM {
 	return &BrokerFSM{
 		notifiers:         make(map[string]chan interface{}),
 		logs:              make(map[uint64]*ReplicationEntry),
 		brokers:           make(map[string]*BrokerInfo),
 		partitionMetadata: make(map[string]*PartitionMetadata),
 		producerState:     make(map[string]map[int]map[string]int64),
-		dm:                dm,
 		tm:                tm,
 		cd:                cd,
 	}
@@ -213,6 +210,14 @@ func (f *BrokerFSM) Snapshot() (raft.FSMSnapshot, error) {
 	metadataCopy := make(map[string]*PartitionMetadata, len(f.partitionMetadata))
 	for k, v := range f.partitionMetadata {
 		metaCopy := *v
+		if v.Replicas != nil {
+			metaCopy.Replicas = make([]string, len(v.Replicas))
+			copy(metaCopy.Replicas, v.Replicas)
+		}
+		if v.ISR != nil {
+			metaCopy.ISR = make([]string, len(v.ISR))
+			copy(metaCopy.ISR, v.ISR)
+		}
 		metadataCopy[k] = &metaCopy
 	}
 	producerStateCopy := make(map[string]map[int]map[string]int64, len(f.producerState))

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -22,6 +22,7 @@ type TopicCommand struct {
 	Name              string `json:"name"`
 	Partitions        int    `json:"partitions"`
 	Idempotent        bool   `json:"idempotent"`
+	EventSourcing     bool   `json:"event_sourcing"`
 	LeaderID          string `json:"leader_id"`
 	ReplicationFactor int    `json:"replication_factor,omitempty"`
 }
@@ -127,7 +128,7 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 	f.mu.Unlock()
 
 	if tm != nil {
-		if err := tm.CreateTopic(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent, false); err != nil {
+		if err := tm.CreateTopic(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent, topicCmd.EventSourcing); err != nil {
 			util.Error("FSM: Failed to create topic '%s' in local manager: %v", topicCmd.Name, err)
 		}
 	}

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -89,6 +89,10 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 		var replicas []string
 		if assignedLeader == "" {
 			replicas = ring.GetN(key, replicationFactor)
+			if len(replicas) == 0 {
+				f.mu.Unlock()
+				return fmt.Errorf("no replicas assigned for partition %s", key)
+			}
 			assignedLeader = replicas[0]
 		} else {
 			// Explicit leader: build replica set starting from leader
@@ -123,7 +127,7 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 	f.mu.Unlock()
 
 	if tm != nil {
-		if err := tm.CreateTopic(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent); err != nil {
+		if err := tm.CreateTopic(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent, false); err != nil {
 			util.Error("FSM: Failed to create topic '%s' in local manager: %v", topicCmd.Name, err)
 		}
 	}

--- a/pkg/cluster/replication/fsm/fsm_replication.go
+++ b/pkg/cluster/replication/fsm/fsm_replication.go
@@ -74,8 +74,8 @@ func (f *BrokerFSM) applyMessageBatch(cmd *types.MessageCommand) interface{} {
 		return errorAckResponse(err.Error(), first.ProducerID, first.Epoch)
 	}
 
-	partition.SetHWM(last.Offset + 1)
-	partition.UpdateLEO(last.Offset + 1)
+	// Re-read after EnqueueBatch since it assigns actual disk offsets
+	last = cmd.Messages[len(cmd.Messages)-1]
 
 	f.mu.Lock()
 	if effectiveIdempotent {

--- a/pkg/cluster/replication/fsm/fsm_test.go
+++ b/pkg/cluster/replication/fsm/fsm_test.go
@@ -45,7 +45,7 @@ func (m *MockHandlerProvider) GetHandler(topic string, partitionID int) (types.S
 
 func newTestFSM() *BrokerFSM {
 	tm := topic.NewTopicManager(config.DefaultConfig(), &MockHandlerProvider{}, nil)
-	fsm := NewBrokerFSM(nil, tm, nil)
+	fsm := NewBrokerFSM(tm, nil)
 
 	if fsm.brokers == nil {
 		fsm.brokers = make(map[string]*BrokerInfo)
@@ -273,7 +273,7 @@ func TestBrokerFSM_SequenceScope_Partition(t *testing.T) {
 	fsm := newTestFSM()
 	fsm.partitionMetadata["t1-0"] = &PartitionMetadata{PartitionCount: 2, Idempotent: true}
 	fsm.partitionMetadata["t1-1"] = &PartitionMetadata{PartitionCount: 2, Idempotent: true}
-	if err := fsm.tm.CreateTopic("t1", 2, true); err != nil {
+	if err := fsm.tm.CreateTopic("t1", 2, true, false); err != nil {
 		t.Fatalf("CreateTopic failed: %v", err)
 	}
 

--- a/pkg/cluster/replication/isr_manager.go
+++ b/pkg/cluster/replication/isr_manager.go
@@ -1,8 +1,10 @@
 package replication
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -12,7 +14,7 @@ import (
 	"github.com/cursus-io/cursus/util"
 )
 
-const defaultHeartbeatTimeout = 10 * time.Second
+const defaultHeartbeatTimeout = 3 * time.Second
 
 type CommandApplier interface {
 	ApplyCommand(prefix string, data []byte) error
@@ -28,12 +30,13 @@ type ISRManager struct {
 	heartbeatTimeout time.Duration
 	leaderSince      time.Time
 
-	stopCh    chan struct{}
+	ctx       context.Context
 	startOnce sync.Once
-	stopOnce  sync.Once
 }
 
-func NewISRManager(fsm *fsm.BrokerFSM, brokerID string, heartbeatTimeout time.Duration, applier CommandApplier) *ISRManager {
+// NewISRManager creates a new ISRManager. The provided ctx controls the lifetime
+// of the background ISR-check goroutine started by Start().
+func NewISRManager(ctx context.Context, fsm *fsm.BrokerFSM, brokerID string, heartbeatTimeout time.Duration, applier CommandApplier) *ISRManager {
 	if heartbeatTimeout <= 0 {
 		heartbeatTimeout = defaultHeartbeatTimeout
 	}
@@ -49,7 +52,7 @@ func NewISRManager(fsm *fsm.BrokerFSM, brokerID string, heartbeatTimeout time.Du
 		applier:          applier,
 		lastSeen:         lastSeen,
 		heartbeatTimeout: heartbeatTimeout,
-		stopCh:           make(chan struct{}),
+		ctx:              ctx,
 	}
 }
 
@@ -66,7 +69,7 @@ func (i *ISRManager) Start() {
 					i.UpdateHeartbeat(i.brokerID)
 					i.refreshAllISRs()
 					i.CleanStaleHeartbeats()
-				case <-i.stopCh:
+				case <-i.ctx.Done():
 					return
 				}
 			}
@@ -74,11 +77,8 @@ func (i *ISRManager) Start() {
 	})
 }
 
-func (i *ISRManager) Stop() {
-	i.stopOnce.Do(func() {
-		close(i.stopCh)
-	})
-}
+// Stop is a no-op; cancellation is handled by the context passed to NewISRManager.
+func (i *ISRManager) Stop() {}
 
 func (i *ISRManager) refreshAllISRs() {
 	if i.applier != nil && !i.applier.IsLeader() {
@@ -92,7 +92,11 @@ func (i *ISRManager) refreshAllISRs() {
 			continue
 		}
 		topic := key[:idx]
-		partition, _ := strconv.Atoi(key[idx+1:])
+		partition, err := strconv.Atoi(key[idx+1:])
+		if err != nil {
+			util.Warn("ISRManager: skipping invalid partition key: %s", key)
+			continue
+		}
 
 		i.ComputeISR(topic, partition)
 	}
@@ -210,7 +214,7 @@ func (i *ISRManager) ComputeISR(topic string, partition int) []string {
 			newMetadata.ISR = currentISR
 
 			if !leaderAlive && len(currentISR) > 0 {
-				// Elect new leader from ISR
+				sort.Strings(currentISR)
 				newMetadata.Leader = currentISR[0]
 				newMetadata.LeaderEpoch++
 				util.Info("ISRManager: Failover for %s: %s -> %s", key, metadata.Leader, newMetadata.Leader)
@@ -238,7 +242,11 @@ func (i *ISRManager) ComputeISR(topic string, partition int) []string {
 				}
 			}
 
-			data, _ := json.Marshal(newMetadata)
+			data, err := json.Marshal(newMetadata)
+		if err != nil {
+			util.Error("ISRManager: Failed to marshal metadata for %s: %v", key, err)
+			return currentISR
+		}
 			// The FSM expects PARTITION:<topic>-<partition>:<json>
 			// ApplyCommand(prefix, data) results in "prefix:data"
 			payload := []byte(fmt.Sprintf("%s:%s", key, string(data)))

--- a/pkg/cluster/replication/isr_manager.go
+++ b/pkg/cluster/replication/isr_manager.go
@@ -31,6 +31,7 @@ type ISRManager struct {
 	leaderSince      time.Time
 
 	ctx       context.Context
+	cancel    context.CancelFunc
 	startOnce sync.Once
 }
 
@@ -46,13 +47,16 @@ func NewISRManager(ctx context.Context, fsm *fsm.BrokerFSM, brokerID string, hea
 		lastSeen[brokerID] = time.Now()
 	}
 
+	childCtx, cancel := context.WithCancel(ctx)
+
 	return &ISRManager{
 		fsm:              fsm,
 		brokerID:         brokerID,
 		applier:          applier,
 		lastSeen:         lastSeen,
 		heartbeatTimeout: heartbeatTimeout,
-		ctx:              ctx,
+		ctx:              childCtx,
+		cancel:           cancel,
 	}
 }
 
@@ -77,8 +81,12 @@ func (i *ISRManager) Start() {
 	})
 }
 
-// Stop is a no-op; cancellation is handled by the context passed to NewISRManager.
-func (i *ISRManager) Stop() {}
+// Stop cancels the ISR manager's context, shutting down the background goroutine.
+func (i *ISRManager) Stop() {
+	if i.cancel != nil {
+		i.cancel()
+	}
+}
 
 func (i *ISRManager) refreshAllISRs() {
 	if i.applier != nil && !i.applier.IsLeader() {

--- a/pkg/cluster/replication/isr_manager_ext_test.go
+++ b/pkg/cluster/replication/isr_manager_ext_test.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,8 +10,8 @@ import (
 )
 
 func TestISRManager_Lifecycle(t *testing.T) {
-	brokerFSM := fsm.NewBrokerFSM(nil, nil, nil)
-	isrManager := NewISRManager(brokerFSM, "node1", 100*time.Millisecond, nil)
+	brokerFSM := fsm.NewBrokerFSM(nil, nil)
+	isrManager := NewISRManager(context.Background(), brokerFSM, "node1", 100*time.Millisecond, nil)
 	t.Cleanup(isrManager.Stop)
 
 	isrManager.Start()
@@ -23,9 +24,9 @@ func TestISRManager_Lifecycle(t *testing.T) {
 }
 
 func TestISRManager_SetLeader(t *testing.T) {
-	brokerFSM := fsm.NewBrokerFSM(nil, nil, nil)
+	brokerFSM := fsm.NewBrokerFSM(nil, nil)
 	applier := &MockCommandApplier{IsLeaderResult: false}
-	isrManager := NewISRManager(brokerFSM, "node1", 100*time.Millisecond, applier)
+	isrManager := NewISRManager(context.Background(), brokerFSM, "node1", 100*time.Millisecond, applier)
 
 	isrManager.SetLeader(true)
 	isrManager.mu.RLock()

--- a/pkg/cluster/replication/isr_manager_test.go
+++ b/pkg/cluster/replication/isr_manager_test.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
-	"github.com/cursus-io/cursus/pkg/disk"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/hashicorp/raft"
@@ -63,9 +63,8 @@ func TestISRManager_Quorum(t *testing.T) {
 
 	hp := &FakeHandlerProvider{}
 	tm := topic.NewTopicManager(cfg, hp, nil)
-	dm := disk.NewDiskManager(cfg)
-	cd := coordinator.NewCoordinator(cfg, tm)
-	brokerFSM := fsm.NewBrokerFSM(dm, tm, cd)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
+	brokerFSM := fsm.NewBrokerFSM(tm, cd)
 
 	topicName := "test-topic"
 	partitionID := 0
@@ -94,7 +93,7 @@ func TestISRManager_Quorum(t *testing.T) {
 		t.Fatalf("failed to apply TOPIC command: %v", err)
 	}
 
-	if err := tm.CreateTopic(topicName, 1, false); err != nil {
+	if err := tm.CreateTopic(topicName, 1, false, false); err != nil {
 		t.Fatalf("CreateTopic failed: %v", err)
 	}
 
@@ -114,7 +113,7 @@ func TestISRManager_Quorum(t *testing.T) {
 
 	// Mock applier to act as leader and update FSM
 	applier := &MockCommandApplier{IsLeaderResult: true, fsm: brokerFSM}
-	isrManager := NewISRManager(brokerFSM, "node1", 100*time.Millisecond, applier)
+	isrManager := NewISRManager(context.Background(), brokerFSM, "node1", 100*time.Millisecond, applier)
 
 	// Heartbeat node1 & node2 only
 	isrManager.UpdateHeartbeat("node1")
@@ -151,9 +150,8 @@ func TestISRManager_ReplicaSubset(t *testing.T) {
 
 	hp := &FakeHandlerProvider{}
 	tm := topic.NewTopicManager(cfg, hp, nil)
-	dm := disk.NewDiskManager(cfg)
-	cd := coordinator.NewCoordinator(cfg, tm)
-	brokerFSM := fsm.NewBrokerFSM(dm, tm, cd)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
+	brokerFSM := fsm.NewBrokerFSM(tm, cd)
 
 	// Register 5 brokers
 	for i := 1; i <= 5; i++ {
@@ -177,7 +175,7 @@ func TestISRManager_ReplicaSubset(t *testing.T) {
 	brokerFSM.Apply(&raft.Log{Data: []byte(fmt.Sprintf("PARTITION:%s:%s", key, metaData))})
 
 	applier := &MockCommandApplier{IsLeaderResult: true, fsm: brokerFSM}
-	isrManager := NewISRManager(brokerFSM, "node1", 100*time.Millisecond, applier)
+	isrManager := NewISRManager(context.Background(), brokerFSM, "node1", 100*time.Millisecond, applier)
 
 	// Only heartbeat node1 and node3 (node5 is stale)
 	isrManager.UpdateHeartbeat("node1")
@@ -214,9 +212,8 @@ func TestISRManager_UncleanLeaderElection(t *testing.T) {
 
 	hp := &FakeHandlerProvider{}
 	tm := topic.NewTopicManager(cfg, hp, nil)
-	dm := disk.NewDiskManager(cfg)
-	cd := coordinator.NewCoordinator(cfg, tm)
-	brokerFSM := fsm.NewBrokerFSM(dm, tm, cd)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
+	brokerFSM := fsm.NewBrokerFSM(tm, cd)
 
 	// Register 3 brokers
 	for i := 1; i <= 3; i++ {
@@ -239,7 +236,7 @@ func TestISRManager_UncleanLeaderElection(t *testing.T) {
 	brokerFSM.Apply(&raft.Log{Data: []byte(fmt.Sprintf("PARTITION:%s:%s", key, metaData))})
 
 	applier := &MockCommandApplier{IsLeaderResult: true, fsm: brokerFSM}
-	isrManager := NewISRManager(brokerFSM, "node2", 100*time.Millisecond, applier)
+	isrManager := NewISRManager(context.Background(), brokerFSM, "node2", 100*time.Millisecond, applier)
 
 	// Only heartbeat node2 (leader node1 is dead, no heartbeat)
 	isrManager.UpdateHeartbeat("node2")

--- a/pkg/cluster/replication/manager.go
+++ b/pkg/cluster/replication/manager.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -15,7 +16,6 @@ import (
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
-	"github.com/cursus-io/cursus/pkg/disk"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
@@ -56,8 +56,8 @@ type RaftReplicationManager struct {
 	leaderCh chan bool
 }
 
-func NewRaftReplicationManager(cfg *config.Config, brokerID string, diskManager *disk.DiskManager, topicManager *topic.TopicManager, coordinator *coordinator.Coordinator, client client.TCPClusterClient) (*RaftReplicationManager, error) {
-	brokerFSM := fsm.NewBrokerFSM(diskManager, topicManager, coordinator)
+func NewRaftReplicationManager(ctx context.Context, cfg *config.Config, brokerID string, topicManager *topic.TopicManager, coordinator *coordinator.Coordinator, client client.TCPClusterClient) (*RaftReplicationManager, error) {
+	brokerFSM := fsm.NewBrokerFSM(topicManager, coordinator)
 
 	localAddr := fmt.Sprintf("%s:%d", cfg.AdvertisedHost, cfg.RaftPort)
 	raftCfg := raft.DefaultConfig()
@@ -66,7 +66,7 @@ func NewRaftReplicationManager(cfg *config.Config, brokerID string, diskManager 
 	// Raft Security Rule: HeartbeatTimeout must be larger than LeaderLeaseTimeout
 	raftCfg.HeartbeatTimeout = 1000 * time.Millisecond
 	raftCfg.ElectionTimeout = 2000 * time.Millisecond
-	raftCfg.LeaderLeaseTimeout = 500 * time.Millisecond
+	raftCfg.LeaderLeaseTimeout = 800 * time.Millisecond
 	raftCfg.CommitTimeout = 50 * time.Millisecond
 	raftCfg.LogLevel = "Info"
 
@@ -172,7 +172,7 @@ func NewRaftReplicationManager(cfg *config.Config, brokerID string, diskManager 
 		leaderCh:  make(chan bool, 10),
 	}
 
-	rm.isrManager = NewISRManager(brokerFSM, brokerID, 5*time.Second, rm)
+	rm.isrManager = NewISRManager(ctx, brokerFSM, brokerID, 5*time.Second, rm)
 	go rm.isrManager.Start()
 
 	go rm.observeLeadership(notifyCh)

--- a/pkg/cluster/server_test.go
+++ b/pkg/cluster/server_test.go
@@ -43,7 +43,7 @@ func TestClusterServer_Join(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	addr := ln.Addr().String()
 
@@ -52,7 +52,7 @@ func TestClusterServer_Join(t *testing.T) {
 
 		conn, err := net.Dial("tcp", addr)
 		assert.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		payload := `{"node_id":"node1","address":"127.0.0.1:9001"}`
 		msg := util.EncodeMessage("cluster", "JOIN_CLUSTER "+payload)
@@ -75,7 +75,7 @@ func TestClusterServer_Join(t *testing.T) {
 
 		conn, err := net.Dial("tcp", addr)
 		assert.NoError(t, err)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		payload := `{"node_id":"node2","address":"127.0.0.1:9002"}`
 		msg := util.EncodeMessage("cluster", "JOIN_CLUSTER "+payload)
@@ -101,7 +101,7 @@ func TestClusterServer_Heartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	addr := ln.Addr().String()
 
@@ -109,7 +109,7 @@ func TestClusterServer_Heartbeat(t *testing.T) {
 
 	conn, err := net.Dial("tcp", addr)
 	assert.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	payload := `{"node_id":"node-hb"}`
 	msg := util.EncodeMessage("cluster", "HEARTBEAT_CLUSTER "+payload)
@@ -130,7 +130,7 @@ func TestClusterServer_List(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	addr := ln.Addr().String()
 
@@ -138,7 +138,7 @@ func TestClusterServer_List(t *testing.T) {
 
 	conn, err := net.Dial("tcp", addr)
 	assert.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	msg := util.EncodeMessage("cluster", "LIST_CLUSTER")
 	err = util.WriteWithLength(conn, msg)

--- a/pkg/controller/cluster_handler.go
+++ b/pkg/controller/cluster_handler.go
@@ -14,6 +14,9 @@ import (
 const DefaultFSMApplyTimeout = 5 * time.Second
 
 func backoffDelay(attempt int, base time.Duration) time.Duration {
+	if attempt > 30 {
+		attempt = 30
+	}
 	delay := base * time.Duration(1<<uint(attempt))
 	if delay > 5*time.Second {
 		delay = 5 * time.Second
@@ -78,7 +81,9 @@ func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
 			}
 			lastErr = err
 			util.Debug("Retrying forward to leader (Target Leader %s)... attempt %d: %v", ch.Cluster.RaftManager.GetLeaderAddress(), i+1, err)
-			time.Sleep(backoffDelay(i, 100*time.Millisecond))
+			if i < maxRetries-1 {
+				time.Sleep(backoffDelay(i, 100*time.Millisecond))
+			}
 		}
 		leaderAddr := ch.Cluster.RaftManager.GetLeaderAddress()
 		return fmt.Sprintf("ERROR: failed to forward command to leader (Leader: %s, Error: %v)", leaderAddr, lastErr), true, nil

--- a/pkg/controller/cluster_handler.go
+++ b/pkg/controller/cluster_handler.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -11,6 +12,26 @@ import (
 )
 
 const DefaultFSMApplyTimeout = 5 * time.Second
+
+func backoffDelay(attempt int, base time.Duration) time.Duration {
+	delay := base * time.Duration(1<<uint(attempt))
+	if delay > 5*time.Second {
+		delay = 5 * time.Second
+	}
+	// Add jitter: ±25%
+	jitter := time.Duration(rand.Int63n(int64(delay)/2)) - delay/4
+	return delay + jitter
+}
+
+// isDistributed returns true if the broker is running in distributed cluster mode.
+func (ch *CommandHandler) isDistributed() bool {
+	return ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil
+}
+
+// hasRouter returns true if distributed mode is enabled with a working router.
+func (ch *CommandHandler) hasRouter() bool {
+	return ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.Router != nil
+}
 
 func (ch *CommandHandler) ProcessCommand(cmd string) string {
 	ctx := NewClientContext("default-group", 0)
@@ -26,14 +47,11 @@ func (ch *CommandHandler) isAuthorizedForPartition(topic string, partition int) 
 
 // isLeaderAndForward checks if the current node is the cluster leader
 func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
-	if !ch.Config.EnabledDistribution || ch.Cluster == nil || ch.Cluster.RaftManager == nil {
+	if !ch.isDistributed() {
 		return "", false, nil
 	}
 
-	const (
-		maxRetries = 5
-		retryDelay = 500 * time.Millisecond
-	)
+	const maxRetries = 5
 
 	for i := 0; i < maxRetries; i++ {
 		if ch.Cluster.RaftManager.GetLeaderAddress() != "" {
@@ -43,7 +61,7 @@ func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
 			return "ERROR: no Raft leader elected after retries", true, fmt.Errorf("no leader elected")
 		}
 		util.Debug("Waiting for Raft leader to be elected... (attempt %d/%d)", i+1, maxRetries)
-		time.Sleep(retryDelay)
+		time.Sleep(backoffDelay(i, 100*time.Millisecond))
 	}
 
 	if !ch.Cluster.RaftManager.IsLeader() {
@@ -60,7 +78,7 @@ func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
 			}
 			lastErr = err
 			util.Debug("Retrying forward to leader (Target Leader %s)... attempt %d: %v", ch.Cluster.RaftManager.GetLeaderAddress(), i+1, err)
-			time.Sleep(retryDelay)
+			time.Sleep(backoffDelay(i, 100*time.Millisecond))
 		}
 		leaderAddr := ch.Cluster.RaftManager.GetLeaderAddress()
 		return fmt.Sprintf("ERROR: failed to forward command to leader (Leader: %s, Error: %v)", leaderAddr, lastErr), true, nil
@@ -69,14 +87,11 @@ func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
 }
 
 func (ch *CommandHandler) isCoordinatorAndForward(groupName, cmd string) (string, bool, error) {
-	if !ch.Config.EnabledDistribution || ch.Cluster == nil || ch.Cluster.Router == nil {
+	if !ch.hasRouter() {
 		return "", false, nil
 	}
 
-	const (
-		maxRetries = 3
-		retryDelay = 200 * time.Millisecond
-	)
+	const maxRetries = 3
 
 	encodedCmd := util.EncodeMessage("", cmd)
 	var lastErr error
@@ -91,14 +106,14 @@ func (ch *CommandHandler) isCoordinatorAndForward(groupName, cmd string) (string
 		} else {
 			lastErr = err
 		}
-		time.Sleep(retryDelay)
+		time.Sleep(backoffDelay(i, 100*time.Millisecond))
 	}
 
 	return fmt.Sprintf("ERROR: failed to forward command to coordinator for group %s: %v", groupName, lastErr), true, nil
 }
 
 func (ch *CommandHandler) isPartitionLeaderAndForward(topic string, partition int, cmd string) (string, bool, error) {
-	if !ch.Config.EnabledDistribution || ch.Cluster == nil || ch.Cluster.Router == nil {
+	if !ch.hasRouter() {
 		return "", false, nil
 	}
 
@@ -107,10 +122,7 @@ func (ch *CommandHandler) isPartitionLeaderAndForward(topic string, partition in
 		return "", false, nil
 	}
 
-	const (
-		maxRetries = 3
-		retryDelay = 200 * time.Millisecond
-	)
+	const maxRetries = 3
 
 	encodedCmd := util.EncodeMessage("", cmd)
 	var lastErr error
@@ -124,7 +136,7 @@ func (ch *CommandHandler) isPartitionLeaderAndForward(topic string, partition in
 		} else {
 			lastErr = err
 		}
-		time.Sleep(retryDelay)
+		time.Sleep(backoffDelay(i, 100*time.Millisecond))
 	}
 
 	return fmt.Sprintf("ERROR: failed to forward command to partition leader for %s:%d: %v", topic, partition, lastErr), true, nil

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -94,6 +94,7 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 			"name":               topicName,
 			"partitions":         partitions,
 			"idempotent":         idempotent,
+			"event_sourcing":     eventSourcing,
 			"replication_factor": replicationFactor,
 		}
 		_, err := ch.applyAndWait("TOPIC", payload)

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -16,8 +16,11 @@ import (
 	"github.com/cursus-io/cursus/util"
 )
 
-// todo. consider an LRU cache(match) to prevent potential memory bloat.
-var regexCache sync.Map
+var (
+	regexMu      sync.RWMutex
+	regexCache   = make(map[string]*regexp.Regexp)
+	maxCacheSize = 1024
+)
 
 // handleHelp processes HELP command
 func (ch *CommandHandler) handleHelp() string {
@@ -36,6 +39,11 @@ FETCH_OFFSET topic=<name> partition=<N> group=<name> - fetch committed offset
 REGISTER_GROUP topic=<name> group=<name> - register consumer group
 GROUP_STATUS group=<name> - get group status
 DESCRIBE topic=<name> - get topic/partition metadata (leader, ISR, offsets)
+APPEND_STREAM topic=<name> key=<aggregate_key> version=<N> event_type=<type> message=<payload> - append event to stream
+READ_STREAM topic=<name> key=<aggregate_key> [from_version=<N>] - read events from stream (binary response)
+SAVE_SNAPSHOT topic=<name> key=<aggregate_key> version=<N> message=<json_payload> - save aggregate snapshot
+READ_SNAPSHOT topic=<name> key=<aggregate_key> - read latest snapshot
+STREAM_VERSION topic=<name> key=<aggregate_key> - get current stream version
 HELP - show this help
 EXIT - exit`
 }
@@ -62,6 +70,11 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 		idempotent = strings.ToLower(idempStr) == "true"
 	}
 
+	eventSourcing := false
+	if esStr, ok := args["event_sourcing"]; ok {
+		eventSourcing = strings.ToLower(esStr) == "true"
+	}
+
 	replicationFactor := ch.Config.DefaultReplicationFactor
 	if rfStr, ok := args["replication_factor"]; ok {
 		n, err := strconv.Atoi(rfStr)
@@ -72,7 +85,7 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 	}
 
 	tm := ch.TopicManager
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
 			return resp
 		}
@@ -88,7 +101,7 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 			return fmt.Sprintf("❌ Failed to create topic: %v", err)
 		}
 	} else {
-		if err := tm.CreateTopic(topicName, partitions, idempotent); err != nil {
+		if err := tm.CreateTopic(topicName, partitions, idempotent, eventSourcing); err != nil {
 			return fmt.Sprintf("ERROR: failed to create topic '%s': %v", topicName, err)
 		}
 	}
@@ -115,7 +128,7 @@ func (ch *CommandHandler) handleDelete(cmd string) string {
 		return "missing topic parameter. Expected: DELETE topic=<name>"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
 			return resp
 		}
@@ -139,7 +152,7 @@ func (ch *CommandHandler) handleDelete(cmd string) string {
 
 // handleList processes LIST command
 func (ch *CommandHandler) handleList() string {
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward("LIST"); forwarded {
 			return resp
 		}
@@ -155,7 +168,7 @@ func (ch *CommandHandler) handleList() string {
 
 // handleListCluster processes LIST_CLUSTER command
 func (ch *CommandHandler) handleListCluster() string {
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		fsm := ch.Cluster.RaftManager.GetFSM()
 		if fsm == nil {
 			return "ERROR: FSM not available"
@@ -183,7 +196,7 @@ func (ch *CommandHandler) handleRegisterGroup(cmd string) string {
 		return "REGISTER_GROUP requires group parameter"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.Router != nil {
+	if ch.hasRouter() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -232,7 +245,7 @@ func (ch *CommandHandler) handleJoinGroup(cmd string, ctx *ClientContext) string
 	consumerID = fmt.Sprintf("%s-%s", consumerID, randSuffix)
 
 	var assignments []int
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -303,7 +316,7 @@ func (ch *CommandHandler) handleSyncGroup(cmd string) string {
 		return "coordinator not available"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -336,7 +349,7 @@ func (ch *CommandHandler) handleLeaveGroup(cmd string) string {
 		return "LEAVE_GROUP requires member parameter"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -385,7 +398,7 @@ func (ch *CommandHandler) handleFetchOffset(cmd string) string {
 		return "FETCH_OFFSET requires group parameter"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -430,7 +443,7 @@ func (ch *CommandHandler) handleGroupStatus(cmd string) string {
 		return "coordinator not available"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -468,7 +481,7 @@ func (ch *CommandHandler) handleHeartbeat(cmd string) string {
 		return "HEARTBEAT requires member parameter"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupName, cmd); forwarded {
 			return resp
 		}
@@ -518,7 +531,7 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 		return "invalid offset"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupID, cmd); forwarded {
 			return resp
 		}
@@ -570,7 +583,7 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 	memberID := args["member"]
 	generation, _ := strconv.Atoi(args["generation"])
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isCoordinatorAndForward(groupID, cmd); forwarded {
 			return resp
 		}
@@ -596,7 +609,8 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 			continue
 		}
 
-		p, err := strconv.Atoi(kv[0])
+		partStr := strings.TrimPrefix(kv[0], "P")
+		p, err := strconv.Atoi(partStr)
 		if err != nil {
 			util.Warn("Invalid partition in batch commit: %s", kv[0])
 			continue
@@ -607,7 +621,7 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 			continue
 		}
 
-		if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+		if ch.isDistributed() {
 			if !ch.isAuthorizedForPartition(topicName, p) {
 				util.Warn("Unauthorized batch commit attempt for %s:%d", topicName, p)
 				continue
@@ -627,7 +641,7 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 		return "ERROR: no_valid_offsets"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		batchCommitData := map[string]interface{}{
 			"type":    "BATCH_COMMIT",
 			"group":   groupID,
@@ -693,10 +707,12 @@ func isTopicMatched(pattern, topicName string) bool {
 }
 
 func match(p, t string) bool {
-	if val, ok := regexCache.Load(p); ok {
-		if cachedRe, ok := val.(*regexp.Regexp); ok {
-			return cachedRe.MatchString(t)
-		}
+	regexMu.RLock()
+	cachedRe, ok := regexCache[p]
+	regexMu.RUnlock()
+
+	if ok {
+		return cachedRe.MatchString(t)
 	}
 
 	escaped := regexp.QuoteMeta(p)
@@ -709,7 +725,13 @@ func match(p, t string) bool {
 		return false
 	}
 
-	regexCache.Store(p, newRe)
+	regexMu.Lock()
+	if len(regexCache) >= maxCacheSize {
+		regexCache = make(map[string]*regexp.Regexp)
+	}
+	regexCache[p] = newRe
+	regexMu.Unlock()
+
 	return newRe.MatchString(t)
 }
 
@@ -721,7 +743,7 @@ func (ch *CommandHandler) handleDescribeTopic(cmd string) string {
 		return "missing topic parameter. Expected: DESCRIBE topic=<name>"
 	}
 
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
 			return resp
 		}
@@ -751,7 +773,7 @@ func (ch *CommandHandler) handleDescribeTopic(cmd string) string {
 	}
 
 	var raftLeader string
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		raftLeader = ch.Cluster.RaftManager.GetLeaderAddress()
 	}
 
@@ -759,10 +781,10 @@ func (ch *CommandHandler) handleDescribeTopic(cmd string) string {
 		pm := PartitionMetadata{
 			ID:  p.ID(),
 			LEO: p.NextOffset(),
-			HWM: p.HWM,
+			HWM: p.GetHWM(),
 		}
 
-		if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+		if ch.isDistributed() {
 			if fsmObj := ch.Cluster.RaftManager.GetFSM(); fsmObj != nil {
 				partitionKey := fmt.Sprintf("%s-%d", topicName, p.ID())
 				if partMeta := fsmObj.GetPartitionMetadata(partitionKey); partMeta != nil {

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -227,7 +227,7 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 	ctx.Generation = cArgs.Generation
 	ctx.MemberID = cArgs.MemberID
 
-	_, p, err := ch.getTopicAndPartition(cArgs.TopicName, cArgs.PartitionID)
+	t, p, err := ch.getTopicAndPartition(cArgs.TopicName, cArgs.PartitionID)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,13 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 	streamConn := stream.NewStreamConnection(conn, cArgs.TopicName, cArgs.PartitionID, cArgs.GroupName, actualOffset)
 	streamConn.SetBatchSize(cArgs.BatchSize)
 	streamConn.SetInterval(100 * time.Millisecond)
-	streamConn.SetCoordinator(ch.Coordinator)
+	streamConn.SetCommitter(ch.Coordinator)
+
+	// Pass partition's message signal for event-driven streaming
+	signalCh := t.NewMessageSignal(cArgs.PartitionID)
+	if signalCh != nil {
+		streamConn.SetNewMessageCh(signalCh)
+	}
 
 	readFn := func(offset uint64, max int) ([]types.Message, error) {
 		return p.ReadCommitted(offset, max)
@@ -268,7 +274,7 @@ func (ch *CommandHandler) validateConsumeSyntax(cmd, raw string) string {
 
 // checkLeaderOrRedirect checks if this broker is the leader and writes a redirect error if not.
 func (ch *CommandHandler) checkLeaderOrRedirect(conn net.Conn) error {
-	if !ch.Config.EnabledDistribution || ch.Cluster.Router == nil {
+	if !ch.Config.EnabledDistribution || ch.Cluster == nil || ch.Cluster.Router == nil {
 		return nil
 	}
 

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -241,7 +241,9 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 	streamConn := stream.NewStreamConnection(conn, cArgs.TopicName, cArgs.PartitionID, cArgs.GroupName, actualOffset)
 	streamConn.SetBatchSize(cArgs.BatchSize)
 	streamConn.SetInterval(100 * time.Millisecond)
-	streamConn.SetCommitter(ch.Coordinator)
+	if ch.Coordinator != nil {
+		streamConn.SetCommitter(ch.Coordinator)
+	}
 
 	// Pass partition's message signal for event-driven streaming
 	signalCh := t.NewMessageSignal(cArgs.PartitionID)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -8,6 +8,7 @@ import (
 	clusterController "github.com/cursus-io/cursus/pkg/cluster/controller"
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/eventsource"
 	"github.com/cursus-io/cursus/pkg/stream"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/types"
@@ -23,6 +24,15 @@ type CommandHandler struct {
 	Coordinator   *coordinator.Coordinator
 	StreamManager *stream.StreamManager
 	Cluster       *clusterController.ClusterController
+	ESHandler     *eventsource.Handler
+	commands      []commandEntry
+}
+
+// commandEntry defines a single command routing rule.
+type commandEntry struct {
+	prefix  string
+	exact   bool
+	handler func(cmd string, ctx *ClientContext) string
 }
 
 type ConsumeArgs struct {
@@ -38,13 +48,39 @@ func NewCommandHandler(
 	sm *stream.StreamManager,
 	cc *clusterController.ClusterController,
 ) *CommandHandler {
-	return &CommandHandler{
+	ch := &CommandHandler{
 		TopicManager:  tm,
 		Config:        cfg,
 		Coordinator:   cd,
 		StreamManager: sm,
 		Cluster:       cc,
+		ESHandler:     eventsource.NewHandler(tm),
 	}
+	ch.commands = []commandEntry{
+		{prefix: "HELP", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleHelp() }},
+		{prefix: "LIST_CLUSTER", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListCluster() }},
+		{prefix: "LIST", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleList() }},
+		{prefix: "CREATE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCreate(cmd) }},
+		{prefix: "DELETE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDelete(cmd) }},
+		{prefix: "PUBLISH ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handlePublish(cmd) }},
+		{prefix: "REGISTER_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleRegisterGroup(cmd) }},
+		{prefix: "JOIN_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleJoinGroup(cmd, ctx) }},
+		{prefix: "SYNC_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleSyncGroup(cmd) }},
+		{prefix: "LEAVE_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleLeaveGroup(cmd) }},
+		{prefix: "FETCH_OFFSET ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleFetchOffset(cmd) }},
+		{prefix: "GROUP_STATUS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleGroupStatus(cmd) }},
+		{prefix: "DESCRIBE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDescribeTopic(cmd) }},
+		{prefix: "HEARTBEAT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleHeartbeat(cmd) }},
+		{prefix: "COMMIT_OFFSET ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCommitOffset(cmd) }},
+		{prefix: "BATCH_COMMIT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleBatchCommit(cmd) }},
+		{prefix: "APPEND_STREAM ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.ESHandler.HandleAppendStream(cmd) }},
+		{prefix: "STREAM_VERSION ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.ESHandler.HandleStreamVersion(cmd) }},
+		{prefix: "SAVE_SNAPSHOT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.ESHandler.HandleSaveSnapshot(cmd) }},
+		{prefix: "READ_SNAPSHOT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.ESHandler.HandleReadSnapshot(cmd) }},
+		{prefix: "READ_STREAM ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return STREAM_DATA_SIGNAL }},
+		{prefix: "REPLICATE_MESSAGE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleReplicateMessage(cmd) }},
+	}
+	return ch
 }
 
 func (ch *CommandHandler) logCommandResult(cmd, response string) {
@@ -77,46 +113,20 @@ func (ch *CommandHandler) HandleCommand(rawCmd string, ctx *ClientContext) strin
 	return resp
 }
 
-// handleCommandByType delegates to specific command handlers
+// handleCommandByType dispatches to the matching command handler from the registry.
 func (ch *CommandHandler) handleCommandByType(cmd, upper string, ctx *ClientContext) string {
-	switch {
-	case strings.EqualFold(cmd, "HELP"):
-		return ch.handleHelp()
-	case strings.HasPrefix(upper, "CREATE "):
-		return ch.handleCreate(cmd)
-	case strings.HasPrefix(upper, "DELETE "):
-		return ch.handleDelete(cmd)
-	case strings.EqualFold(cmd, "LIST"):
-		return ch.handleList()
-	case strings.EqualFold(cmd, "LIST_CLUSTER"):
-		return ch.handleListCluster()
-	case strings.HasPrefix(upper, "PUBLISH "):
-		return ch.handlePublish(cmd)
-	case strings.HasPrefix(upper, "REGISTER_GROUP "):
-		return ch.handleRegisterGroup(cmd)
-	case strings.HasPrefix(upper, "JOIN_GROUP "):
-		return ch.handleJoinGroup(cmd, ctx)
-	case strings.HasPrefix(upper, "SYNC_GROUP "):
-		return ch.handleSyncGroup(cmd)
-	case strings.HasPrefix(upper, "LEAVE_GROUP "):
-		return ch.handleLeaveGroup(cmd)
-	case strings.HasPrefix(upper, "FETCH_OFFSET "):
-		return ch.handleFetchOffset(cmd)
-	case strings.HasPrefix(upper, "GROUP_STATUS "):
-		return ch.handleGroupStatus(cmd)
-	case strings.HasPrefix(upper, "DESCRIBE "):
-		return ch.handleDescribeTopic(cmd)
-	case strings.HasPrefix(upper, "HEARTBEAT "):
-		return ch.handleHeartbeat(cmd)
-	case strings.HasPrefix(upper, "COMMIT_OFFSET "):
-		return ch.handleCommitOffset(cmd)
-	case strings.HasPrefix(upper, "BATCH_COMMIT "):
-		return ch.handleBatchCommit(cmd)
-	case strings.HasPrefix(upper, "REPLICATE_MESSAGE "):
-		return ch.handleReplicateMessage(cmd)
-	default:
-		return "ERROR: unknown command: " + cmd
+	for _, entry := range ch.commands {
+		if entry.exact {
+			if strings.EqualFold(cmd, entry.prefix) {
+				return entry.handler(cmd, ctx)
+			}
+		} else {
+			if strings.HasPrefix(upper, entry.prefix) {
+				return entry.handler(cmd, ctx)
+			}
+		}
 	}
+	return "ERROR: unknown command: " + cmd
 }
 
 func (ch *CommandHandler) fail(raw, msg string) string {

--- a/pkg/controller/handler_consume_test.go
+++ b/pkg/controller/handler_consume_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"context"
 	"net"
 	"strings"
 	"testing"
@@ -17,12 +18,12 @@ func TestCommandHandler_ConsumeFull(t *testing.T) {
 	cfg := config.DefaultConfig()
 	hp := &mockHandlerProvider{}
 	tm := topic.NewTopicManager(cfg, hp, nil)
-	_ = tm.CreateTopic("topic1", 1, false)
+	_ = tm.CreateTopic("topic1", 1, false, false)
 
 	p, _ := tm.GetTopic("topic1").GetPartition(0)
 	p.SetHWM(100)
 
-	coord := coordinator.NewCoordinator(cfg, &DummyPublisher{})
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 	_ = coord.RegisterGroup("topic1", "g1", 1)
 	memberID := "m1"
 	_, _ = coord.AddConsumer("g1", memberID)
@@ -35,8 +36,8 @@ func TestCommandHandler_ConsumeFull(t *testing.T) {
 
 	t.Run("HandleConsumeCommand basic", func(t *testing.T) {
 		server, client := net.Pipe()
-		defer server.Close()
-		defer client.Close()
+		defer func() { _ = server.Close() }()
+		defer func() { _ = client.Close() }()
 
 		errCh := make(chan error, 1)
 		go func() {
@@ -51,7 +52,7 @@ func TestCommandHandler_ConsumeFull(t *testing.T) {
 		_, err := client.Read(buf)
 		assert.NoError(t, err)
 
-		client.Close()
+		_ = client.Close()
 		err = <-errCh
 		if err != nil && !strings.Contains(err.Error(), "closed pipe") && !strings.Contains(err.Error(), "EOF") {
 			t.Errorf("HandleConsumeCommand failed: %v", err)
@@ -60,8 +61,8 @@ func TestCommandHandler_ConsumeFull(t *testing.T) {
 
 	t.Run("HandleConsumeCommand topic pattern", func(t *testing.T) {
 		server, client := net.Pipe()
-		defer server.Close()
-		defer client.Close()
+		defer func() { _ = server.Close() }()
+		defer func() { _ = client.Close() }()
 
 		errCh := make(chan error, 1)
 		go func() {
@@ -75,7 +76,7 @@ func TestCommandHandler_ConsumeFull(t *testing.T) {
 		_, err := client.Read(buf)
 		assert.NoError(t, err)
 
-		client.Close()
+		_ = client.Close()
 		err = <-errCh
 		if err != nil && !strings.Contains(err.Error(), "closed pipe") && !strings.Contains(err.Error(), "EOF") {
 			t.Errorf("HandleConsumeCommand failed: %v", err)
@@ -84,8 +85,8 @@ func TestCommandHandler_ConsumeFull(t *testing.T) {
 
 	t.Run("HandleConsumeCommand invalid topic", func(t *testing.T) {
 		server, client := net.Pipe()
-		defer server.Close()
-		defer client.Close()
+		defer func() { _ = server.Close() }()
+		defer func() { _ = client.Close() }()
 
 		cmd := "CONSUME topic=no-topic partition=0 offset=0 group=g1 member=" + memberID
 		_, err := ch.HandleConsumeCommand(server, cmd, ctx)

--- a/pkg/controller/handler_ext_test.go
+++ b/pkg/controller/handler_ext_test.go
@@ -20,7 +20,7 @@ func TestCommandHandler_Publish(t *testing.T) {
 	ch := controller.NewCommandHandler(tm, cfg, nil, nil, nil)
 	ctx := controller.NewClientContext("test-group", 0)
 
-	_ = tm.CreateTopic("test-topic", 1, false)
+	_ = tm.CreateTopic("test-topic", 1, false, false)
 
 	t.Run("PUBLISH basic", func(t *testing.T) {
 		cmd := "PUBLISH topic=test-topic producerId=p1 acks=1 message=hello"
@@ -74,7 +74,7 @@ func TestCommandHandler_Consume(t *testing.T) {
 	ch := controller.NewCommandHandler(tm, cfg, nil, nil, nil)
 	ctx := controller.NewClientContext("test-group", 0)
 
-	_ = tm.CreateTopic("test-topic", 1, false)
+	_ = tm.CreateTopic("test-topic", 1, false, false)
 
 	t.Run("CONSUME syntax error", func(t *testing.T) {
 		resp := ch.HandleCommand("CONSUME topic=test-topic", ctx)
@@ -85,8 +85,8 @@ func TestCommandHandler_Consume(t *testing.T) {
 
 	t.Run("HandleConsumeCommand missing parameters", func(t *testing.T) {
 		server, client := net.Pipe()
-		defer server.Close()
-		defer client.Close()
+		defer func() { _ = server.Close() }()
+		defer func() { _ = client.Close() }()
 
 		go func() {
 			buf := make([]byte, 1024)
@@ -106,7 +106,7 @@ func TestCommandHandler_BatchPublish(t *testing.T) {
 	tm := topic.NewTopicManager(cfg, hp, nil)
 	ch := controller.NewCommandHandler(tm, cfg, nil, nil, nil)
 
-	_ = tm.CreateTopic("test-topic", 1, false)
+	_ = tm.CreateTopic("test-topic", 1, false, false)
 
 	t.Run("HandleBatchMessage valid", func(t *testing.T) {
 		msgs := []types.Message{

--- a/pkg/controller/handler_group_test.go
+++ b/pkg/controller/handler_group_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -17,7 +18,7 @@ type DummyPublisher struct{}
 func (d *DummyPublisher) Publish(topic string, msg *types.Message) error {
 	return nil
 }
-func (d *DummyPublisher) CreateTopic(topic string, partitionCount int, idempotent bool) error {
+func (d *DummyPublisher) CreateTopic(topic string, partitionCount int, idempotent bool, eventSourcing bool) error {
 	return nil
 }
 
@@ -25,9 +26,9 @@ func TestCommandHandler_GroupOps(t *testing.T) {
 	cfg := config.DefaultConfig()
 	hp := &mockHandlerProvider{}
 	tm := topic.NewTopicManager(cfg, hp, nil)
-	_ = tm.CreateTopic("topic1", 4, false)
+	_ = tm.CreateTopic("topic1", 4, false, false)
 
-	coord := coordinator.NewCoordinator(cfg, &DummyPublisher{})
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 	ch := controller.NewCommandHandler(tm, cfg, coord, nil, nil)
 	ctx := controller.NewClientContext("", 0)
 
@@ -77,9 +78,9 @@ func TestCommandHandler_OffsetOps(t *testing.T) {
 	cfg := config.DefaultConfig()
 	hp := &mockHandlerProvider{}
 	tm := topic.NewTopicManager(cfg, hp, nil)
-	_ = tm.CreateTopic("topic1", 4, false)
+	_ = tm.CreateTopic("topic1", 4, false, false)
 
-	coord := coordinator.NewCoordinator(cfg, &DummyPublisher{})
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 	ch := controller.NewCommandHandler(tm, cfg, coord, nil, nil)
 	ctx := controller.NewClientContext("g1", 0)
 

--- a/pkg/controller/handler_real_test.go
+++ b/pkg/controller/handler_real_test.go
@@ -114,7 +114,9 @@ func TestCommandHandler_GroupCommands(t *testing.T) {
 	ch := controller.NewCommandHandler(tm, cfg, nil, nil, nil)
 	ctx := controller.NewClientContext("test-group", 0)
 
-	_ = tm.CreateTopic("topic1", 1, false, false)
+	if err := tm.CreateTopic("topic1", 1, false, false); err != nil {
+		t.Fatalf("CreateTopic failed: %v", err)
+	}
 
 	commands := []struct {
 		cmd    string

--- a/pkg/controller/handler_real_test.go
+++ b/pkg/controller/handler_real_test.go
@@ -114,7 +114,7 @@ func TestCommandHandler_GroupCommands(t *testing.T) {
 	ch := controller.NewCommandHandler(tm, cfg, nil, nil, nil)
 	ctx := controller.NewClientContext("test-group", 0)
 
-	_ = tm.CreateTopic("topic1", 1, false)
+	_ = tm.CreateTopic("topic1", 1, false, false)
 
 	commands := []struct {
 		cmd    string

--- a/pkg/controller/produce_handler.go
+++ b/pkg/controller/produce_handler.go
@@ -116,8 +116,6 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 			return fmt.Sprintf("ERROR: PARTITION_NOT_FOUND %d", partition)
 		}
 
-		assignedOffset := p.ReserveOffsets(1)
-		msg.Offset = assignedOffset
 		effectiveIdempotent := isIdempotent || ch.Config.EnableIdempotence
 
 		scope := "global"
@@ -128,7 +126,6 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 			SequenceScope: scope,
 			Messages: []types.Message{
 				{
-					Offset:     assignedOffset,
 					Payload:    message,
 					ProducerID: producerID,
 					SeqNum:     seqNum,
@@ -138,10 +135,16 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 			Acks: acks,
 		}
 
-		// 1. Append locally
+		// Save HWM before enqueue so we can roll back on replication failure
+		prevHWM := p.GetHWM()
+
+		// 1. Append locally (EnqueueBatch assigns offsets and updates LEO/HWM internally)
 		if err := p.EnqueueBatch(messageData.Messages); err != nil {
 			return ch.errorResponse(fmt.Sprintf("failed to append locally: %v", err))
 		}
+
+		// Read the offset assigned by EnqueueBatch
+		assignedOffset := messageData.Messages[0].Offset
 
 		// 2. Replicate to followers if acks != 0
 		if acksLower != "0" {
@@ -152,13 +155,11 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 
 			err = ch.Cluster.ReplicateToFollowers(topicName, partition, messageData, minISR)
 			if err != nil {
-				return ch.errorResponse(fmt.Sprintf("replication failed: %v", err))
+				// Roll back HWM so consumers don't see unreplicated messages
+				p.SetHWM(prevHWM)
+				return ch.errorResponse(fmt.Sprintf("replication failed (offset=%d): %v", assignedOffset, err))
 			}
 		}
-
-		// 3. Update HWM and LEO locally
-		p.SetHWM(assignedOffset + 1)
-		p.UpdateLEO(assignedOffset + 1)
 
 		ackResp = types.AckResponse{
 			Status:        "OK",
@@ -193,7 +194,7 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 	}
 
 Respond:
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if leader := ch.Cluster.RaftManager.GetLeaderAddress(); leader != "" {
 			ackResp.Leader = leader
 		}
@@ -230,13 +231,14 @@ func (ch *CommandHandler) handleReplicateMessage(cmd string) string {
 		return fmt.Sprintf("ERROR: partition %d not found", msgCmd.Partition)
 	}
 
+	// Guard against empty messages to prevent index-out-of-range panic
+	if len(msgCmd.Messages) == 0 {
+		return "ERROR: empty messages in replicate command"
+	}
+
 	if err := p.EnqueueBatch(msgCmd.Messages); err != nil {
 		return fmt.Sprintf("ERROR: enqueue failed: %v", err)
 	}
-
-	lastMsg := msgCmd.Messages[len(msgCmd.Messages)-1]
-	p.SetHWM(lastMsg.Offset + 1)
-	p.UpdateLEO(lastMsg.Offset + 1)
 
 	return "OK"
 }
@@ -308,19 +310,19 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 			return fmt.Sprintf("ERROR: PARTITION_NOT_FOUND %d", batch.Partition), nil
 		}
 
-		batchSize := len(batch.Messages)
-		startOffset := p.ReserveOffsets(batchSize)
-		for i := range batch.Messages {
-			batch.Messages[i].Offset = startOffset + uint64(i)
-		}
-
 		effectiveIdempotent := batch.IsIdempotent || ch.Config.EnableIdempotence
 		scope := "global"
 
-		// 1. Append locally
+		// Save HWM before enqueue so we can roll back on replication failure
+		prevHWM := p.GetHWM()
+
+		// 1. Append locally (EnqueueBatch assigns offsets and updates LEO/HWM internally)
 		if err := p.EnqueueBatch(batch.Messages); err != nil {
 			return ch.errorResponse(fmt.Sprintf("failed to append batch locally: %v", err)), nil
 		}
+
+		// Read offsets assigned by EnqueueBatch
+		lastOffset := batch.Messages[len(batch.Messages)-1].Offset
 
 		// 2. Replicate to followers if acks != 0
 		if acksLower != "0" {
@@ -340,14 +342,11 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 
 			err = ch.Cluster.ReplicateToFollowers(batch.Topic, batch.Partition, msgCmd, minISR)
 			if err != nil {
-				return ch.errorResponse(fmt.Sprintf("batch replication failed: %v", err)), nil
+				// Roll back HWM so consumers don't see unreplicated messages
+				p.SetHWM(prevHWM)
+				return ch.errorResponse(fmt.Sprintf("batch replication failed (offset=%d): %v", lastOffset, err)), nil
 			}
 		}
-
-		// 3. Update HWM and LEO locally
-		lastOffset := batch.Messages[len(batch.Messages)-1].Offset
-		p.SetHWM(lastOffset + 1)
-		p.UpdateLEO(lastOffset + 1)
 
 		respAck = types.AckResponse{
 			Status:        "OK",
@@ -389,7 +388,7 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 	}
 
 Respond:
-	if ch.Config.EnabledDistribution && ch.Cluster != nil && ch.Cluster.RaftManager != nil {
+	if ch.isDistributed() {
 		if leader := ch.Cluster.RaftManager.GetLeaderAddress(); leader != "" {
 			respAck.Leader = leader
 		}

--- a/pkg/controller/produce_handler.go
+++ b/pkg/controller/produce_handler.go
@@ -310,6 +310,10 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 			return fmt.Sprintf("ERROR: PARTITION_NOT_FOUND %d", batch.Partition), nil
 		}
 
+		if len(batch.Messages) == 0 {
+			return ch.errorResponse("empty batch messages"), nil
+		}
+
 		effectiveIdempotent := batch.IsIdempotent || ch.Config.EnableIdempotence
 		scope := "global"
 

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -263,7 +263,7 @@ func (c *Coordinator) getGroupSafe(name string) *GroupMetadata {
 }
 
 // getOffsetSafe reads an offset from the group's per-group offset map.
-// Caller must hold at least gm.mu.RLock.
+// GUARDED_BY(gm.mu) — caller must hold at least gm.mu.RLock.
 func (gm *GroupMetadata) getOffsetSafe(topic string, partition int) (uint64, bool) {
 	if partitions, ok := gm.Offsets[topic]; ok {
 		if offset, ok := partitions[partition]; ok {
@@ -274,7 +274,7 @@ func (gm *GroupMetadata) getOffsetSafe(topic string, partition int) (uint64, boo
 }
 
 // storeOffset writes an offset into the group's per-group offset map.
-// Caller must hold gm.mu.Lock.
+// GUARDED_BY(gm.mu) — caller must hold gm.mu.Lock (exclusive).
 func (gm *GroupMetadata) storeOffset(topic string, partition int, offset uint64) {
 	if gm.Offsets == nil {
 		gm.Offsets = make(map[string]map[int]uint64)

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -15,13 +16,12 @@ type Coordinator struct {
 	groups map[string]*GroupMetadata // All consumer groups
 	mu     sync.RWMutex              // Global lock for coordinator state
 	cfg    *config.Config            // Configuration reference
-	stopCh chan struct{}
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	topicHandler              TopicHandler
 	offsetTopic               string
 	offsetTopicPartitionCount int
-
-	offsets map[string]map[string]map[int]uint64 // group -> topic -> partition -> offset
 
 	// ensure only the active GroupCoordinator handles session expiration.
 	leaderChecker func() bool
@@ -29,16 +29,18 @@ type Coordinator struct {
 
 type TopicHandler interface {
 	Publish(topic string, msg *types.Message) error
-	CreateTopic(topic string, partitionCount int, idempotent bool) error
+	CreateTopic(topic string, partitionCount int, idempotent bool, eventSourcing bool) error
 }
 
 // GroupMetadata holds metadata for a single consumer group.
 type GroupMetadata struct {
+	mu            sync.RWMutex               // Per-group lock for offset operations
 	TopicName     string                     // Topic this group consumes
 	Members       map[string]*MemberMetadata // Active members
 	Generation    int                        // Current generation (unused but reserved)
 	Partitions    []int                      // All partitions of the topic
 	LastRebalance time.Time                  // Timestamp of last rebalance
+	Offsets       map[string]map[int]uint64  // topic -> partition -> offset
 }
 
 // MemberMetadata holds state for a single consumer instance.
@@ -87,22 +89,25 @@ type BulkOffsetMsg struct {
 }
 
 // NewCoordinator creates a new Coordinator instance.
-func NewCoordinator(cfg *config.Config, handler TopicHandler) *Coordinator {
+// The provided ctx controls the lifetime of background goroutines (e.g., heartbeat monitor).
+func NewCoordinator(ctx context.Context, cfg *config.Config, handler TopicHandler) *Coordinator {
 	if handler == nil {
 		util.Fatal("Coordinator requires a non-nil TopicHandler")
 	}
 
+	childCtx, cancel := context.WithCancel(ctx)
+
 	c := &Coordinator{
 		groups:                    make(map[string]*GroupMetadata),
 		cfg:                       cfg,
-		stopCh:                    make(chan struct{}),
+		ctx:                       childCtx,
+		cancel:                    cancel,
 		topicHandler:              handler,
 		offsetTopic:               "__consumer_offsets",
 		offsetTopicPartitionCount: 4, // init. dynamic
-		offsets:                   make(map[string]map[string]map[int]uint64),
 	}
 
-	if err := handler.CreateTopic(c.offsetTopic, c.offsetTopicPartitionCount, false); err != nil {
+	if err := handler.CreateTopic(c.offsetTopic, c.offsetTopicPartitionCount, false, false); err != nil {
 		util.Error("Coordinator: failed to create offset topic '%s': %v", c.offsetTopic, err)
 	}
 	return c
@@ -119,9 +124,9 @@ func (c *Coordinator) Start() {
 	go c.monitorHeartbeats()
 }
 
-// Stop launches background monitoring processes (graceful shutdown)
+// Stop cancels the coordinator context, shutting down all background goroutines.
 func (c *Coordinator) Stop() {
-	close(c.stopCh)
+	c.cancel()
 }
 
 // GetAssignments returns the current partition assignments for each group member.
@@ -250,13 +255,32 @@ func contains(slice []int, item int) bool {
 	return false
 }
 
-func (c *Coordinator) getOffsetSafe(group, topic string, partition int) (uint64, bool) {
-	if topics, ok := c.offsets[group]; ok {
-		if partitions, ok := topics[topic]; ok {
-			if offset, ok := partitions[partition]; ok {
-				return offset, true
-			}
+// getGroupSafe returns the GroupMetadata for the given name under the global read lock.
+func (c *Coordinator) getGroupSafe(name string) *GroupMetadata {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.groups[name]
+}
+
+// getOffsetSafe reads an offset from the group's per-group offset map.
+// Caller must hold at least gm.mu.RLock.
+func (gm *GroupMetadata) getOffsetSafe(topic string, partition int) (uint64, bool) {
+	if partitions, ok := gm.Offsets[topic]; ok {
+		if offset, ok := partitions[partition]; ok {
+			return offset, true
 		}
 	}
 	return 0, false
+}
+
+// storeOffset writes an offset into the group's per-group offset map.
+// Caller must hold gm.mu.Lock.
+func (gm *GroupMetadata) storeOffset(topic string, partition int, offset uint64) {
+	if gm.Offsets == nil {
+		gm.Offsets = make(map[string]map[int]uint64)
+	}
+	if _, ok := gm.Offsets[topic]; !ok {
+		gm.Offsets[topic] = make(map[int]uint64)
+	}
+	gm.Offsets[topic][partition] = offset
 }

--- a/pkg/coordinator/coordinator_ext_test.go
+++ b/pkg/coordinator/coordinator_ext_test.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cursus-io/cursus/pkg/config"
@@ -9,7 +10,7 @@ import (
 
 func TestCoordinator_StatusAndList(t *testing.T) {
 	cfg := &config.Config{}
-	c := NewCoordinator(cfg, &DummyPublisher{})
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 
 	_ = c.RegisterGroup("topic1", "group1", 4)
 	_, _ = c.AddConsumer("group1", "c1")
@@ -41,7 +42,7 @@ func TestCoordinator_StatusAndList(t *testing.T) {
 
 func TestCoordinator_Offsets(t *testing.T) {
 	cfg := &config.Config{}
-	c := NewCoordinator(cfg, &DummyPublisher{})
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 
 	_ = c.RegisterGroup("topic1", "group1", 2)
 
@@ -88,7 +89,7 @@ func TestCoordinator_Offsets(t *testing.T) {
 
 func TestCoordinator_MemberAssignments(t *testing.T) {
 	cfg := &config.Config{}
-	c := NewCoordinator(cfg, &DummyPublisher{})
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 
 	_ = c.RegisterGroup("t1", "g1", 2)
 	_, _ = c.AddConsumer("g1", "m1")

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -13,21 +13,11 @@ func calculateOffsetPartitionCount(groupCount int) int {
 	return min(max(groupCount/10, 4), 50)
 }
 
-func (c *Coordinator) storeOffsetInMemory(group, topic string, partition int, offset uint64) {
-	if _, ok := c.offsets[group]; !ok {
-		c.offsets[group] = make(map[string]map[int]uint64)
-	}
-	if _, ok := c.offsets[group][topic]; !ok {
-		c.offsets[group][topic] = make(map[int]uint64)
-	}
-	c.offsets[group][topic][partition] = offset
-}
-
-func (c *Coordinator) CommitOffset(group, topic string, partition int, offset uint64) error {
-	util.Debug("Committing offset: group='%s', topic='%s', partition=%d, offset=%d", group, topic, partition, offset)
+func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offset uint64) error {
+	util.Debug("Committing offset: group='%s', topic='%s', partition=%d, offset=%d", groupName, topic, partition, offset)
 
 	offsetMsg := OffsetCommitMessage{
-		Group:     group,
+		Group:     groupName,
 		Topic:     topic,
 		Partition: partition,
 		Offset:    offset,
@@ -42,24 +32,30 @@ func (c *Coordinator) CommitOffset(group, topic string, partition int, offset ui
 	if err := c.topicHandler.Publish(c.offsetTopic, &types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
-		Key:        fmt.Sprintf("%s-%s-%d", group, topic, partition),
+		Key:        fmt.Sprintf("%s-%s-%d", groupName, topic, partition),
 	}); err != nil {
 		return err
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.storeOffsetInMemory(group, topic, partition, offset)
+	gm := c.getGroupSafe(groupName)
+	if gm == nil {
+		return fmt.Errorf("group '%s' not found", groupName)
+	}
+
+	gm.mu.Lock()
+	gm.storeOffset(topic, partition, offset)
+	gm.mu.Unlock()
+
 	return nil
 }
 
-func (c *Coordinator) CommitOffsetsBulk(group, topic string, offsets []OffsetItem) error {
+func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []OffsetItem) error {
 	if len(offsets) == 0 {
 		return nil
 	}
 
 	bulkMsg := BulkOffsetMsg{
-		Group:     group,
+		Group:     groupName,
 		Topic:     topic,
 		Offsets:   offsets,
 		Timestamp: time.Now(),
@@ -73,47 +69,65 @@ func (c *Coordinator) CommitOffsetsBulk(group, topic string, offsets []OffsetIte
 	if err := c.topicHandler.Publish(c.offsetTopic, &types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
-		Key:        fmt.Sprintf("%s-%s-bulk", group, topic),
+		Key:        fmt.Sprintf("%s-%s-bulk", groupName, topic),
 	}); err != nil {
 		return err
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for _, item := range offsets {
-		c.storeOffsetInMemory(group, topic, item.Partition, item.Offset)
+	gm := c.getGroupSafe(groupName)
+	if gm == nil {
+		return fmt.Errorf("group '%s' not found", groupName)
 	}
+
+	gm.mu.Lock()
+	for _, item := range offsets {
+		gm.storeOffset(topic, item.Partition, item.Offset)
+	}
+	gm.mu.Unlock()
 
 	return nil
 }
 
-func (c *Coordinator) ApplyOffsetUpdateFromFSM(group, topic string, offsets []OffsetItem) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if group == "" || topic == "" {
+func (c *Coordinator) ApplyOffsetUpdateFromFSM(groupName, topic string, offsets []OffsetItem) error {
+	if groupName == "" || topic == "" {
 		return fmt.Errorf("invalid group or topic name")
 	}
 
-	if _, ok := c.offsets[group]; !ok {
-		c.offsets[group] = make(map[string]map[int]uint64)
+	// FSM replay may arrive before RegisterGroup, so we need to get-or-create.
+	c.mu.Lock()
+	gm, ok := c.groups[groupName]
+	if !ok {
+		gm = &GroupMetadata{
+			Offsets: make(map[string]map[int]uint64),
+		}
+		c.groups[groupName] = gm
 	}
-	if _, ok := c.offsets[group][topic]; !ok {
-		c.offsets[group][topic] = make(map[int]uint64)
-	}
+	c.mu.Unlock()
 
-	for _, item := range offsets {
-		c.offsets[group][topic][item.Partition] = item.Offset
+	gm.mu.Lock()
+	if gm.Offsets == nil {
+		gm.Offsets = make(map[string]map[int]uint64)
 	}
+	if _, exists := gm.Offsets[topic]; !exists {
+		gm.Offsets[topic] = make(map[int]uint64)
+	}
+	for _, item := range offsets {
+		gm.Offsets[topic][item.Partition] = item.Offset
+	}
+	gm.mu.Unlock()
 
 	return nil
 }
 
-func (c *Coordinator) GetOffset(group, topic string, partition int) (uint64, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.getOffsetSafe(group, topic, partition)
+func (c *Coordinator) GetOffset(groupName, topic string, partition int) (uint64, bool) {
+	gm := c.getGroupSafe(groupName)
+	if gm == nil {
+		return 0, false
+	}
+
+	gm.mu.RLock()
+	defer gm.mu.RUnlock()
+	return gm.getOffsetSafe(topic, partition)
 }
 
 // updateOffsetPartitionCount updates the number of partitions for the internal offset topic.
@@ -134,7 +148,7 @@ func (c *Coordinator) updateOffsetPartitionCount() {
 	c.mu.Unlock()
 
 	go func() {
-		if err := c.topicHandler.CreateTopic(topicName, newCount, false); err != nil {
+		if err := c.topicHandler.CreateTopic(topicName, newCount, false, false); err != nil {
 			util.Error("Failed to scale offset topic '%s' to %d partitions: %v", topicName, newCount, err)
 			return
 		}
@@ -143,6 +157,7 @@ func (c *Coordinator) updateOffsetPartitionCount() {
 }
 
 func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, offset uint64, generation int, memberID string) error {
+	// Validate membership under global lock (membership is managed globally)
 	c.mu.RLock()
 	group := c.groups[groupName]
 
@@ -160,6 +175,12 @@ func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, 
 	}
 	c.mu.RUnlock()
 
+	// Store offset under per-group lock
+	group.mu.Lock()
+	prevOffset, hadPrev := group.getOffsetSafe(topic, partition)
+	group.storeOffset(topic, partition, offset)
+	group.mu.Unlock()
+
 	offsetMsg := OffsetCommitMessage{
 		Group:     groupName,
 		Topic:     topic,
@@ -170,6 +191,7 @@ func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, 
 
 	payload, err := json.Marshal(offsetMsg)
 	if err != nil {
+		c.rollbackOffset(group, topic, partition, prevOffset, hadPrev)
 		return fmt.Errorf("failed to marshal offset: %w", err)
 	}
 
@@ -180,20 +202,21 @@ func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, 
 	})
 
 	if err != nil {
+		c.rollbackOffset(group, topic, partition, prevOffset, hadPrev)
 		return fmt.Errorf("failed to publish offset: %w", err)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	return nil
+}
 
-	g, ok := c.groups[groupName]
-	if ok && g.Generation == generation {
-		c.storeOffsetInMemory(groupName, topic, partition, offset)
-		return nil
+func (c *Coordinator) rollbackOffset(gm *GroupMetadata, topic string, partition int, prevOffset uint64, hadPrev bool) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+	if hadPrev {
+		gm.storeOffset(topic, partition, prevOffset)
+	} else if partitions, ok := gm.Offsets[topic]; ok {
+		delete(partitions, partition)
 	}
-
-	util.Warn("offset published but not stored in memory: Generation changed (%d -> %d) for group %s", generation, g.Generation, groupName)
-	return fmt.Errorf("generation changed during commit")
 }
 
 func (c *Coordinator) getGroupUnsafe(name string) *GroupMetadata {

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -16,6 +16,11 @@ func calculateOffsetPartitionCount(groupCount int) int {
 func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offset uint64) error {
 	util.Debug("Committing offset: group='%s', topic='%s', partition=%d, offset=%d", groupName, topic, partition, offset)
 
+	gm := c.getGroupSafe(groupName)
+	if gm == nil {
+		return fmt.Errorf("group '%s' not found", groupName)
+	}
+
 	offsetMsg := OffsetCommitMessage{
 		Group:     groupName,
 		Topic:     topic,
@@ -37,11 +42,6 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 		return err
 	}
 
-	gm := c.getGroupSafe(groupName)
-	if gm == nil {
-		return fmt.Errorf("group '%s' not found", groupName)
-	}
-
 	gm.mu.Lock()
 	gm.storeOffset(topic, partition, offset)
 	gm.mu.Unlock()
@@ -52,6 +52,11 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []OffsetItem) error {
 	if len(offsets) == 0 {
 		return nil
+	}
+
+	gm := c.getGroupSafe(groupName)
+	if gm == nil {
+		return fmt.Errorf("group '%s' not found", groupName)
 	}
 
 	bulkMsg := BulkOffsetMsg{
@@ -72,11 +77,6 @@ func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []Offse
 		Key:        fmt.Sprintf("%s-%s-bulk", groupName, topic),
 	}); err != nil {
 		return err
-	}
-
-	gm := c.getGroupSafe(groupName)
-	if gm == nil {
-		return fmt.Errorf("group '%s' not found", groupName)
 	}
 
 	gm.mu.Lock()

--- a/pkg/coordinator/coordinator_test.go
+++ b/pkg/coordinator/coordinator_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestCoordinator_Register_Add_Remove(t *testing.T) {
 	cfg := &config.Config{ConsumerSessionTimeoutMS: 30000, ConsumerHeartbeatCheckMS: 5000}
-	c := coordinator.NewCoordinator(context.Background(), cfg, &coordinator.DummyPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := coordinator.NewCoordinator(ctx, cfg, &coordinator.DummyPublisher{})
+	defer c.Stop()
 
 	err := c.RegisterGroup("orders", "groupA", 3)
 	if err != nil {

--- a/pkg/coordinator/coordinator_test.go
+++ b/pkg/coordinator/coordinator_test.go
@@ -1,6 +1,7 @@
 package coordinator_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cursus-io/cursus/pkg/config"
@@ -9,7 +10,7 @@ import (
 
 func TestCoordinator_Register_Add_Remove(t *testing.T) {
 	cfg := &config.Config{ConsumerSessionTimeoutMS: 30000, ConsumerHeartbeatCheckMS: 5000}
-	c := coordinator.NewCoordinator(cfg, &coordinator.DummyPublisher{})
+	c := coordinator.NewCoordinator(context.Background(), cfg, &coordinator.DummyPublisher{})
 
 	err := c.RegisterGroup("orders", "groupA", 3)
 	if err != nil {

--- a/pkg/coordinator/heartbeat.go
+++ b/pkg/coordinator/heartbeat.go
@@ -22,7 +22,7 @@ func (c *Coordinator) monitorHeartbeats() {
 				}
 			}
 			c.checkAllGroupsTimeout()
-		case <-c.stopCh:
+		case <-c.ctx.Done():
 			return
 		}
 	}
@@ -60,15 +60,14 @@ func (c *Coordinator) checkSingleGroupTimeout(groupName string, timeout time.Dur
 		}
 	}
 
-	hasChanges := len(timedOutMembers) > 0
-	if hasChanges {
+	if len(timedOutMembers) > 0 {
 		group.Generation++
+		c.rebalanceRange(groupName)
 	}
 	c.mu.Unlock()
 
-	if hasChanges {
-		util.Warn("⚠️ Group '%s': %d members timed out. Triggering rebalance.", groupName, len(timedOutMembers))
-		c.triggerRebalance(groupName)
+	if len(timedOutMembers) > 0 {
+		util.Warn("⚠️ Group '%s': %d members timed out. Triggered rebalance.", groupName, len(timedOutMembers))
 	}
 }
 
@@ -92,9 +91,4 @@ func (c *Coordinator) RecordHeartbeat(groupName, consumerID string) error {
 
 	util.Info("💓 Heartbeat from %s/%s", groupName, consumerID)
 	return nil
-}
-
-// triggerRebalance invokes the range-based rebalance strategy.
-func (c *Coordinator) triggerRebalance(groupName string) {
-	c.rebalanceRange(groupName)
 }

--- a/pkg/coordinator/rebalancer.go
+++ b/pkg/coordinator/rebalancer.go
@@ -34,6 +34,7 @@ func (c *Coordinator) RegisterGroup(topicName, groupName string, partitionCount 
 		TopicName:  topicName,
 		Members:    make(map[string]*MemberMetadata),
 		Partitions: partitions,
+		Offsets:    make(map[string]map[int]uint64),
 	}
 	c.mu.Unlock()
 
@@ -132,7 +133,9 @@ func (c *Coordinator) rebalanceRange(groupName string) {
 			if end > pCount {
 				end = pCount
 			}
-			newAssignments = group.Partitions[partitionIdx:end]
+			// Copy the slice to avoid sharing the backing array with group.Partitions
+			newAssignments = make([]int, end-partitionIdx)
+			copy(newAssignments, group.Partitions[partitionIdx:end])
 		}
 
 		group.Members[memberID].Assignments = newAssignments

--- a/pkg/coordinator/rebalancer_test.go
+++ b/pkg/coordinator/rebalancer_test.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -13,7 +14,7 @@ type DummyPublisher struct{}
 func (d *DummyPublisher) Publish(topic string, msg *types.Message) error {
 	return nil
 }
-func (d *DummyPublisher) CreateTopic(topic string, partitionCount int, idempotent bool) error {
+func (d *DummyPublisher) CreateTopic(topic string, partitionCount int, idempotent bool, eventSourcing bool) error {
 	return nil
 }
 
@@ -21,7 +22,7 @@ func TestRebalanceRange_AssignsPartitionsEvenly(t *testing.T) {
 	cfg := &config.Config{
 		ConsumerSessionTimeoutMS: 30000,
 	}
-	c := NewCoordinator(cfg, &DummyPublisher{})
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 
 	groupName := "group1"
 	partitionCount := 5
@@ -56,7 +57,7 @@ func TestRebalanceRange_AssignsPartitionsEvenly(t *testing.T) {
 
 func TestRebalanceRange_NoMembers(t *testing.T) {
 	cfg := &config.Config{}
-	c := NewCoordinator(cfg, &DummyPublisher{})
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 
 	groupName := "groupEmpty"
 	if err := c.RegisterGroup("topicX", groupName, 3); err != nil {
@@ -68,7 +69,7 @@ func TestRebalanceRange_NoMembers(t *testing.T) {
 
 func TestRebalanceRange_MoreMembersThanPartitions(t *testing.T) {
 	cfg := &config.Config{}
-	c := NewCoordinator(cfg, &DummyPublisher{})
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
 
 	groupName := "group2"
 	if err := c.RegisterGroup("topicY", groupName, 2); err != nil {

--- a/pkg/disk/flush_common.go
+++ b/pkg/disk/flush_common.go
@@ -1,8 +1,10 @@
 package disk
 
 import (
+	"bufio"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -357,12 +359,25 @@ func (d *DiskHandler) rotateSegment(nextBaseOffset uint64) error {
 	return d.openIndexFiles()
 }
 
+// openSegment opens or creates the current segment file for writing.
+func (d *DiskHandler) openSegment() error {
+	flags := os.O_CREATE | os.O_RDWR | os.O_APPEND
+	filePath := d.GetSegmentPath(d.CurrentSegment)
+
+	f, err := os.OpenFile(filePath, flags, 0644)
+	if err != nil {
+		return err
+	}
+	d.file = f
+	d.writer = bufio.NewWriter(f)
+	return nil
+}
+
 // Flush forces all pending data to be written and synced to disk.
 func (d *DiskHandler) Flush() {
-	pendingLen := len(d.writeCh)
-	batch := make([]types.DiskMessage, 0, pendingLen)
+	batch := make([]types.DiskMessage, 0, d.batchSize)
 
-	for range len(d.writeCh) {
+	for {
 		select {
 		case msg := <-d.writeCh:
 			batch = append(batch, msg)

--- a/pkg/disk/flush_common.go
+++ b/pkg/disk/flush_common.go
@@ -377,9 +377,12 @@ func (d *DiskHandler) openSegment() error {
 func (d *DiskHandler) Flush() {
 	batch := make([]types.DiskMessage, 0, d.batchSize)
 
-	for {
+	for len(batch) < d.batchSize {
 		select {
-		case msg := <-d.writeCh:
+		case msg, ok := <-d.writeCh:
+			if !ok {
+				goto perform_write
+			}
 			batch = append(batch, msg)
 		default:
 			goto perform_write
@@ -392,7 +395,6 @@ perform_write:
 			util.Error("Flush write failed: %v", err)
 			return
 		}
-		return
 	}
 
 	d.ioMu.Lock()

--- a/pkg/disk/flush_default.go
+++ b/pkg/disk/flush_default.go
@@ -1,28 +1,12 @@
-//go:build windows
-// +build windows
+//go:build !linux
 
 package disk
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"net"
-	"os"
 )
-
-func (d *DiskHandler) openSegment() error {
-	flags := os.O_CREATE | os.O_RDWR | os.O_APPEND
-	filePath := d.GetSegmentPath(d.CurrentSegment)
-
-	f, err := os.OpenFile(filePath, flags, 0644)
-	if err != nil {
-		return err
-	}
-	d.file = f
-	d.writer = bufio.NewWriter(f)
-	return nil
-}
 
 func (d *DiskHandler) SendCurrentSegmentToConn(conn net.Conn) (int, error) {
 	d.mu.Lock()

--- a/pkg/disk/flush_linux.go
+++ b/pkg/disk/flush_linux.go
@@ -4,31 +4,13 @@
 package disk
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"net"
-	"os"
 
 	"github.com/cursus-io/cursus/util"
 	"golang.org/x/sys/unix"
 )
-
-func (d *DiskHandler) openSegment() error {
-	flags := os.O_CREATE | os.O_RDWR | os.O_APPEND
-	filePath := d.GetSegmentPath(d.CurrentSegment)
-
-	f, err := os.OpenFile(filePath, flags, 0644)
-	if err != nil {
-		return err
-	}
-	d.file = f
-	d.writer = bufio.NewWriter(f)
-
-	// sequential access hint
-	_ = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_SEQUENTIAL)
-	return nil
-}
 
 func (d *DiskHandler) SendCurrentSegmentToConn(conn net.Conn) (int, error) {
 	d.mu.Lock()

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -224,10 +224,7 @@ func countMessagesInFile(filePath string) (int, error) {
 }
 
 func (d *DiskHandler) AppendMessageSync(topic string, partition int, msg *types.Message) (uint64, error) {
-	d.mu.Lock()
-	offset := d.AbsoluteOffset
-	d.AbsoluteOffset++
-	d.mu.Unlock()
+	offset := atomic.AddUint64(&d.AbsoluteOffset, 1) - 1
 
 	msg.Offset = offset
 	if err := d.WriteDirect(topic, partition, *msg); err != nil {
@@ -238,10 +235,7 @@ func (d *DiskHandler) AppendMessageSync(topic string, partition int, msg *types.
 
 // AppendMessage sends a message to the internal write channel for asynchronous disk persistence.
 func (d *DiskHandler) AppendMessage(topic string, partition int, msg *types.Message) (uint64, error) {
-	d.mu.Lock()
-	offset := d.AbsoluteOffset
-	d.AbsoluteOffset++
-	d.mu.Unlock()
+	offset := atomic.AddUint64(&d.AbsoluteOffset, 1) - 1
 
 	msg.Offset = offset
 	diskMsg := types.DiskMessage{

--- a/pkg/eventsource/handler.go
+++ b/pkg/eventsource/handler.go
@@ -158,23 +158,26 @@ func (h *Handler) HandleAppendStream(cmd string) string {
 		return fmt.Sprintf("ERROR: %v", err)
 	}
 
-	// EnqueueSync acquires p.mu.Lock internally.
-	if err := p.EnqueueSync(msg); err != nil {
-		return fmt.Sprintf("ERROR: enqueue failed: %v", err)
-	}
-
-	// Atomically check version and append index entry.
-	// This prevents two concurrent requests from both passing the version check.
-	offset := p.NextOffset() - 1
-	ok, current, err := idx.CheckAndAppend(key, expectedVersion, offset, 0)
+	// Atomically: check version, enqueue message, and append index entry.
+	// Holding the index lock across all three prevents concurrent requests
+	// from interleaving between the version check and the append.
+	var appendedOffset uint64
+	ok, current, err := idx.CheckEnqueueAndAppend(key, expectedVersion, func() (uint64, error) {
+		if err := p.EnqueueSync(msg); err != nil {
+			return 0, err
+		}
+		offset := p.NextOffset() - 1
+		appendedOffset = offset
+		return offset, nil
+	})
 	if err != nil {
-		return fmt.Sprintf("ERROR: index append failed: %v", err)
+		return fmt.Sprintf("ERROR: %v", err)
 	}
 	if !ok {
 		return fmt.Sprintf("ERROR: version_conflict current=%d expected=%d", current, expectedVersion)
 	}
 
-	return fmt.Sprintf("OK version=%d offset=%d partition=%d", expectedVersion, offset, partitionID)
+	return fmt.Sprintf("OK version=%d offset=%d partition=%d", expectedVersion, appendedOffset, partitionID)
 }
 
 // HandleReadStream writes event data directly to conn.
@@ -203,6 +206,10 @@ func (h *Handler) HandleReadStream(cmd string, conn net.Conn) {
 	t := h.tm.GetTopic(topicName)
 	if t == nil {
 		writeError(conn, fmt.Sprintf("topic '%s' does not exist", topicName))
+		return
+	}
+	if !t.IsEventSourcing {
+		writeError(conn, fmt.Sprintf("topic '%s' is not event-sourcing enabled", topicName))
 		return
 	}
 
@@ -332,6 +339,9 @@ func (h *Handler) HandleSaveSnapshot(cmd string) string {
 	if t == nil {
 		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
 	}
+	if !t.IsEventSourcing {
+		return fmt.Sprintf("ERROR: topic '%s' is not event-sourcing enabled", topicName)
+	}
 
 	partitionID := t.GetPartitionForMessage(types.Message{Key: key})
 	if partitionID < 0 {
@@ -379,6 +389,9 @@ func (h *Handler) HandleReadSnapshot(cmd string) string {
 	if t == nil {
 		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
 	}
+	if !t.IsEventSourcing {
+		return fmt.Sprintf("ERROR: topic '%s' is not event-sourcing enabled", topicName)
+	}
 
 	partitionID := t.GetPartitionForMessage(types.Message{Key: key})
 	if partitionID < 0 {
@@ -423,6 +436,9 @@ func (h *Handler) HandleStreamVersion(cmd string) string {
 	t := h.tm.GetTopic(topicName)
 	if t == nil {
 		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
+	}
+	if !t.IsEventSourcing {
+		return fmt.Sprintf("ERROR: topic '%s' is not event-sourcing enabled", topicName)
 	}
 
 	partitionID := t.GetPartitionForMessage(types.Message{Key: key})

--- a/pkg/eventsource/handler.go
+++ b/pkg/eventsource/handler.go
@@ -1,0 +1,475 @@
+package eventsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
+)
+
+// Handler processes event sourcing commands (APPEND_STREAM, READ_STREAM, etc.).
+type Handler struct {
+	tm *topic.TopicManager
+
+	mu        sync.RWMutex
+	indexes   map[string]*StreamIndex   // key: "topic:partition"
+	snapshots map[string]*SnapshotStore // key: "topic:partition"
+}
+
+// NewHandler creates a new event sourcing command handler.
+func NewHandler(tm *topic.TopicManager) *Handler {
+	return &Handler{
+		tm:        tm,
+		indexes:   make(map[string]*StreamIndex),
+		snapshots: make(map[string]*SnapshotStore),
+	}
+}
+
+// getIndex returns the StreamIndex for the given topic and partition, creating it lazily.
+func (h *Handler) getIndex(topicName string, partitionID int) (*StreamIndex, error) {
+	key := fmt.Sprintf("%s:%d", topicName, partitionID)
+
+	h.mu.RLock()
+	idx, ok := h.indexes[key]
+	h.mu.RUnlock()
+	if ok {
+		return idx, nil
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if idx, ok := h.indexes[key]; ok {
+		return idx, nil
+	}
+
+	dir := h.tm.GetLogDir(topicName, partitionID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("create dir for stream index %s:%d: %w", topicName, partitionID, err)
+	}
+	idx, err := NewStreamIndex(dir, partitionID)
+	if err != nil {
+		return nil, fmt.Errorf("open stream index for %s:%d: %w", topicName, partitionID, err)
+	}
+	h.indexes[key] = idx
+	return idx, nil
+}
+
+// getSnapshot returns the SnapshotStore for the given topic and partition, creating it lazily.
+func (h *Handler) getSnapshot(topicName string, partitionID int) (*SnapshotStore, error) {
+	key := fmt.Sprintf("%s:%d", topicName, partitionID)
+
+	h.mu.RLock()
+	ss, ok := h.snapshots[key]
+	h.mu.RUnlock()
+	if ok {
+		return ss, nil
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if ss, ok := h.snapshots[key]; ok {
+		return ss, nil
+	}
+
+	dir := h.tm.GetLogDir(topicName, partitionID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("create dir for snapshot store %s:%d: %w", topicName, partitionID, err)
+	}
+	ss, err := NewSnapshotStore(dir, partitionID)
+	if err != nil {
+		return nil, fmt.Errorf("open snapshot store for %s:%d: %w", topicName, partitionID, err)
+	}
+	h.snapshots[key] = ss
+	return ss, nil
+}
+
+// HandleAppendStream processes:
+//
+//	APPEND_STREAM topic=<name> key=<aggregate_key> version=<expected> event_type=<type> message=<payload>
+func (h *Handler) HandleAppendStream(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("APPEND_STREAM "):])
+
+	topicName := args["topic"]
+	if topicName == "" {
+		return "ERROR: missing topic parameter"
+	}
+	key := args["key"]
+	if key == "" {
+		return "ERROR: missing key parameter"
+	}
+	versionStr := args["version"]
+	if versionStr == "" {
+		return "ERROR: missing version parameter"
+	}
+	expectedVersion, err := strconv.ParseUint(versionStr, 10, 64)
+	if err != nil {
+		return "ERROR: invalid version"
+	}
+	payload := args["message"]
+	if payload == "" {
+		return "ERROR: missing message parameter"
+	}
+
+	t := h.tm.GetTopic(topicName)
+	if t == nil {
+		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
+	}
+	if !t.IsEventSourcing {
+		return fmt.Sprintf("ERROR: topic '%s' is not event-sourcing enabled", topicName)
+	}
+
+	// Route to partition by key.
+	msg := types.Message{
+		Key:              key,
+		Payload:          payload,
+		EventType:        args["event_type"],
+		AggregateVersion: expectedVersion,
+		Metadata:         args["metadata"],
+	}
+	if svStr := args["schema_version"]; svStr != "" {
+		sv, err := strconv.ParseUint(svStr, 10, 32)
+		if err == nil {
+			msg.SchemaVersion = uint32(sv)
+		}
+	}
+
+	partitionID := t.GetPartitionForMessage(msg)
+	if partitionID < 0 {
+		return "ERROR: no partitions available"
+	}
+
+	p, err := t.GetPartition(partitionID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+
+	idx, err := h.getIndex(topicName, partitionID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+
+	// EnqueueSync acquires p.mu.Lock internally.
+	if err := p.EnqueueSync(msg); err != nil {
+		return fmt.Sprintf("ERROR: enqueue failed: %v", err)
+	}
+
+	// Atomically check version and append index entry.
+	// This prevents two concurrent requests from both passing the version check.
+	offset := p.NextOffset() - 1
+	ok, current, err := idx.CheckAndAppend(key, expectedVersion, offset, 0)
+	if err != nil {
+		return fmt.Sprintf("ERROR: index append failed: %v", err)
+	}
+	if !ok {
+		return fmt.Sprintf("ERROR: version_conflict current=%d expected=%d", current, expectedVersion)
+	}
+
+	return fmt.Sprintf("OK version=%d offset=%d partition=%d", expectedVersion, offset, partitionID)
+}
+
+// HandleReadStream writes event data directly to conn.
+// Protocol: two length-prefixed frames — JSON envelope + binary batch.
+func (h *Handler) HandleReadStream(cmd string, conn net.Conn) {
+	args := parseKeyValueArgs(cmd[len("READ_STREAM "):])
+
+	topicName := args["topic"]
+	if topicName == "" {
+		writeError(conn, "missing topic parameter")
+		return
+	}
+	key := args["key"]
+	if key == "" {
+		writeError(conn, "missing key parameter")
+		return
+	}
+	fromVersion := uint64(1)
+	if fv := args["from_version"]; fv != "" {
+		v, err := strconv.ParseUint(fv, 10, 64)
+		if err == nil {
+			fromVersion = v
+		}
+	}
+
+	t := h.tm.GetTopic(topicName)
+	if t == nil {
+		writeError(conn, fmt.Sprintf("topic '%s' does not exist", topicName))
+		return
+	}
+
+	// Determine the partition for this key.
+	partitionID := t.GetPartitionForMessage(types.Message{Key: key})
+	if partitionID < 0 {
+		writeError(conn, "no partitions available")
+		return
+	}
+
+	idx, err := h.getIndex(topicName, partitionID)
+	if err != nil {
+		writeError(conn, err.Error())
+		return
+	}
+
+	// Check snapshot: if one exists with version >= fromVersion, use it as base.
+	ss, err := h.getSnapshot(topicName, partitionID)
+	if err != nil {
+		writeError(conn, err.Error())
+		return
+	}
+
+	snap, err := ss.Read(key)
+	if err != nil {
+		writeError(conn, fmt.Sprintf("snapshot read error: %v", err))
+		return
+	}
+
+	actualFromVersion := fromVersion
+	if snap != nil && snap.Version >= fromVersion {
+		// Start reading from the version after the snapshot.
+		actualFromVersion = snap.Version + 1
+	}
+
+	entries, err := idx.Lookup(key, actualFromVersion)
+	if err != nil {
+		writeError(conn, fmt.Sprintf("index lookup error: %v", err))
+		return
+	}
+
+	p, err := t.GetPartition(partitionID)
+	if err != nil {
+		writeError(conn, err.Error())
+		return
+	}
+
+	// Collect messages from the partition for each index entry.
+	var msgs []types.Message
+	for _, entry := range entries {
+		batch, err := p.ReadMessages(entry.Offset, 1)
+		if err != nil {
+			writeError(conn, fmt.Sprintf("read error at offset %d: %v", entry.Offset, err))
+			return
+		}
+		if len(batch) > 0 {
+			msgs = append(msgs, batch[0])
+		}
+	}
+
+	// Build JSON envelope.
+	envelope := struct {
+		Topic     string        `json:"topic"`
+		Key       string        `json:"key"`
+		Partition int           `json:"partition"`
+		Count     int           `json:"count"`
+		Snapshot  *SnapshotData `json:"snapshot,omitempty"`
+	}{
+		Topic:     topicName,
+		Key:       key,
+		Partition: partitionID,
+		Count:     len(msgs),
+	}
+	if snap != nil && snap.Version >= fromVersion {
+		envelope.Snapshot = snap
+	}
+
+	envJSON, err := json.Marshal(envelope)
+	if err != nil {
+		writeError(conn, fmt.Sprintf("marshal envelope: %v", err))
+		return
+	}
+
+	// Frame 1: JSON envelope.
+	if err := util.WriteWithLength(conn, envJSON); err != nil {
+		return
+	}
+
+	// Frame 2: binary batch.
+	batchData, err := util.EncodeBatchMessages(topicName, partitionID, "1", false, msgs)
+	if err != nil {
+		// Envelope already sent; best effort write of empty batch.
+		_ = util.WriteWithLength(conn, []byte{})
+		return
+	}
+	_ = util.WriteWithLength(conn, batchData)
+}
+
+// HandleSaveSnapshot processes:
+//
+//	SAVE_SNAPSHOT topic=<name> key=<aggregate_key> version=<N> message=<json_payload>
+func (h *Handler) HandleSaveSnapshot(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("SAVE_SNAPSHOT "):])
+
+	topicName := args["topic"]
+	if topicName == "" {
+		return "ERROR: missing topic parameter"
+	}
+	key := args["key"]
+	if key == "" {
+		return "ERROR: missing key parameter"
+	}
+	versionStr := args["version"]
+	if versionStr == "" {
+		return "ERROR: missing version parameter"
+	}
+	version, err := strconv.ParseUint(versionStr, 10, 64)
+	if err != nil {
+		return "ERROR: invalid version"
+	}
+	payload := args["message"]
+	if payload == "" {
+		return "ERROR: missing message parameter"
+	}
+
+	t := h.tm.GetTopic(topicName)
+	if t == nil {
+		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
+	}
+
+	partitionID := t.GetPartitionForMessage(types.Message{Key: key})
+	if partitionID < 0 {
+		return "ERROR: no partitions available"
+	}
+
+	// Validate that version <= current stream version.
+	idx, err := h.getIndex(topicName, partitionID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+	currentVersion := idx.GetVersion(key)
+	if version > currentVersion {
+		return fmt.Sprintf("ERROR: snapshot version %d exceeds stream version %d", version, currentVersion)
+	}
+
+	ss, err := h.getSnapshot(topicName, partitionID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+
+	if err := ss.Save(key, version, payload); err != nil {
+		return fmt.Sprintf("ERROR: snapshot save failed: %v", err)
+	}
+
+	return fmt.Sprintf("OK version=%d partition=%d", version, partitionID)
+}
+
+// HandleReadSnapshot processes:
+//
+//	READ_SNAPSHOT topic=<name> key=<aggregate_key>
+func (h *Handler) HandleReadSnapshot(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("READ_SNAPSHOT "):])
+
+	topicName := args["topic"]
+	if topicName == "" {
+		return "ERROR: missing topic parameter"
+	}
+	key := args["key"]
+	if key == "" {
+		return "ERROR: missing key parameter"
+	}
+
+	t := h.tm.GetTopic(topicName)
+	if t == nil {
+		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
+	}
+
+	partitionID := t.GetPartitionForMessage(types.Message{Key: key})
+	if partitionID < 0 {
+		return "ERROR: no partitions available"
+	}
+
+	ss, err := h.getSnapshot(topicName, partitionID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+
+	snap, err := ss.Read(key)
+	if err != nil {
+		return fmt.Sprintf("ERROR: snapshot read failed: %v", err)
+	}
+	if snap == nil {
+		return "NULL"
+	}
+
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Sprintf("ERROR: marshal snapshot: %v", err)
+	}
+	return string(data)
+}
+
+// HandleStreamVersion processes:
+//
+//	STREAM_VERSION topic=<name> key=<aggregate_key>
+func (h *Handler) HandleStreamVersion(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("STREAM_VERSION "):])
+
+	topicName := args["topic"]
+	if topicName == "" {
+		return "ERROR: missing topic parameter"
+	}
+	key := args["key"]
+	if key == "" {
+		return "ERROR: missing key parameter"
+	}
+
+	t := h.tm.GetTopic(topicName)
+	if t == nil {
+		return fmt.Sprintf("ERROR: topic '%s' does not exist", topicName)
+	}
+
+	partitionID := t.GetPartitionForMessage(types.Message{Key: key})
+	if partitionID < 0 {
+		return "ERROR: no partitions available"
+	}
+
+	idx, err := h.getIndex(topicName, partitionID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+
+	version := idx.GetVersion(key)
+	return fmt.Sprintf("%d", version)
+}
+
+// writeError writes a JSON error envelope to the connection.
+func writeError(conn net.Conn, msg string) {
+	errResp, _ := json.Marshal(map[string]string{"error": msg})
+	_ = util.WriteWithLength(conn, errResp)
+}
+
+// parseKeyValueArgs parses "key=value" pairs from a command argument string.
+// The "message" key receives all text after "message=" (preserving spaces).
+func parseKeyValueArgs(argsStr string) map[string]string {
+	result := make(map[string]string)
+
+	messageIdx := strings.Index(argsStr, "message=")
+
+	if messageIdx != -1 {
+		beforeMessage := argsStr[:messageIdx]
+		parts := strings.Fields(beforeMessage)
+		for _, part := range parts {
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) == 2 {
+				result[kv[0]] = kv[1]
+			}
+		}
+		result["message"] = strings.TrimSpace(argsStr[messageIdx+8:])
+	} else {
+		parts := strings.Fields(argsStr)
+		for _, part := range parts {
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) == 2 {
+				result[kv[0]] = kv[1]
+			}
+		}
+	}
+	return result
+}

--- a/pkg/eventsource/handler_test.go
+++ b/pkg/eventsource/handler_test.go
@@ -102,13 +102,16 @@ func TestSnapshotVersionValidation(t *testing.T) {
 	}
 	assert.Equal(t, uint64(3), idx.GetVersion(key))
 
-	// A snapshot at version 5 would be invalid (version > current).
-	// The handler enforces this check: version > currentVersion => error.
-	// Verify the condition that the handler checks.
+	// Simulate the handler's version validation:
+	// snapshot version > currentVersion should be rejected.
 	currentVersion := idx.GetVersion(key)
 	snapshotVersion := uint64(5)
 	assert.True(t, snapshotVersion > currentVersion,
-		"snapshot version %d should exceed stream version %d", snapshotVersion, currentVersion)
+		"snapshot version %d should exceed stream version %d — handler would reject this", snapshotVersion, currentVersion)
+
+	// Version at or below current should pass validation.
+	assert.False(t, uint64(3) > currentVersion, "version 3 should pass validation")
+	assert.False(t, uint64(1) > currentVersion, "version 1 should pass validation")
 
 	// Save at version 3 (current) should succeed.
 	err = ss.Save(key, 3, `{"items":["a","b","c"]}`)
@@ -119,6 +122,16 @@ func TestSnapshotVersionValidation(t *testing.T) {
 	require.NotNil(t, snap)
 	assert.Equal(t, uint64(3), snap.Version)
 	assert.Equal(t, `{"items":["a","b","c"]}`, snap.Payload)
+
+	// Overwrite with a lower version — the store allows it (last write wins),
+	// but the handler would prevent this in production via its version check.
+	err = ss.Save(key, 2, `{"items":["a","b"]}`)
+	require.NoError(t, err)
+
+	snap, err = ss.Read(key)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(2), snap.Version, "snapshot store uses last-write-wins; handler prevents version regression")
 }
 
 // TestMultipleAggregates verifies that events appended to different aggregate keys

--- a/pkg/eventsource/handler_test.go
+++ b/pkg/eventsource/handler_test.go
@@ -1,0 +1,164 @@
+package eventsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppendAndReadStream_Integration verifies that appending events updates
+// the version correctly and that snapshot-based lookup skips already-snapshotted versions.
+func TestAppendAndReadStream_Integration(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	ss, err := NewSnapshotStore(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = ss.Close() }()
+
+	key := "order-123"
+
+	// Append 3 events for the same aggregate key.
+	for v := uint64(1); v <= 3; v++ {
+		err := idx.Append(key, v, v*100, 0)
+		require.NoError(t, err, "append version %d should succeed", v)
+	}
+
+	// Verify the current version is 3.
+	assert.Equal(t, uint64(3), idx.GetVersion(key))
+
+	// Save a snapshot at version 2.
+	err = ss.Save(key, 2, `{"total":200}`)
+	require.NoError(t, err)
+
+	snap, err := ss.Read(key)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(2), snap.Version)
+	assert.Equal(t, `{"total":200}`, snap.Payload)
+
+	// Lookup from snapshot.Version+1 should return only version 3.
+	entries, err := idx.Lookup(key, snap.Version+1)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, uint64(3), entries[0].AggregateVersion)
+	assert.Equal(t, uint64(300), entries[0].Offset)
+}
+
+// TestVersionConflict verifies that the version counter advances correctly
+// after each append, which is used by the handler to detect optimistic concurrency conflicts.
+func TestVersionConflict(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	key := "account-456"
+
+	// Append 2 events.
+	require.NoError(t, idx.Append(key, 1, 10, 0))
+	require.NoError(t, idx.Append(key, 2, 20, 0))
+
+	// Verify current version is 2.
+	assert.Equal(t, uint64(2), idx.GetVersion(key))
+
+	// Simulate a second writer that successfully appends version 3.
+	require.NoError(t, idx.Append(key, 3, 30, 0))
+
+	// Now GetVersion returns 3, so the original writer with expected_version=2
+	// would detect a conflict (expected_version != currentVersion+1).
+	assert.Equal(t, uint64(3), idx.GetVersion(key))
+
+	// Verify all 3 entries are present.
+	entries, err := idx.Lookup(key, 1)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+}
+
+// TestSnapshotVersionValidation verifies that snapshot versions are validated
+// against the current stream version: a snapshot version exceeding the stream
+// version is invalid, while saving at the current version succeeds.
+func TestSnapshotVersionValidation(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	ss, err := NewSnapshotStore(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = ss.Close() }()
+
+	key := "cart-789"
+
+	// Append 3 events to reach version 3.
+	for v := uint64(1); v <= 3; v++ {
+		require.NoError(t, idx.Append(key, v, v*10, 0))
+	}
+	assert.Equal(t, uint64(3), idx.GetVersion(key))
+
+	// A snapshot at version 5 would be invalid (version > current).
+	// The handler enforces this check: version > currentVersion => error.
+	// Verify the condition that the handler checks.
+	currentVersion := idx.GetVersion(key)
+	snapshotVersion := uint64(5)
+	assert.True(t, snapshotVersion > currentVersion,
+		"snapshot version %d should exceed stream version %d", snapshotVersion, currentVersion)
+
+	// Save at version 3 (current) should succeed.
+	err = ss.Save(key, 3, `{"items":["a","b","c"]}`)
+	require.NoError(t, err)
+
+	snap, err := ss.Read(key)
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(3), snap.Version)
+	assert.Equal(t, `{"items":["a","b","c"]}`, snap.Payload)
+}
+
+// TestMultipleAggregates verifies that events appended to different aggregate keys
+// maintain independent version tracking.
+func TestMultipleAggregates(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	keys := []string{"order-1", "order-2", "order-3"}
+
+	// Append a different number of events per key.
+	for i, key := range keys {
+		count := uint64(i + 1) // 1, 2, 3 events respectively
+		for v := uint64(1); v <= count; v++ {
+			err := idx.Append(key, v, uint64(i*100)+v, 0)
+			require.NoError(t, err)
+		}
+	}
+
+	// Verify each key has its own independent version.
+	assert.Equal(t, uint64(1), idx.GetVersion("order-1"))
+	assert.Equal(t, uint64(2), idx.GetVersion("order-2"))
+	assert.Equal(t, uint64(3), idx.GetVersion("order-3"))
+
+	// Verify lookup returns only entries for the requested key.
+	entries1, err := idx.Lookup("order-1", 1)
+	require.NoError(t, err)
+	assert.Len(t, entries1, 1)
+
+	entries2, err := idx.Lookup("order-2", 1)
+	require.NoError(t, err)
+	assert.Len(t, entries2, 2)
+
+	entries3, err := idx.Lookup("order-3", 1)
+	require.NoError(t, err)
+	assert.Len(t, entries3, 3)
+
+	// A key that was never appended should have version 0.
+	assert.Equal(t, uint64(0), idx.GetVersion("nonexistent"))
+}

--- a/pkg/eventsource/snapshot_store.go
+++ b/pkg/eventsource/snapshot_store.go
@@ -1,0 +1,235 @@
+package eventsource
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// snapshotPointer holds the in-memory index entry for a snapshot.
+type snapshotPointer struct {
+	fileOffset uint64
+	version    uint64
+}
+
+// SnapshotData represents a snapshot read back from the store.
+type SnapshotData struct {
+	Version uint64 `json:"version"`
+	Payload string `json:"payload"`
+}
+
+// SnapshotStore is a per-partition append-only snapshot store.
+// Each entry on disk has the format:
+//
+//	[KeyLen:2][Key:K][Version:8][PayloadLen:4][Payload:P]
+//
+// The in-memory index keeps only the latest snapshot per key (last write wins).
+type SnapshotStore struct {
+	mu    sync.RWMutex
+	file  *os.File
+	index map[string]*snapshotPointer
+	// writeOffset tracks the current end-of-file position for appends.
+	writeOffset uint64
+}
+
+// NewSnapshotStore opens (or creates) the snapshot file for the given partition
+// and rebuilds the in-memory index by scanning the file sequentially.
+func NewSnapshotStore(dir string, partitionID int) (*SnapshotStore, error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("snapshot store: mkdir: %w", err)
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("partition_%d_snapshots.dat", partitionID))
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot store: open file: %w", err)
+	}
+
+	s := &SnapshotStore{
+		file:  f,
+		index: make(map[string]*snapshotPointer),
+	}
+
+	if err := s.loadFromDisk(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("snapshot store: load: %w", err)
+	}
+
+	return s, nil
+}
+
+// loadFromDisk scans the file sequentially and populates the in-memory index.
+// For duplicate keys the last entry wins.
+func (s *SnapshotStore) loadFromDisk() error {
+	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
+	var offset uint64
+	for {
+		entryOffset := offset
+
+		// Read KeyLen (2 bytes).
+		var keyLen uint16
+		if err := binary.Read(s.file, binary.BigEndian, &keyLen); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			return err
+		}
+		offset += 2
+
+		// Read Key.
+		keyBuf := make([]byte, keyLen)
+		if _, err := io.ReadFull(s.file, keyBuf); err != nil {
+			return err
+		}
+		offset += uint64(keyLen)
+
+		// Read Version (8 bytes).
+		var version uint64
+		if err := binary.Read(s.file, binary.BigEndian, &version); err != nil {
+			return err
+		}
+		offset += 8
+
+		// Read PayloadLen (4 bytes).
+		var payloadLen uint32
+		if err := binary.Read(s.file, binary.BigEndian, &payloadLen); err != nil {
+			return err
+		}
+		offset += 4
+
+		// Skip Payload bytes.
+		if _, err := s.file.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
+			return err
+		}
+		offset += uint64(payloadLen)
+
+		key := string(keyBuf)
+		s.index[key] = &snapshotPointer{
+			fileOffset: entryOffset,
+			version:    version,
+		}
+	}
+
+	s.writeOffset = offset
+	return nil
+}
+
+// Save appends a new snapshot entry to the file and updates the in-memory index.
+func (s *SnapshotStore) Save(key string, version uint64, payload string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	keyBytes := []byte(key)
+	keyLen := uint16(len(keyBytes))
+	payloadBytes := []byte(payload)
+	payloadLen := uint32(len(payloadBytes))
+
+	// Seek to the append position.
+	if _, err := s.file.Seek(int64(s.writeOffset), io.SeekStart); err != nil {
+		return fmt.Errorf("snapshot store: seek: %w", err)
+	}
+
+	entryOffset := s.writeOffset
+
+	// Write KeyLen.
+	if err := binary.Write(s.file, binary.BigEndian, keyLen); err != nil {
+		return fmt.Errorf("snapshot store: write key len: %w", err)
+	}
+
+	// Write Key.
+	if _, err := s.file.Write(keyBytes); err != nil {
+		return fmt.Errorf("snapshot store: write key: %w", err)
+	}
+
+	// Write Version.
+	if err := binary.Write(s.file, binary.BigEndian, version); err != nil {
+		return fmt.Errorf("snapshot store: write version: %w", err)
+	}
+
+	// Write PayloadLen.
+	if err := binary.Write(s.file, binary.BigEndian, payloadLen); err != nil {
+		return fmt.Errorf("snapshot store: write payload len: %w", err)
+	}
+
+	// Write Payload.
+	if _, err := s.file.Write(payloadBytes); err != nil {
+		return fmt.Errorf("snapshot store: write payload: %w", err)
+	}
+
+	// Sync to disk.
+	if err := s.file.Sync(); err != nil {
+		return fmt.Errorf("snapshot store: sync: %w", err)
+	}
+
+	// Update write offset and index.
+	s.writeOffset = entryOffset + 2 + uint64(keyLen) + 8 + 4 + uint64(payloadLen)
+	s.index[key] = &snapshotPointer{
+		fileOffset: entryOffset,
+		version:    version,
+	}
+
+	return nil
+}
+
+// Read returns the latest snapshot for the given key, or nil if not found.
+func (s *SnapshotStore) Read(key string) (*SnapshotData, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ptr, ok := s.index[key]
+	if !ok {
+		return nil, nil
+	}
+
+	// Seek to the entry's file offset.
+	if _, err := s.file.Seek(int64(ptr.fileOffset), io.SeekStart); err != nil {
+		return nil, fmt.Errorf("snapshot store: seek: %w", err)
+	}
+
+	// Read KeyLen.
+	var keyLen uint16
+	if err := binary.Read(s.file, binary.BigEndian, &keyLen); err != nil {
+		return nil, fmt.Errorf("snapshot store: read key len: %w", err)
+	}
+
+	// Skip Key.
+	if _, err := s.file.Seek(int64(keyLen), io.SeekCurrent); err != nil {
+		return nil, fmt.Errorf("snapshot store: skip key: %w", err)
+	}
+
+	// Read Version.
+	var version uint64
+	if err := binary.Read(s.file, binary.BigEndian, &version); err != nil {
+		return nil, fmt.Errorf("snapshot store: read version: %w", err)
+	}
+
+	// Read PayloadLen.
+	var payloadLen uint32
+	if err := binary.Read(s.file, binary.BigEndian, &payloadLen); err != nil {
+		return nil, fmt.Errorf("snapshot store: read payload len: %w", err)
+	}
+
+	// Read Payload.
+	payloadBuf := make([]byte, payloadLen)
+	if _, err := io.ReadFull(s.file, payloadBuf); err != nil {
+		return nil, fmt.Errorf("snapshot store: read payload: %w", err)
+	}
+
+	return &SnapshotData{
+		Version: version,
+		Payload: string(payloadBuf),
+	}, nil
+}
+
+// Close closes the underlying file.
+func (s *SnapshotStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.file.Close()
+}

--- a/pkg/eventsource/snapshot_store.go
+++ b/pkg/eventsource/snapshot_store.go
@@ -69,6 +69,7 @@ func (s *SnapshotStore) loadFromDisk() error {
 	}
 
 	var offset uint64
+	var lastGoodOffset uint64
 	for {
 		entryOffset := offset
 
@@ -85,6 +86,13 @@ func (s *SnapshotStore) loadFromDisk() error {
 		// Read Key.
 		keyBuf := make([]byte, keyLen)
 		if _, err := io.ReadFull(s.file, keyBuf); err != nil {
+			if err == io.ErrUnexpectedEOF {
+				// Truncate to last good entry.
+				if truncErr := s.file.Truncate(int64(lastGoodOffset)); truncErr != nil {
+					return fmt.Errorf("snapshot store: truncate after partial key: %w", truncErr)
+				}
+				break
+			}
 			return err
 		}
 		offset += uint64(keyLen)
@@ -92,6 +100,12 @@ func (s *SnapshotStore) loadFromDisk() error {
 		// Read Version (8 bytes).
 		var version uint64
 		if err := binary.Read(s.file, binary.BigEndian, &version); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				if truncErr := s.file.Truncate(int64(lastGoodOffset)); truncErr != nil {
+					return fmt.Errorf("snapshot store: truncate after partial version: %w", truncErr)
+				}
+				break
+			}
 			return err
 		}
 		offset += 8
@@ -99,13 +113,22 @@ func (s *SnapshotStore) loadFromDisk() error {
 		// Read PayloadLen (4 bytes).
 		var payloadLen uint32
 		if err := binary.Read(s.file, binary.BigEndian, &payloadLen); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				if truncErr := s.file.Truncate(int64(lastGoodOffset)); truncErr != nil {
+					return fmt.Errorf("snapshot store: truncate after partial payload len: %w", truncErr)
+				}
+				break
+			}
 			return err
 		}
 		offset += 4
 
 		// Skip Payload bytes.
 		if _, err := s.file.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
-			return err
+			if truncErr := s.file.Truncate(int64(lastGoodOffset)); truncErr != nil {
+				return fmt.Errorf("snapshot store: truncate after partial payload: %w", truncErr)
+			}
+			break
 		}
 		offset += uint64(payloadLen)
 
@@ -114,9 +137,10 @@ func (s *SnapshotStore) loadFromDisk() error {
 			fileOffset: entryOffset,
 			version:    version,
 		}
+		lastGoodOffset = offset
 	}
 
-	s.writeOffset = offset
+	s.writeOffset = lastGoodOffset
 	return nil
 }
 
@@ -187,37 +211,38 @@ func (s *SnapshotStore) Read(key string) (*SnapshotData, error) {
 		return nil, nil
 	}
 
-	// Seek to the entry's file offset.
-	if _, err := s.file.Seek(int64(ptr.fileOffset), io.SeekStart); err != nil {
-		return nil, fmt.Errorf("snapshot store: seek: %w", err)
-	}
+	pos := int64(ptr.fileOffset)
 
-	// Read KeyLen.
-	var keyLen uint16
-	if err := binary.Read(s.file, binary.BigEndian, &keyLen); err != nil {
+	// Read KeyLen (2 bytes).
+	var keyLenBuf [2]byte
+	if _, err := s.file.ReadAt(keyLenBuf[:], pos); err != nil {
 		return nil, fmt.Errorf("snapshot store: read key len: %w", err)
 	}
+	keyLen := binary.BigEndian.Uint16(keyLenBuf[:])
+	pos += 2
 
 	// Skip Key.
-	if _, err := s.file.Seek(int64(keyLen), io.SeekCurrent); err != nil {
-		return nil, fmt.Errorf("snapshot store: skip key: %w", err)
-	}
+	pos += int64(keyLen)
 
-	// Read Version.
-	var version uint64
-	if err := binary.Read(s.file, binary.BigEndian, &version); err != nil {
+	// Read Version (8 bytes).
+	var versionBuf [8]byte
+	if _, err := s.file.ReadAt(versionBuf[:], pos); err != nil {
 		return nil, fmt.Errorf("snapshot store: read version: %w", err)
 	}
+	version := binary.BigEndian.Uint64(versionBuf[:])
+	pos += 8
 
-	// Read PayloadLen.
-	var payloadLen uint32
-	if err := binary.Read(s.file, binary.BigEndian, &payloadLen); err != nil {
+	// Read PayloadLen (4 bytes).
+	var payloadLenBuf [4]byte
+	if _, err := s.file.ReadAt(payloadLenBuf[:], pos); err != nil {
 		return nil, fmt.Errorf("snapshot store: read payload len: %w", err)
 	}
+	payloadLen := binary.BigEndian.Uint32(payloadLenBuf[:])
+	pos += 4
 
 	// Read Payload.
 	payloadBuf := make([]byte, payloadLen)
-	if _, err := io.ReadFull(s.file, payloadBuf); err != nil {
+	if _, err := s.file.ReadAt(payloadBuf, pos); err != nil {
 		return nil, fmt.Errorf("snapshot store: read payload: %w", err)
 	}
 

--- a/pkg/eventsource/snapshot_store_test.go
+++ b/pkg/eventsource/snapshot_store_test.go
@@ -1,0 +1,92 @@
+package eventsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotStore_SaveAndRead(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSnapshotStore(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	err = store.Save("user:1", 5, `{"name":"alice"}`)
+	require.NoError(t, err)
+
+	snap, err := store.Read("user:1")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(5), snap.Version)
+	assert.Equal(t, `{"name":"alice"}`, snap.Payload)
+}
+
+func TestSnapshotStore_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSnapshotStore(dir, 1)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	err = store.Save("order:99", 1, `{"status":"pending"}`)
+	require.NoError(t, err)
+
+	err = store.Save("order:99", 3, `{"status":"shipped"}`)
+	require.NoError(t, err)
+
+	snap, err := store.Read("order:99")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(3), snap.Version)
+	assert.Equal(t, `{"status":"shipped"}`, snap.Payload)
+}
+
+func TestSnapshotStore_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSnapshotStore(dir, 2)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	snap, err := store.Read("nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, snap)
+}
+
+func TestSnapshotStore_LoadFromDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	// First session: write snapshots and close.
+	store, err := NewSnapshotStore(dir, 3)
+	require.NoError(t, err)
+
+	err = store.Save("account:1", 10, `{"balance":100}`)
+	require.NoError(t, err)
+
+	err = store.Save("account:2", 7, `{"balance":200}`)
+	require.NoError(t, err)
+
+	// Overwrite account:1 so the reload must pick the latest entry.
+	err = store.Save("account:1", 15, `{"balance":150}`)
+	require.NoError(t, err)
+
+	err = store.Close()
+	require.NoError(t, err)
+
+	// Second session: reopen and verify persistence.
+	store2, err := NewSnapshotStore(dir, 3)
+	require.NoError(t, err)
+	defer func() { _ = store2.Close() }()
+
+	snap, err := store2.Read("account:1")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(15), snap.Version)
+	assert.Equal(t, `{"balance":150}`, snap.Payload)
+
+	snap, err = store2.Read("account:2")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(7), snap.Version)
+	assert.Equal(t, `{"balance":200}`, snap.Payload)
+}

--- a/pkg/eventsource/stream_index.go
+++ b/pkg/eventsource/stream_index.go
@@ -171,6 +171,33 @@ func (si *StreamIndex) CheckAndAppend(key string, expectedVersion, offset, posit
 	return true, expectedVersion, nil
 }
 
+// CheckEnqueueAndAppend atomically validates expected version, enqueues via the
+// provided callback, and appends the resulting offset to the index.
+// This ensures no concurrent request can interleave between version check and append.
+func (si *StreamIndex) CheckEnqueueAndAppend(key string, expectedVersion uint64, enqueueFn func() (uint64, error)) (bool, uint64, error) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+
+	current := uint64(0)
+	if st, ok := si.states[key]; ok {
+		current = st.currentVersion
+	}
+
+	if expectedVersion != current+1 {
+		return false, current, nil
+	}
+
+	offset, err := enqueueFn()
+	if err != nil {
+		return false, current, err
+	}
+
+	if err := si.appendLocked(key, expectedVersion, offset, 0); err != nil {
+		return false, current, err
+	}
+	return true, expectedVersion, nil
+}
+
 // Append writes a new index entry for the given aggregate key.
 // On the first append for a new key, the key-to-hash mapping is written to the sidecar.
 func (si *StreamIndex) Append(key string, aggregateVersion, offset, position uint64) error {

--- a/pkg/eventsource/stream_index.go
+++ b/pkg/eventsource/stream_index.go
@@ -1,0 +1,287 @@
+package eventsource
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cursus-io/cursus/util"
+)
+
+// StreamIndexEntry represents a fixed 32-byte entry on disk.
+// Layout: [KeyHash:8][AggregateVersion:8][Offset:8][Position:8]
+type StreamIndexEntry struct {
+	KeyHash          uint64
+	AggregateVersion uint64
+	Offset           uint64
+	Position         uint64
+}
+
+// StreamIndexEntrySize is the fixed byte size of each entry on disk.
+const StreamIndexEntrySize = 32
+
+// streamState tracks the current version and offset for an aggregate key.
+type streamState struct {
+	currentVersion uint64
+	lastOffset     uint64
+	entryCount     uint32
+}
+
+// StreamIndex is a per-partition index that maps aggregate keys to their event offsets.
+// It maintains an on-disk index file and a sidecar file for key-to-hash recovery.
+type StreamIndex struct {
+	mu sync.RWMutex
+
+	dir         string
+	partitionID int
+
+	indexFile   *os.File
+	sidecarFile *os.File
+
+	// In-memory cache for O(1) version lookup.
+	states map[string]*streamState
+
+	// In-memory entries for lookup queries.
+	entries map[string][]StreamIndexEntry
+
+	// Track which keys have been written to the sidecar.
+	knownKeys map[uint64]string
+}
+
+// NewStreamIndex opens or creates the index and sidecar files for the given partition,
+// then loads existing data from disk into the in-memory cache.
+func NewStreamIndex(dir string, partitionID int) (*StreamIndex, error) {
+	indexPath := filepath.Join(dir, fmt.Sprintf("partition_%d_stream.idx", partitionID))
+	sidecarPath := filepath.Join(dir, fmt.Sprintf("partition_%d_stream_keys.dat", partitionID))
+
+	indexFile, err := os.OpenFile(indexPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open index file: %w", err)
+	}
+
+	sidecarFile, err := os.OpenFile(sidecarPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		_ = indexFile.Close()
+		return nil, fmt.Errorf("open sidecar file: %w", err)
+	}
+
+	si := &StreamIndex{
+		dir:         dir,
+		partitionID: partitionID,
+		indexFile:   indexFile,
+		sidecarFile: sidecarFile,
+		states:      make(map[string]*streamState),
+		entries:     make(map[string][]StreamIndexEntry),
+		knownKeys:   make(map[uint64]string),
+	}
+
+	if err := si.loadFromDisk(); err != nil {
+		_ = indexFile.Close()
+		_ = sidecarFile.Close()
+		return nil, fmt.Errorf("load from disk: %w", err)
+	}
+
+	return si, nil
+}
+
+// loadFromDisk reads the sidecar file to rebuild the key-to-hash mapping,
+// then reads the index file to rebuild the in-memory cache.
+func (si *StreamIndex) loadFromDisk() error {
+	// Read sidecar: each record is [hash:8][keyLen:2][keyBytes:N]
+	sidecarData, err := os.ReadFile(si.sidecarFile.Name())
+	if err != nil {
+		return fmt.Errorf("read sidecar: %w", err)
+	}
+
+	hashToKey := make(map[uint64]string)
+	pos := 0
+	for pos < len(sidecarData) {
+		if pos+10 > len(sidecarData) {
+			break
+		}
+		hash := binary.BigEndian.Uint64(sidecarData[pos : pos+8])
+		keyLen := binary.BigEndian.Uint16(sidecarData[pos+8 : pos+10])
+		pos += 10
+		if pos+int(keyLen) > len(sidecarData) {
+			break
+		}
+		key := string(sidecarData[pos : pos+int(keyLen)])
+		pos += int(keyLen)
+		hashToKey[hash] = key
+		si.knownKeys[hash] = key
+	}
+
+	// Read index file entries.
+	indexData, err := os.ReadFile(si.indexFile.Name())
+	if err != nil {
+		return fmt.Errorf("read index: %w", err)
+	}
+
+	for i := 0; i+StreamIndexEntrySize <= len(indexData); i += StreamIndexEntrySize {
+		entry := StreamIndexEntry{
+			KeyHash:          binary.BigEndian.Uint64(indexData[i : i+8]),
+			AggregateVersion: binary.BigEndian.Uint64(indexData[i+8 : i+16]),
+			Offset:           binary.BigEndian.Uint64(indexData[i+16 : i+24]),
+			Position:         binary.BigEndian.Uint64(indexData[i+24 : i+32]),
+		}
+
+		key, ok := hashToKey[entry.KeyHash]
+		if !ok {
+			// Skip entries with unknown keys (should not happen with valid data).
+			continue
+		}
+
+		si.entries[key] = append(si.entries[key], entry)
+
+		st, exists := si.states[key]
+		if !exists {
+			st = &streamState{}
+			si.states[key] = st
+		}
+		if entry.AggregateVersion > st.currentVersion {
+			st.currentVersion = entry.AggregateVersion
+		}
+		st.lastOffset = entry.Offset
+		st.entryCount++
+	}
+
+	return nil
+}
+
+// CheckAndAppend atomically validates expected version and appends.
+// Returns (true, nil) on success, (false, nil) on version conflict.
+func (si *StreamIndex) CheckAndAppend(key string, expectedVersion, offset, position uint64) (bool, uint64, error) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+
+	current := uint64(0)
+	if st, ok := si.states[key]; ok {
+		current = st.currentVersion
+	}
+
+	if expectedVersion != current+1 {
+		return false, current, nil
+	}
+
+	if err := si.appendLocked(key, expectedVersion, offset, position); err != nil {
+		return false, current, err
+	}
+	return true, expectedVersion, nil
+}
+
+// Append writes a new index entry for the given aggregate key.
+// On the first append for a new key, the key-to-hash mapping is written to the sidecar.
+func (si *StreamIndex) Append(key string, aggregateVersion, offset, position uint64) error {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	return si.appendLocked(key, aggregateVersion, offset, position)
+}
+
+// appendLocked writes an entry while the caller already holds si.mu.
+func (si *StreamIndex) appendLocked(key string, aggregateVersion, offset, position uint64) error {
+	keyHash := util.GenerateID(key)
+
+	// Write to sidecar on first occurrence of this key.
+	if _, exists := si.knownKeys[keyHash]; !exists {
+		if err := si.writeSidecarEntry(keyHash, key); err != nil {
+			return fmt.Errorf("write sidecar entry: %w", err)
+		}
+		si.knownKeys[keyHash] = key
+	}
+
+	entry := StreamIndexEntry{
+		KeyHash:          keyHash,
+		AggregateVersion: aggregateVersion,
+		Offset:           offset,
+		Position:         position,
+	}
+
+	// Write entry to disk.
+	var buf [StreamIndexEntrySize]byte
+	binary.BigEndian.PutUint64(buf[0:8], entry.KeyHash)
+	binary.BigEndian.PutUint64(buf[8:16], entry.AggregateVersion)
+	binary.BigEndian.PutUint64(buf[16:24], entry.Offset)
+	binary.BigEndian.PutUint64(buf[24:32], entry.Position)
+
+	if _, err := si.indexFile.Write(buf[:]); err != nil {
+		return fmt.Errorf("write index entry: %w", err)
+	}
+
+	// Update in-memory state.
+	si.entries[key] = append(si.entries[key], entry)
+
+	st, exists := si.states[key]
+	if !exists {
+		st = &streamState{}
+		si.states[key] = st
+	}
+	st.currentVersion = aggregateVersion
+	st.lastOffset = offset
+	st.entryCount++
+
+	return nil
+}
+
+// writeSidecarEntry writes a key-to-hash mapping: [hash:8][keyLen:2][keyBytes:N]
+func (si *StreamIndex) writeSidecarEntry(hash uint64, key string) error {
+	keyBytes := []byte(key)
+	buf := make([]byte, 10+len(keyBytes))
+	binary.BigEndian.PutUint64(buf[0:8], hash)
+	binary.BigEndian.PutUint16(buf[8:10], uint16(len(keyBytes)))
+	copy(buf[10:], keyBytes)
+
+	if _, err := si.sidecarFile.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetVersion returns the current aggregate version for the given key.
+// Returns 0 if the key is not found.
+func (si *StreamIndex) GetVersion(key string) uint64 {
+	si.mu.RLock()
+	defer si.mu.RUnlock()
+
+	st, ok := si.states[key]
+	if !ok {
+		return 0
+	}
+	return st.currentVersion
+}
+
+// Lookup returns all index entries for the given key with AggregateVersion >= fromVersion.
+// Returns nil if the key is not found.
+func (si *StreamIndex) Lookup(key string, fromVersion uint64) ([]StreamIndexEntry, error) {
+	si.mu.RLock()
+	defer si.mu.RUnlock()
+
+	entries, ok := si.entries[key]
+	if !ok {
+		return nil, nil
+	}
+
+	var result []StreamIndexEntry
+	for _, e := range entries {
+		if e.AggregateVersion >= fromVersion {
+			result = append(result, e)
+		}
+	}
+	return result, nil
+}
+
+// Close closes the underlying index and sidecar files.
+func (si *StreamIndex) Close() error {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+
+	var firstErr error
+	if err := si.indexFile.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if err := si.sidecarFile.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}

--- a/pkg/eventsource/stream_index_test.go
+++ b/pkg/eventsource/stream_index_test.go
@@ -1,0 +1,97 @@
+package eventsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamIndex_AppendAndLookup(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	key := "order-123"
+
+	require.NoError(t, idx.Append(key, 1, 100, 0))
+	require.NoError(t, idx.Append(key, 2, 200, 1))
+	require.NoError(t, idx.Append(key, 3, 300, 2))
+
+	assert.Equal(t, uint64(3), idx.GetVersion(key))
+
+	entries, err := idx.Lookup(key, 2)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, uint64(2), entries[0].AggregateVersion)
+	assert.Equal(t, uint64(200), entries[0].Offset)
+	assert.Equal(t, uint64(3), entries[1].AggregateVersion)
+	assert.Equal(t, uint64(300), entries[1].Offset)
+}
+
+func TestStreamIndex_LoadFromDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write entries and close.
+	idx, err := NewStreamIndex(dir, 1)
+	require.NoError(t, err)
+
+	require.NoError(t, idx.Append("user-1", 1, 10, 0))
+	require.NoError(t, idx.Append("user-1", 2, 20, 1))
+	require.NoError(t, idx.Append("user-1", 3, 30, 2))
+	require.NoError(t, idx.Close())
+
+	// Reopen and verify cache is restored.
+	idx2, err := NewStreamIndex(dir, 1)
+	require.NoError(t, err)
+	defer func() { _ = idx2.Close() }()
+
+	assert.Equal(t, uint64(3), idx2.GetVersion("user-1"))
+
+	entries, err := idx2.Lookup("user-1", 1)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+	assert.Equal(t, uint64(1), entries[0].AggregateVersion)
+	assert.Equal(t, uint64(2), entries[1].AggregateVersion)
+	assert.Equal(t, uint64(3), entries[2].AggregateVersion)
+}
+
+func TestStreamIndex_MultipleKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	require.NoError(t, idx.Append("key-a", 1, 100, 0))
+	require.NoError(t, idx.Append("key-a", 2, 200, 1))
+	require.NoError(t, idx.Append("key-b", 1, 300, 2))
+
+	assert.Equal(t, uint64(2), idx.GetVersion("key-a"))
+	assert.Equal(t, uint64(1), idx.GetVersion("key-b"))
+
+	entriesA, err := idx.Lookup("key-a", 1)
+	require.NoError(t, err)
+	assert.Len(t, entriesA, 2)
+
+	entriesB, err := idx.Lookup("key-b", 1)
+	require.NoError(t, err)
+	assert.Len(t, entriesB, 1)
+	assert.Equal(t, uint64(300), entriesB[0].Offset)
+}
+
+func TestStreamIndex_UnknownKey(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	assert.Equal(t, uint64(0), idx.GetVersion("nonexistent"))
+
+	entries, err := idx.Lookup("nonexistent", 1)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+}

--- a/pkg/eventsource/stream_index_test.go
+++ b/pkg/eventsource/stream_index_test.go
@@ -95,3 +95,41 @@ func TestStreamIndex_UnknownKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, entries)
 }
+
+func TestStreamIndex_CheckAndAppend_VersionConflict(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	key := "order-conflict"
+
+	// First append at version 1 should succeed.
+	ok, _, err := idx.CheckAndAppend(key, 1, 100, 0)
+	require.NoError(t, err)
+	assert.True(t, ok, "first append should succeed")
+
+	// Second append at version 2 should succeed.
+	ok, _, err = idx.CheckAndAppend(key, 2, 200, 1)
+	require.NoError(t, err)
+	assert.True(t, ok, "second append should succeed")
+
+	// Duplicate version 2 should fail (conflict).
+	ok, current, err := idx.CheckAndAppend(key, 2, 300, 2)
+	require.NoError(t, err)
+	assert.False(t, ok, "duplicate version should conflict")
+	assert.Equal(t, uint64(2), current, "current version should be 2")
+
+	// Out-of-order version 1 should also fail.
+	ok, current, err = idx.CheckAndAppend(key, 1, 400, 3)
+	require.NoError(t, err)
+	assert.False(t, ok, "out-of-order version should conflict")
+	assert.Equal(t, uint64(2), current, "current version should still be 2")
+
+	// Version 3 should succeed (correct next version).
+	ok, _, err = idx.CheckAndAppend(key, 3, 500, 4)
+	require.NoError(t, err)
+	assert.True(t, ok, "version 3 should succeed")
+	assert.Equal(t, uint64(3), idx.GetVersion(key))
+}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -77,7 +77,7 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 
 		var err error
 		clusterClient := client.TCPClusterClient{}
-		rm, err := replication.NewRaftReplicationManager(cfg, raftServerID, dm, tm, cd, clusterClient)
+		rm, err := replication.NewRaftReplicationManager(ctx, cfg, raftServerID, tm, cd, clusterClient)
 		if err != nil {
 			return fmt.Errorf("failed to create raft replication manager: %w", err)
 		}
@@ -221,11 +221,6 @@ func initializeConnection(cfg *config.Config, tm *topic.TopicManager, cd *coordi
 }
 
 func readMessage(conn net.Conn, compressionType string) ([]byte, error) {
-	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		util.Error("⚠️ SetReadDeadline error: %v", err)
-		return nil, err
-	}
-
 	lenBuf := make([]byte, 4)
 	if _, err := io.ReadFull(conn, lenBuf); err != nil {
 		if err != io.EOF {
@@ -299,6 +294,11 @@ func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *con
 }
 
 func handleCommandMessage(payload string, cmdHandler *controller.CommandHandler, ctx *controller.ClientContext, conn net.Conn) (bool, error) {
+	if strings.HasPrefix(strings.ToUpper(payload), "READ_STREAM ") {
+		cmdHandler.ESHandler.HandleReadStream(payload, conn)
+		return false, nil
+	}
+
 	resp := cmdHandler.HandleCommand(payload, ctx)
 	if resp == controller.STREAM_DATA_SIGNAL {
 		if strings.HasPrefix(strings.ToUpper(payload), "STREAM ") {
@@ -339,7 +339,8 @@ func isBatchMessage(data []byte) bool {
 func isCommand(s string) bool {
 	keywords := []string{"CREATE", "DELETE", "LIST", "LIST_CLUSTER", "PUBLISH", "CONSUME", "STREAM", "HELP",
 		"HEARTBEAT", "JOIN_GROUP", "LEAVE_GROUP", "COMMIT_OFFSET", "BATCH_COMMIT", "REGISTER_GROUP",
-		"GROUP_STATUS", "FETCH_OFFSET", "LIST_GROUPS", "SYNC_GROUP", "DESCRIBE"}
+		"GROUP_STATUS", "FETCH_OFFSET", "LIST_GROUPS", "SYNC_GROUP", "DESCRIBE",
+		"APPEND_STREAM", "READ_STREAM", "SAVE_SNAPSHOT", "READ_SNAPSHOT", "STREAM_VERSION"}
 	for _, k := range keywords {
 		if strings.HasPrefix(strings.ToUpper(s), k) {
 			return true

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -47,7 +47,7 @@ func TestHealthCheckServer(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
+	_ = ln.Close()
 
 	startHealthCheckServer(port, ready)
 
@@ -56,14 +56,14 @@ func TestHealthCheckServer(t *testing.T) {
 	resp, err := http.Get(url)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// Test Ready
 	ready.Store(true)
 	resp, err = http.Get(url)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 func TestWriteResponse(t *testing.T) {
@@ -71,18 +71,18 @@ func TestWriteResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	done := make(chan bool)
 	go func() {
 		conn, _ := l.Accept()
 		writeResponse(conn, "OK")
-		conn.Close()
+		_ = conn.Close()
 		done <- true
 	}()
 
 	conn, _ := net.Dial("tcp", l.Addr().String())
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	lenBuf := make([]byte, 4)
 	_, _ = io.ReadFull(conn, lenBuf)
@@ -100,7 +100,7 @@ func TestReadMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	go func() {
 		conn, _ := l.Accept()
@@ -109,11 +109,11 @@ func TestReadMessage(t *testing.T) {
 		binary.BigEndian.PutUint32(buf[0:4], uint32(len(msg)))
 		copy(buf[4:], []byte(msg))
 		_, _ = conn.Write(buf)
-		conn.Close()
+		_ = conn.Close()
 	}()
 
 	conn, _ := net.Dial("tcp", l.Addr().String())
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	data, err := readMessage(conn, "none")
 	assert.NoError(t, err)
@@ -125,7 +125,7 @@ func TestHandleConnection_Exit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	cfg := config.DefaultConfig()
 	done := make(chan struct{})
@@ -146,7 +146,7 @@ func TestHandleConnection_Exit(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[0:4], uint32(len(msg)))
 	copy(buf[4:], []byte(msg))
 	_, _ = conn.Write(buf)
-	conn.Close()
+	_ = conn.Close()
 
 	select {
 	case <-done:

--- a/pkg/stream/connection.go
+++ b/pkg/stream/connection.go
@@ -5,10 +5,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
 )
+
+// OffsetCommitter abstracts offset commit operations to break the
+// circular dependency between stream and coordinator packages.
+type OffsetCommitter interface {
+	CommitOffset(group, topic string, partition int, offset uint64) error
+}
 
 type StreamConnection struct {
 	conn      net.Conn
@@ -23,10 +28,12 @@ type StreamConnection struct {
 	stopCh   chan struct{}
 	stopOnce sync.Once
 
-	batchSize int
-	interval  time.Duration
+	batchSize         int
+	interval          time.Duration
+	keepaliveInterval time.Duration
+	newMessageCh      <-chan struct{} // signal from partition when new messages arrive
 
-	coordinator *coordinator.Coordinator
+	committer OffsetCommitter
 }
 
 // NewStreamConnection creates a new stream connection
@@ -39,8 +46,9 @@ func NewStreamConnection(conn net.Conn, topic string, partition int, group strin
 		offset:     offset,
 		lastActive: time.Now(),
 		stopCh:     make(chan struct{}),
-		batchSize:  10,
-		interval:   100 * time.Millisecond,
+		batchSize:         10,
+		interval:          100 * time.Millisecond,
+		keepaliveInterval: 5 * time.Second,
 	}
 	return sc
 }
@@ -57,10 +65,22 @@ func (sc *StreamConnection) SetInterval(interval time.Duration) {
 	sc.interval = interval
 }
 
-func (sc *StreamConnection) SetCoordinator(coord *coordinator.Coordinator) {
+func (sc *StreamConnection) SetCommitter(c OffsetCommitter) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	sc.coordinator = coord
+	sc.committer = c
+}
+
+func (sc *StreamConnection) SetKeepaliveInterval(d time.Duration) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.keepaliveInterval = d
+}
+
+func (sc *StreamConnection) SetNewMessageCh(ch <-chan struct{}) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.newMessageCh = ch
 }
 
 func (sc *StreamConnection) Run(
@@ -68,71 +88,100 @@ func (sc *StreamConnection) Run(
 	commitInterval time.Duration,
 ) {
 	defer func() {
-		if sc.coordinator != nil {
-			_ = sc.coordinator.CommitOffset(sc.group, sc.topic, sc.partition, sc.Offset())
+		if sc.committer != nil {
+			_ = sc.committer.CommitOffset(sc.group, sc.topic, sc.partition, sc.Offset())
 		}
 	}()
 
-	ticker := time.NewTicker(sc.interval)
+	pollTicker := time.NewTicker(sc.interval)
 	commitTicker := time.NewTicker(commitInterval)
-	defer ticker.Stop()
+	keepaliveTicker := time.NewTicker(sc.keepaliveInterval)
+	defer pollTicker.Stop()
 	defer commitTicker.Stop()
+	defer keepaliveTicker.Stop()
+
+	// sendMessages reads and sends available messages. Returns false on fatal error.
+	sendMessages := func() bool {
+		sc.mu.RLock()
+		conn := sc.conn
+		bs := sc.batchSize
+		sc.mu.RUnlock()
+
+		if conn == nil {
+			return false
+		}
+
+		currentOffset := sc.Offset()
+		msgs, err := readFn(currentOffset, bs)
+		if err != nil {
+			util.Error("Stream read error for %s/%d: %v", sc.topic, sc.partition, err)
+			return false
+		}
+
+		if len(msgs) == 0 {
+			return true
+		}
+
+		// Offset gap detection
+		firstOffset := msgs[0].Offset
+		if currentOffset > 0 && firstOffset > currentOffset {
+			util.Warn("Stream %s/%d: offset gap detected, expected %d but got %d (missing %d messages)",
+				sc.topic, sc.partition, currentOffset, firstOffset, firstOffset-currentOffset)
+		}
+
+		batchData, err := util.EncodeBatchMessages(sc.topic, sc.partition, "1", false, msgs)
+		if err != nil {
+			util.Error("Failed to encode batch messages: %v", err)
+			return false
+		}
+
+		if err := util.WriteWithLength(conn, batchData); err != nil {
+			util.Debug("Batch write error in stream: %v", err)
+			sc.closeConn()
+			return false
+		}
+
+		lastOffset := msgs[len(msgs)-1].Offset
+		sc.SetOffset(lastOffset + 1)
+		sc.SetLastActive(time.Now())
+		return true
+	}
 
 	for {
 		select {
 		case <-sc.stopCh:
 			return
+
 		case <-commitTicker.C:
-			if sc.coordinator != nil {
-				_ = sc.coordinator.CommitOffset(sc.group, sc.topic, sc.partition, sc.Offset())
-				util.Debug("Periodically committed offset %d for %s/%d", sc.Offset(), sc.topic, sc.partition)
+			if sc.committer != nil {
+				_ = sc.committer.CommitOffset(sc.group, sc.topic, sc.partition, sc.Offset())
 			}
-		case <-ticker.C:
-			sc.mu.Lock()
-			conn := sc.conn
-			if conn == nil {
-				sc.mu.Unlock()
-				util.Debug("Stream connection closed, stopping stream for %s partition %d", sc.topic, sc.partition)
-				return
-			}
-			sc.mu.Unlock()
-			msgs, err := readFn(sc.Offset(), sc.batchSize)
-			if err != nil {
-				util.Error("Stream read error for %s/%d: %v", sc.topic, sc.partition, err)
+
+		case <-sc.newMessageCh:
+			if !sendMessages() {
 				sc.Stop()
 				return
 			}
 
-			if len(msgs) == 0 {
+		case <-pollTicker.C:
+			if !sendMessages() {
+				sc.Stop()
+				return
+			}
+
+		case <-keepaliveTicker.C:
+			sc.mu.RLock()
+			conn := sc.conn
+			sc.mu.RUnlock()
+			if conn != nil {
 				if _, err := conn.Write([]byte{0, 0, 0, 0}); err != nil {
-					util.Debug("Keepalive write error in stream: %v", err)
+					util.Debug("Keepalive write error: %v", err)
 					sc.closeConn()
 					sc.Stop()
 					return
 				}
 				sc.SetLastActive(time.Now())
-				continue
 			}
-
-			batchData, err := util.EncodeBatchMessages(sc.topic, sc.partition, "1", false, msgs)
-			if err != nil {
-				util.Error("Failed to encode batch messages: %v", err)
-				sc.Stop()
-				return
-			}
-
-			if err := util.WriteWithLength(conn, batchData); err != nil {
-				util.Debug("Batch write error in stream, closing connection: %v", err)
-				sc.closeConn()
-				sc.Stop()
-				return
-			}
-
-			lastOffset := msgs[len(msgs)-1].Offset
-			sc.SetOffset(lastOffset + 1)
-			sc.SetLastActive(time.Now())
-
-			util.Debug("Stream sent batch of %d messages, new offset: %d", len(msgs), sc.Offset())
 		}
 	}
 }

--- a/pkg/stream/connection_test.go
+++ b/pkg/stream/connection_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestStreamConnection_Basic(t *testing.T) {
 	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
+	defer func() { _ = c1.Close() }()
+	defer func() { _ = c2.Close() }()
 
 	sc := NewStreamConnection(c1, "test-topic", 0, "test-group", 100)
 	assert.Equal(t, "test-topic", sc.Topic())
@@ -29,8 +29,8 @@ func TestStreamConnection_Basic(t *testing.T) {
 
 func TestStreamConnection_Run(t *testing.T) {
 	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
+	defer func() { _ = c1.Close() }()
+	defer func() { _ = c2.Close() }()
 
 	sc := NewStreamConnection(c1, "t1", 0, "g1", 0)
 	sc.SetInterval(10 * time.Millisecond)
@@ -56,11 +56,12 @@ func TestStreamConnection_Run(t *testing.T) {
 
 func TestStreamConnection_Keepalive(t *testing.T) {
 	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
+	defer func() { _ = c1.Close() }()
+	defer func() { _ = c2.Close() }()
 
 	sc := NewStreamConnection(c1, "t1", 0, "g1", 0)
 	sc.SetInterval(10 * time.Millisecond)
+	sc.SetKeepaliveInterval(100 * time.Millisecond)
 
 	readFn := func(offset uint64, max int) ([]types.Message, error) {
 		return []types.Message{}, nil // No messages -> should send keepalive

--- a/pkg/stream/manager.go
+++ b/pkg/stream/manager.go
@@ -62,11 +62,15 @@ func (sm *StreamManager) monitorConnection(key string, stream *StreamConnection)
 	for {
 		select {
 		case <-stream.stopCh:
+			sm.mu.Lock()
+			delete(sm.streams, key)
+			sm.mu.Unlock()
 			stream.closeConn()
 			return
 		case <-ticker.C:
 			if time.Since(stream.LastActive()) > sm.timeout {
 				sm.RemoveStream(key)
+				stream.closeConn()
 				return
 			}
 		}

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -2,7 +2,7 @@ package topic
 
 import (
 	"fmt"
-	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -232,7 +232,9 @@ func (tm *TopicManager) publishInternal(topicName string, _ int, msg *types.Mess
 			return fmt.Errorf("sync publish failed: %w", err)
 		}
 	} else {
-		t.Publish(*msg)
+		if err := t.Publish(*msg); err != nil {
+			return fmt.Errorf("async publish failed: %w", err)
+		}
 	}
 
 	elapsed := time.Since(start).Seconds()
@@ -304,7 +306,7 @@ func (tm *TopicManager) ListTopics() []string {
 }
 
 func (tm *TopicManager) GetLogDir(topicName string, partitionID int) string {
-	return fmt.Sprintf("%s%c%s%cpartition_%d", tm.cfg.LogDir, os.PathSeparator, topicName, os.PathSeparator, partitionID)
+	return filepath.Join(tm.cfg.LogDir, topicName, fmt.Sprintf("partition_%d", partitionID))
 }
 
 func (tm *TopicManager) EnsureDefaultGroups() {

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -2,6 +2,7 @@ package topic
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -28,7 +29,6 @@ type TopicManager struct {
 	cfg           *config.Config
 	StreamManager StreamManager
 	coordinator   *coordinator.Coordinator
-	producerState map[string]map[int]map[string]int64 // Topic -> Partition -> ProducerID -> LastSeq
 }
 
 // HandlerProvider defines an interface to provide disk handlers.
@@ -47,12 +47,11 @@ func NewTopicManager(cfg *config.Config, hp HandlerProvider, sm StreamManager) *
 		hp:            hp,
 		cfg:           cfg,
 		StreamManager: sm,
-		producerState: make(map[string]map[int]map[string]int64),
 	}
 	return tm
 }
 
-func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent bool) error {
+func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent bool, eventSourcing bool) error {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
@@ -63,7 +62,9 @@ func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent 
 			util.Error("cannot decrease partitions for topic '%s' (%d -> %d)", name, current, partitionCount)
 			return fmt.Errorf("cannot decrease partition count for topic '%s': %d -> %d", name, current, partitionCount)
 		case partitionCount > current:
-			existing.AddPartitions(partitionCount-current, tm.hp)
+			if err := existing.AddPartitions(partitionCount-current, tm.hp); err != nil {
+				return fmt.Errorf("failed to add partitions to topic '%s': %w", name, err)
+			}
 			util.Info("topic '%s' partitions increased: %d -> %d", name, current, len(existing.Partitions))
 			return nil
 		default:
@@ -72,7 +73,7 @@ func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent 
 		}
 	}
 
-	t, err := NewTopic(name, partitionCount, tm.hp, tm.cfg, tm.StreamManager, idempotent)
+	t, err := NewTopic(name, partitionCount, tm.hp, tm.cfg, tm.StreamManager, idempotent, eventSourcing)
 	if err != nil {
 		util.Error("failed to create topic '%s': %v", name, err)
 		return fmt.Errorf("failed to create topic '%s': %w", name, err)
@@ -91,7 +92,7 @@ func (tm *TopicManager) GetLastOffset(topicName string, partitionID int) uint64 
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
 
-	t := tm.GetTopic(topicName)
+	t := tm.topics[topicName]
 	if t == nil {
 		return 0
 	}
@@ -143,15 +144,6 @@ func (tm *TopicManager) processBatchMessages(topicName string, messages []types.
 	for _, m := range messages {
 		msg := m
 
-		// Check and mark duplicate before routing.
-		// Moving this BEFORE the write prevents race conditions from concurrent retries.
-		if t.IsIdempotent && msg.ProducerID != "" && msg.SeqNum > 0 {
-			if isDup := tm.CheckAndMarkProducerSequence(topicName, -1, &msg); isDup {
-				util.Debug("tm: skipping duplicate message (Global) in batch from producer %s (seq %d)", msg.ProducerID, msg.SeqNum)
-				continue
-			}
-		}
-
 		partition = t.GetPartitionForMessage(msg)
 		if partition == -1 {
 			util.Debug("tm: skipping message for topic '%s' (no valid partition found)", topicName)
@@ -170,7 +162,6 @@ func (tm *TopicManager) processBatchMessages(topicName string, messages []types.
 		return err
 	}
 
-	// Sequence advancement moved BEFORE write for atomicity and race prevention.
 	return nil
 }
 
@@ -203,9 +194,9 @@ func (tm *TopicManager) executeBatch(t *Topic, partitioned map[int][]types.Messa
 			}
 		}(targetPartition, batch)
 	}
-	t.mu.RUnlock()
 
 	wg.Wait()
+	t.mu.RUnlock()
 	close(errCh)
 
 	var lastErr error
@@ -236,14 +227,6 @@ func (tm *TopicManager) publishInternal(topicName string, _ int, msg *types.Mess
 		return fmt.Errorf("topic '%s' does not exist", topicName)
 	}
 
-	// Check and mark duplicate before write.
-	if t.IsIdempotent && msg.ProducerID != "" && msg.SeqNum > 0 {
-		if isDup := tm.CheckAndMarkProducerSequence(topicName, -1, msg); isDup {
-			util.Debug("tm: skipping duplicate message (Global) from producer %s (seq %d)", msg.ProducerID, msg.SeqNum)
-			return nil
-		}
-	}
-
 	if requireAck {
 		if err := t.PublishSync(*msg); err != nil {
 			return fmt.Errorf("sync publish failed: %w", err)
@@ -256,33 +239,6 @@ func (tm *TopicManager) publishInternal(topicName string, _ int, msg *types.Mess
 	metrics.MessagesProcessed.Inc()
 	metrics.LatencyHist.Observe(elapsed)
 	return nil
-}
-
-// CheckAndMarkProducerSequence checks whether msg is a duplicate and records the new sequence if not.
-// This is an atomic operation to prevent race conditions in high-concurrency stress tests.
-func (tm *TopicManager) CheckAndMarkProducerSequence(topicName string, partition int, msg *types.Message) bool {
-	tm.mu.Lock()
-	defer tm.mu.Unlock()
-
-	// Ensure maps are initialized for this topic/partition
-	if _, ok := tm.producerState[topicName]; !ok {
-		tm.producerState[topicName] = make(map[int]map[string]int64)
-	}
-	if _, ok := tm.producerState[topicName][partition]; !ok {
-		tm.producerState[topicName][partition] = make(map[string]int64)
-	}
-
-	lastSeq, ok := tm.producerState[topicName][partition][msg.ProducerID]
-	if ok && int64(msg.SeqNum) <= lastSeq {
-		util.Debug("tm: [idempotency] DUPLICATE detected for topic=%s, partition=%d, producer=%s, seq=%d (lastSeq=%d)",
-			topicName, partition, msg.ProducerID, msg.SeqNum, lastSeq)
-		return true // Duplicate
-	}
-
-	tm.producerState[topicName][partition][msg.ProducerID] = int64(msg.SeqNum)
-	util.Debug("tm: [idempotency] UPDATED sequence for topic=%s, partition=%d, producer=%s, seq=%d (previous=%d, ok=%v)",
-		topicName, partition, msg.ProducerID, msg.SeqNum, lastSeq, ok)
-	return false // New message, state updated
 }
 
 func (tm *TopicManager) RegisterConsumerGroup(topicName, groupName string, consumerCount int) (*types.ConsumerGroup, error) {
@@ -332,7 +288,6 @@ func (tm *TopicManager) DeleteTopic(name string) bool {
 	defer tm.mu.Unlock()
 	if _, ok := tm.topics[name]; ok {
 		delete(tm.topics, name)
-		delete(tm.producerState, name)
 		return true
 	}
 	return false
@@ -346,6 +301,10 @@ func (tm *TopicManager) ListTopics() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+func (tm *TopicManager) GetLogDir(topicName string, partitionID int) string {
+	return fmt.Sprintf("%s%c%s%cpartition_%d", tm.cfg.LogDir, os.PathSeparator, topicName, os.PathSeparator, partitionID)
 }
 
 func (tm *TopicManager) EnsureDefaultGroups() {

--- a/pkg/topic/manager_ext_test.go
+++ b/pkg/topic/manager_ext_test.go
@@ -36,7 +36,7 @@ func TestTopicManager_GetLastOffset(t *testing.T) {
 	mockHandler.On("GetLatestOffset").Return(uint64(0))
 	hp.On("GetHandler", topicName, 0).Return(mockHandler, nil)
 
-	err := tm.CreateTopic(topicName, 1, false)
+	err := tm.CreateTopic(topicName, 1, false, false)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint64(0), tm.GetLastOffset(topicName, -1))
@@ -62,7 +62,7 @@ func TestTopicManager_Publish(t *testing.T) {
 	mockHandler.On("GetLatestOffset").Return(uint64(0))
 	hp.On("GetHandler", topicName, 0).Return(mockHandler, nil)
 
-	err = tm.CreateTopic(topicName, 1, false)
+	err = tm.CreateTopic(topicName, 1, false, false)
 	assert.NoError(t, err)
 
 	// mock.Anything is used because we don't care about the specific message object for this test
@@ -88,7 +88,7 @@ func TestTopicManager_PublishWithAck(t *testing.T) {
 	mockHandler.On("GetLatestOffset").Return(uint64(0))
 	hp.On("GetHandler", topicName, 0).Return(mockHandler, nil)
 
-	err = tm.CreateTopic(topicName, 1, false)
+	err = tm.CreateTopic(topicName, 1, false, false)
 	assert.NoError(t, err)
 
 	mockHandler.On("AppendMessageSync", topicName, 0, mock.Anything).Return(uint64(1), nil)
@@ -123,7 +123,7 @@ func TestTopicManager_PublishBatch(t *testing.T) {
 	mockHandler.On("GetLatestOffset").Return(uint64(0))
 	hp.On("GetHandler", topicName, 0).Return(mockHandler, nil)
 
-	err = tm.CreateTopic(topicName, 1, false)
+	err = tm.CreateTopic(topicName, 1, false, false)
 	assert.NoError(t, err)
 
 	// Two messages in Sync batch
@@ -153,20 +153,6 @@ func TestTopicManager_DeleteAndList(t *testing.T) {
 	assert.Len(t, tm.ListTopics(), 1)
 }
 
-func TestTopicManager_CheckAndMarkProducerSequence(t *testing.T) {
-	tm := NewTopicManager(config.DefaultConfig(), nil, nil)
-	topic := "topic1"
-	partition := 0
-	producer := "p1"
-
-	msg1 := &types.Message{ProducerID: producer, SeqNum: 10}
-	msg2 := &types.Message{ProducerID: producer, SeqNum: 5}  // Duplicate (less than 10)
-	msg3 := &types.Message{ProducerID: producer, SeqNum: 11} // New
-
-	assert.False(t, tm.CheckAndMarkProducerSequence(topic, partition, msg1))
-	assert.True(t, tm.CheckAndMarkProducerSequence(topic, partition, msg2))
-	assert.False(t, tm.CheckAndMarkProducerSequence(topic, partition, msg3))
-}
 
 func TestTopicManager_Flush(t *testing.T) {
 	hp := new(MockHandlerProvider)
@@ -177,7 +163,7 @@ func TestTopicManager_Flush(t *testing.T) {
 	mockHandler.On("GetLatestOffset").Return(uint64(0))
 	hp.On("GetHandler", topicName, 0).Return(mockHandler, nil)
 
-	err := tm.CreateTopic(topicName, 1, false)
+	err := tm.CreateTopic(topicName, 1, false, false)
 	assert.NoError(t, err)
 
 	mockHandler.On("Flush").Return().Once()

--- a/pkg/topic/manager_test.go
+++ b/pkg/topic/manager_test.go
@@ -138,12 +138,12 @@ func TestTopicManagerCreateTopic(t *testing.T) {
 	}
 	sm.On("GetStreamsForPartition", mock.Anything, mock.Anything).Return([]*stream.StreamConnection{}).Maybe()
 
-	assert.NoError(t, tm.CreateTopic(topicName, partitionCount, false))
+	assert.NoError(t, tm.CreateTopic(topicName, partitionCount, false, false))
 	assert.NotNil(t, tm.GetTopic(topicName))
 	assert.Equal(t, partitionCount, len(tm.GetTopic(topicName).Partitions))
 	hp.AssertExpectations(t)
 
-	assert.NoError(t, tm.CreateTopic(topicName, partitionCount, false))
+	assert.NoError(t, tm.CreateTopic(topicName, partitionCount, false, false))
 	assert.Equal(t, partitionCount, len(tm.GetTopic(topicName).Partitions))
 	hp.AssertExpectations(t)
 
@@ -154,18 +154,18 @@ func TestTopicManagerCreateTopic(t *testing.T) {
 		hp.On("GetHandler", topicName, i).Return(mockStorageHandler, nil).Once()
 	}
 
-	assert.NoError(t, tm.CreateTopic(topicName, newPartitionCount, false))
+	assert.NoError(t, tm.CreateTopic(topicName, newPartitionCount, false, false))
 	assert.Equal(t, newPartitionCount, len(tm.GetTopic(topicName).Partitions))
 	hp.AssertExpectations(t)
 
-	assert.Error(t, tm.CreateTopic(topicName, 2, false))
+	assert.Error(t, tm.CreateTopic(topicName, 2, false, false))
 	assert.Equal(t, newPartitionCount, len(tm.GetTopic(topicName).Partitions)) // should still be 5
 	hp.AssertExpectations(t)
 
 	errorTopicName := "error-topic"
 	hp.On("GetHandler", errorTopicName, 0).Return(nil, assert.AnError).Once()
 
-	assert.Error(t, tm.CreateTopic(errorTopicName, 1, false))
+	assert.Error(t, tm.CreateTopic(errorTopicName, 1, false, false))
 	assert.Nil(t, tm.GetTopic(errorTopicName))
 	hp.AssertExpectations(t)
 

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -61,7 +61,6 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 		}
 	}
 
-	go p.runProducerCleanup()
 	return p
 }
 

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -4,12 +4,19 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/disk"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
 )
+
+// producerEntry tracks the last sequence number and activity time for a producer.
+type producerEntry struct {
+	lastSeq  uint64
+	lastSeen time.Time
+}
 
 // Partition handles messages for one shard of a topic.
 type Partition struct {
@@ -22,8 +29,9 @@ type Partition struct {
 	dh            types.StorageHandler
 	closed        bool
 	streamManager StreamManager
-	producerState sync.Map // map[string]uint64 (ProducerID -> LastSeqNum)
+	producerState sync.Map // map[string]*producerEntry
 	isIdempotent  bool
+	closeCh       chan struct{}
 }
 
 // NewPartition creates a partition instance.
@@ -37,6 +45,7 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 		dh:            dh,
 		streamManager: sm,
 		newMessageCh:  make(chan struct{}, 1),
+		closeCh:       make(chan struct{}),
 	}
 
 	p.LEO.Store(initialOffset)
@@ -52,6 +61,7 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 		}
 	}
 
+	go p.runProducerCleanup()
 	return p
 }
 
@@ -65,9 +75,10 @@ func (p *Partition) isDuplicate(msg *types.Message) bool {
 		return false
 	}
 
-	lastSeq, ok := p.producerState.Load(msg.ProducerID)
+	val, ok := p.producerState.Load(msg.ProducerID)
 	if ok {
-		if msg.SeqNum <= lastSeq.(uint64) {
+		entry := val.(*producerEntry)
+		if msg.SeqNum <= entry.lastSeq {
 			return true
 		}
 	}
@@ -76,7 +87,10 @@ func (p *Partition) isDuplicate(msg *types.Message) bool {
 
 func (p *Partition) updateProducerState(msg *types.Message) {
 	if msg.ProducerID != "" {
-		p.producerState.Store(msg.ProducerID, msg.SeqNum)
+		p.producerState.Store(msg.ProducerID, &producerEntry{
+			lastSeq:  msg.SeqNum,
+			lastSeen: time.Now(),
+		})
 	}
 }
 
@@ -259,6 +273,13 @@ func (p *Partition) SetHWM(hwm uint64) {
 	}
 }
 
+// GetHWM returns the high water mark in a thread-safe manner.
+func (p *Partition) GetHWM() uint64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.HWM
+}
+
 func (p *Partition) UpdateLEO(leo uint64) {
 	p.LEO.Store(leo)
 }
@@ -271,4 +292,32 @@ func (p *Partition) Close() {
 		return
 	}
 	p.closed = true
+	close(p.closeCh)
+}
+
+const producerStateTTL = 30 * time.Minute
+
+// cleanStaleProducers removes producer entries that have not been seen within the TTL.
+func (p *Partition) cleanStaleProducers() {
+	cutoff := time.Now().Add(-producerStateTTL)
+	p.producerState.Range(func(key, value any) bool {
+		if entry := value.(*producerEntry); entry.lastSeen.Before(cutoff) {
+			p.producerState.Delete(key)
+		}
+		return true
+	})
+}
+
+// runProducerCleanup periodically evicts stale producer state to bound memory usage.
+func (p *Partition) runProducerCleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.cleanStaleProducers()
+		case <-p.closeCh:
+			return
+		}
+	}
 }

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -37,6 +37,9 @@ func NewTopic(name string, partitionCount int, hp HandlerProvider, cfg *config.C
 		}
 		p := NewPartition(i, name, dh, sm, cfg)
 		p.isIdempotent = idempotent
+		if idempotent {
+			go p.runProducerCleanup()
+		}
 		partitions[i] = p
 	}
 	return &Topic{
@@ -91,6 +94,9 @@ func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
 		}
 		newP := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
 		newP.isIdempotent = t.IsIdempotent
+		if t.IsIdempotent {
+			go newP.runProducerCleanup()
+		}
 		t.Partitions = append(t.Partitions, newP)
 	}
 	return nil
@@ -137,17 +143,17 @@ func (t *Topic) DeregisterConsumerGroup(groupName string) error {
 // Publish sends a message to one partition.
 // Partition selection and enqueue happen under a single RLock to prevent
 // TOCTOU races with AddPartitions.
-func (t *Topic) Publish(msg types.Message) {
+func (t *Topic) Publish(msg types.Message) error {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
 	idx := t.getPartitionIndex(msg, len(t.Partitions))
 	if idx == -1 {
-		util.Error("No partitions available for topic '%s'", t.Name)
-		return
+		return fmt.Errorf("no partitions available for topic '%s'", t.Name)
 	}
 
 	t.Partitions[idx].Enqueue(msg)
+	return nil
 }
 
 // PublishSync sends a message synchronously to one partition.

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -22,12 +22,13 @@ type Topic struct {
 	consumerGroups map[string]*types.ConsumerGroup
 	mu             sync.RWMutex
 	cfg            *config.Config
-	streamManager  StreamManager
-	IsIdempotent   bool
+	streamManager    StreamManager
+	IsIdempotent     bool
+	IsEventSourcing  bool
 }
 
 // NewTopic initializes a topic with partitions.
-func NewTopic(name string, partitionCount int, hp HandlerProvider, cfg *config.Config, sm StreamManager, idempotent bool) (*Topic, error) {
+func NewTopic(name string, partitionCount int, hp HandlerProvider, cfg *config.Config, sm StreamManager, idempotent bool, eventSourcing bool) (*Topic, error) {
 	partitions := make([]*Partition, partitionCount)
 	for i := 0; i < partitionCount; i++ {
 		dh, err := hp.GetHandler(name, i)
@@ -42,32 +43,43 @@ func NewTopic(name string, partitionCount int, hp HandlerProvider, cfg *config.C
 		Name:           name,
 		Partitions:     partitions,
 		consumerGroups: make(map[string]*types.ConsumerGroup),
-		cfg:            cfg,
-		streamManager:  sm,
-		IsIdempotent:   idempotent,
+		cfg:             cfg,
+		streamManager:   sm,
+		IsIdempotent:    idempotent,
+		IsEventSourcing: eventSourcing,
 	}, nil
 }
 
-func (t *Topic) GetPartitionForMessage(msg types.Message) int {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	partitionsLen := uint64(len(t.Partitions))
+// getPartitionIndex computes the target partition index without acquiring any lock.
+// The caller must hold at least RLock and pass the current partition count.
+func (t *Topic) getPartitionIndex(msg types.Message, partitionsLen int) int {
 	if partitionsLen == 0 {
 		return -1
 	}
 
 	if msg.Key != "" {
 		keyID := util.GenerateID(msg.Key)
-		return int(keyID % partitionsLen)
+		return int(keyID % uint64(partitionsLen))
 	}
 
 	oldCounter := atomic.AddUint64(&t.counter, 1) - 1
-	return int(oldCounter % partitionsLen)
+	return int(oldCounter % uint64(partitionsLen))
+}
+
+// GetPartitionForMessage returns the partition index for a message.
+// This is intended for external callers (e.g. TopicManager). Internal publish
+// methods use getPartitionIndex under an already-held RLock to avoid TOCTOU races.
+func (t *Topic) GetPartitionForMessage(msg types.Message) int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.getPartitionIndex(msg, len(t.Partitions))
 }
 
 // AddPartitions extends the topic with new partitions.
-func (t *Topic) AddPartitions(extra int, hp HandlerProvider) {
+// Returns an error if any partition fails to initialize; partitions created
+// before the failure are kept.
+func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -75,13 +87,13 @@ func (t *Topic) AddPartitions(extra int, hp HandlerProvider) {
 		idx := len(t.Partitions)
 		dh, err := hp.GetHandler(t.Name, idx)
 		if err != nil {
-			util.Error("❌ failed to attach partition %d for topic '%s': %v\n", idx, t.Name, err)
-			return
+			return fmt.Errorf("failed to attach partition %d for topic '%s': %w", idx, t.Name, err)
 		}
 		newP := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
 		newP.isIdempotent = t.IsIdempotent
 		t.Partitions = append(t.Partitions, newP)
 	}
+	return nil
 }
 
 // RegisterConsumerGroup registers a consumer group to the topic.
@@ -94,9 +106,8 @@ func (t *Topic) RegisterConsumerGroup(groupName string, consumerCount int) *type
 	}
 
 	group := &types.ConsumerGroup{
-		Name:             groupName,
-		Consumers:        make([]*types.Consumer, consumerCount),
-		CommittedOffsets: make(map[int]uint64),
+		Name:      groupName,
+		Consumers: make([]*types.Consumer, consumerCount),
 	}
 
 	for i := 0; i < consumerCount; i++ {
@@ -124,64 +135,58 @@ func (t *Topic) DeregisterConsumerGroup(groupName string) error {
 }
 
 // Publish sends a message to one partition.
+// Partition selection and enqueue happen under a single RLock to prevent
+// TOCTOU races with AddPartitions.
 func (t *Topic) Publish(msg types.Message) {
-	idx := t.GetPartitionForMessage(msg)
-
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
+	idx := t.getPartitionIndex(msg, len(t.Partitions))
 	if idx == -1 {
-		util.Error("❌ No partitions available for topic '%s'", t.Name)
-		return
-	}
-	if idx < 0 || idx >= len(t.Partitions) {
-		util.Error("❌ Partition index %d out of range for topic '%s'", idx, t.Name)
+		util.Error("No partitions available for topic '%s'", t.Name)
 		return
 	}
 
-	p := t.Partitions[idx]
-	p.Enqueue(msg)
+	t.Partitions[idx].Enqueue(msg)
 }
 
+// PublishSync sends a message synchronously to one partition.
+// Partition selection and enqueue happen under a single RLock to prevent
+// TOCTOU races with AddPartitions.
 func (t *Topic) PublishSync(msg types.Message) error {
-	idx := t.GetPartitionForMessage(msg)
-
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
+	idx := t.getPartitionIndex(msg, len(t.Partitions))
 	if idx == -1 {
 		return fmt.Errorf("no partitions available for topic '%s'", t.Name)
-	}
-	if idx < 0 || idx >= len(t.Partitions) {
-		return fmt.Errorf("partition index %d out of range", idx)
 	}
 
 	return t.Partitions[idx].EnqueueSync(msg)
 }
 
+// PublishBatchSync sends a batch of messages synchronously, grouping by partition.
+// Partition selection and enqueue happen under a single RLock to prevent
+// TOCTOU races with AddPartitions.
 func (t *Topic) PublishBatchSync(msgs []types.Message) error {
 	if len(msgs) == 0 {
 		return nil
 	}
 
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	partitionsLen := len(t.Partitions)
 	partitioned := make(map[int][]types.Message)
 	for _, msg := range msgs {
-		idx := t.GetPartitionForMessage(msg)
+		idx := t.getPartitionIndex(msg, partitionsLen)
 		if idx != -1 {
 			partitioned[idx] = append(partitioned[idx], msg)
 		}
 	}
 
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
 	for idx, pm := range partitioned {
-		if idx < 0 || idx >= len(t.Partitions) {
-			continue
-		}
-
-		p := t.Partitions[idx]
-		if err := p.EnqueueBatchSync(pm); err != nil {
+		if err := t.Partitions[idx].EnqueueBatchSync(pm); err != nil {
 			return fmt.Errorf("partition %d: failed to publish batch: %w", idx, err)
 		}
 	}
@@ -215,39 +220,6 @@ func (t *Topic) applyAssignments(groupName string, assignments map[string][]int)
 	}
 
 	util.Debug("Applied assignments for group '%s': %v", groupName, assignments)
-}
-
-func (t *Topic) GetCommittedOffset(groupName string, partition int) (uint64, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	group, ok := t.consumerGroups[groupName]
-	if !ok {
-		return 0, false
-	}
-
-	offset, ok := group.CommittedOffsets[partition]
-	return offset, ok
-}
-
-func (t *Topic) CommitOffset(groupName string, partition int, offset uint64) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if partition < 0 || partition >= len(t.Partitions) {
-		return fmt.Errorf("partition %d out of range [0, %d)", partition, len(t.Partitions))
-	}
-
-	group, ok := t.consumerGroups[groupName]
-	if !ok {
-		return fmt.Errorf("consumer group '%s' not found", groupName)
-	}
-
-	if group.CommittedOffsets == nil {
-		group.CommittedOffsets = make(map[int]uint64)
-	}
-	group.CommittedOffsets[partition] = offset
-	return nil
 }
 
 func (t *Topic) NewMessageSignal(partition int) <-chan struct{} {

--- a/pkg/topic/topic_ext_test.go
+++ b/pkg/topic/topic_ext_test.go
@@ -27,7 +27,7 @@ func TestTopic_Basic(t *testing.T) {
 		hp.On("GetHandler", topicName, i).Return(mh, nil)
 	}
 
-	topic, err := NewTopic(topicName, partitionCount, hp, cfg, sm, false)
+	topic, err := NewTopic(topicName, partitionCount, hp, cfg, sm, false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, topic)
 	assert.Equal(t, topicName, topic.Name)
@@ -56,16 +56,8 @@ func TestTopic_Basic(t *testing.T) {
 		g2 := topic.RegisterConsumerGroup(groupName, 5) // Existing
 		assert.Equal(t, 3, len(g2.Consumers))
 
-		err := topic.CommitOffset(groupName, 0, 100)
+		err := topic.DeregisterConsumerGroup(groupName)
 		assert.NoError(t, err)
-		off, ok := topic.GetCommittedOffset(groupName, 0)
-		assert.True(t, ok)
-		assert.Equal(t, uint64(100), off)
-
-		err = topic.DeregisterConsumerGroup(groupName)
-		assert.NoError(t, err)
-		_, ok = topic.GetCommittedOffset(groupName, 0)
-		assert.False(t, ok)
 
 		err = topic.DeregisterConsumerGroup("non-existent")
 		assert.Error(t, err)
@@ -76,7 +68,8 @@ func TestTopic_Basic(t *testing.T) {
 		mh.On("GetLatestOffset").Return(uint64(0))
 		hp.On("GetHandler", topicName, 2).Return(mh, nil)
 
-		topic.AddPartitions(1, hp)
+		err := topic.AddPartitions(1, hp)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(topic.Partitions))
 	})
 

--- a/pkg/types/consumer.go
+++ b/pkg/types/consumer.go
@@ -20,7 +20,6 @@ type Consumer struct {
 
 // ConsumerGroup contains consumers subscribed to the same topic.
 type ConsumerGroup struct {
-	Name             string
-	Consumers        []*Consumer
-	CommittedOffsets map[int]uint64
+	Name      string
+	Consumers []*Consumer
 }

--- a/pkg/types/message.go
+++ b/pkg/types/message.go
@@ -11,6 +11,11 @@ type Message struct {
 	Key        string // optional: partition routing key
 	Epoch      int64
 
+	EventType        string
+	SchemaVersion    uint32
+	AggregateVersion uint64
+	Metadata         string
+
 	RetryCount int
 	Retry      bool
 }
@@ -39,6 +44,11 @@ type DiskMessage struct {
 	SeqNum     uint64
 	Epoch      int64
 	Payload    string
+
+	EventType        string
+	SchemaVersion    uint32
+	AggregateVersion uint64
+	Metadata         string
 }
 
 // AppendResult represents the result of appending a message to storage

--- a/pkg/types/message.go
+++ b/pkg/types/message.go
@@ -21,8 +21,8 @@ type Message struct {
 }
 
 func (m Message) String() string {
-	return fmt.Sprintf("Message { ID: %s-%d, Payload:%s, Offset:%d, Key:%s, Epoch:%d, RetryCount:%d }",
-		m.ProducerID, m.SeqNum, m.Payload, m.Offset, m.Key, m.Epoch, m.RetryCount)
+	return fmt.Sprintf("Message { ID: %s-%d, Payload:%s, Offset:%d, Key:%s, Epoch:%d, RetryCount:%d, EventType:%s, AggregateVersion:%d }",
+		m.ProducerID, m.SeqNum, m.Payload, m.Offset, m.Key, m.Epoch, m.RetryCount, m.EventType, m.AggregateVersion)
 }
 
 type Batch struct {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -16,6 +16,6 @@ func TestMessageString(t *testing.T) {
 		RetryCount: 0,
 	}
 
-	expected := "Message { ID: p1-100, Payload:hello, Offset:50, Key:k1, Epoch:1, RetryCount:0 }"
+	expected := "Message { ID: p1-100, Payload:hello, Offset:50, Key:k1, Epoch:1, RetryCount:0, EventType:, AggregateVersion:0 }"
 	assert.Equal(t, expected, m.String())
 }

--- a/sdk/bench/consumer_metrics.go
+++ b/sdk/bench/consumer_metrics.go
@@ -240,35 +240,49 @@ func percentile(sorted []float64, p float64) float64 {
 }
 
 // PrintSummaryTo writes a formatted summary to w.
-func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
+func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	var firstErr error
+	p := func(format string, args ...any) {
+		if firstErr != nil {
+			return
+		}
+		_, firstErr = fmt.Fprintf(w, format, args...)
+	}
+	pln := func(a ...any) {
+		if firstErr != nil {
+			return
+		}
+		_, firstErr = fmt.Fprintln(w, a...)
+	}
 
 	elapsed := time.Since(m.startTime).Seconds()
 	total := atomic.LoadInt64(&m.totalMsgs)
 
-	_, _ = fmt.Fprintln(w)
-	_, _ = fmt.Fprintln(w, consumerSep)
-	_, _ = fmt.Fprintln(w, "CONSUMER BENCHMARK SUMMARY")
-	_, _ = fmt.Fprintf(w, "Total Messages       : %d\n", total)
-	_, _ = fmt.Fprintf(w, "Elapsed Time         : %.2fs\n", elapsed)
+	pln()
+	pln(consumerSep)
+	pln("CONSUMER BENCHMARK SUMMARY")
+	p("Total Messages       : %d\n", total)
+	p("Elapsed Time         : %.2fs\n", elapsed)
 
 	overallTPS := 0.0
 	if elapsed > 0 {
 		overallTPS = float64(total) / elapsed
 	}
-	_, _ = fmt.Fprintf(w, "Overall TPS          : %.2f msg/s\n", overallTPS)
+	p("Overall TPS          : %.2f msg/s\n", overallTPS)
 
 	if m.enableCorrectness {
-		_, _ = fmt.Fprintf(w, "Duplicate (MessageID): %d (fp possible)\n", atomic.LoadInt64(&m.dupCount))
-		_, _ = fmt.Fprintf(w, "Duplicate (Offset)   : %d (fp possible)\n", atomic.LoadInt64(&m.dupOffsetCount))
-		_, _ = fmt.Fprintf(w, "Messages missing     : %d\n", atomic.LoadInt64(&m.missingCount))
+		p("Duplicate (MessageID): %d (fp possible)\n", atomic.LoadInt64(&m.dupCount))
+		p("Duplicate (Offset)   : %d (fp possible)\n", atomic.LoadInt64(&m.dupOffsetCount))
+		p("Messages missing     : %d\n", atomic.LoadInt64(&m.missingCount))
 	} else {
-		_, _ = fmt.Fprintf(w, "Correctness Check    : disabled\n")
+		p("Correctness Check    : disabled\n")
 	}
 
 	if m.rebalance != nil && !m.rebalance.End.IsZero() {
-		_, _ = fmt.Fprintf(w, "Rebalancing Cost     : %d ms\n", m.rebalance.End.Sub(m.rebalance.Start).Milliseconds())
+		p("Rebalancing Cost     : %d ms\n", m.rebalance.End.Sub(m.rebalance.Start).Milliseconds())
 	}
 
 	var phaseKeys []string
@@ -295,23 +309,26 @@ func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
 
 		sort.Float64s(tpsValues)
 
-		_, _ = fmt.Fprintln(w)
-		_, _ = fmt.Fprintf(w, "Phase: %s\n", k)
-		_, _ = fmt.Fprintf(w, "  Phase Total TPS       : %.2f\n", pm.TPS())
-		_, _ = fmt.Fprintf(w, "  p95 Partition TPS     : %.2f\n", percentile(tpsValues, 0.95))
-		_, _ = fmt.Fprintf(w, "  p99 Partition TPS     : %.2f\n", percentile(tpsValues, 0.99))
+		pln()
+		p("Phase: %s\n", k)
+		p("  Phase Total TPS       : %.2f\n", pm.TPS())
+		p("  p95 Partition TPS     : %.2f\n", percentile(tpsValues, 0.95))
+		p("  p99 Partition TPS     : %.2f\n", percentile(tpsValues, 0.99))
 
 		for _, id := range pIDs {
-			p := pm.partitions[id]
-			_, _ = fmt.Fprintf(w, "    #%-2d total=%-8d avgTPS=%.1f\n", p.ID, atomic.LoadInt64(&p.totalMsgs), p.TPS())
+			pt := pm.partitions[id]
+			p("    #%-2d total=%-8d avgTPS=%.1f\n", pt.ID, atomic.LoadInt64(&pt.totalMsgs), pt.TPS())
 		}
 	}
 
-	_, _ = fmt.Fprintln(w, consumerSep)
+	pln(consumerSep)
+	return firstErr
 }
 
 // PrintSummary writes the summary to stdout.
 func (m *ConsumerMetrics) PrintSummary() {
 	_, _ = fmt.Fprintln(os.Stdout, "Benchmark completed successfully!")
-	m.PrintSummaryTo(os.Stdout)
+	if err := m.PrintSummaryTo(os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write summary: %v\n", err)
+	}
 }

--- a/sdk/bench/consumer_metrics.go
+++ b/sdk/bench/consumer_metrics.go
@@ -247,28 +247,28 @@ func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
 	elapsed := time.Since(m.startTime).Seconds()
 	total := atomic.LoadInt64(&m.totalMsgs)
 
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, consumerSep)
-	fmt.Fprintln(w, "CONSUMER BENCHMARK SUMMARY")
-	fmt.Fprintf(w, "Total Messages       : %d\n", total)
-	fmt.Fprintf(w, "Elapsed Time         : %.2fs\n", elapsed)
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, consumerSep)
+	_, _ = fmt.Fprintln(w, "CONSUMER BENCHMARK SUMMARY")
+	_, _ = fmt.Fprintf(w, "Total Messages       : %d\n", total)
+	_, _ = fmt.Fprintf(w, "Elapsed Time         : %.2fs\n", elapsed)
 
 	overallTPS := 0.0
 	if elapsed > 0 {
 		overallTPS = float64(total) / elapsed
 	}
-	fmt.Fprintf(w, "Overall TPS          : %.2f msg/s\n", overallTPS)
+	_, _ = fmt.Fprintf(w, "Overall TPS          : %.2f msg/s\n", overallTPS)
 
 	if m.enableCorrectness {
-		fmt.Fprintf(w, "Duplicate (MessageID): %d (fp possible)\n", atomic.LoadInt64(&m.dupCount))
-		fmt.Fprintf(w, "Duplicate (Offset)   : %d (fp possible)\n", atomic.LoadInt64(&m.dupOffsetCount))
-		fmt.Fprintf(w, "Messages missing     : %d\n", atomic.LoadInt64(&m.missingCount))
+		_, _ = fmt.Fprintf(w, "Duplicate (MessageID): %d (fp possible)\n", atomic.LoadInt64(&m.dupCount))
+		_, _ = fmt.Fprintf(w, "Duplicate (Offset)   : %d (fp possible)\n", atomic.LoadInt64(&m.dupOffsetCount))
+		_, _ = fmt.Fprintf(w, "Messages missing     : %d\n", atomic.LoadInt64(&m.missingCount))
 	} else {
-		fmt.Fprintf(w, "Correctness Check    : disabled\n")
+		_, _ = fmt.Fprintf(w, "Correctness Check    : disabled\n")
 	}
 
 	if m.rebalance != nil && !m.rebalance.End.IsZero() {
-		fmt.Fprintf(w, "Rebalancing Cost     : %d ms\n", m.rebalance.End.Sub(m.rebalance.Start).Milliseconds())
+		_, _ = fmt.Fprintf(w, "Rebalancing Cost     : %d ms\n", m.rebalance.End.Sub(m.rebalance.Start).Milliseconds())
 	}
 
 	var phaseKeys []string
@@ -295,23 +295,23 @@ func (m *ConsumerMetrics) PrintSummaryTo(w io.Writer) {
 
 		sort.Float64s(tpsValues)
 
-		fmt.Fprintln(w)
-		fmt.Fprintf(w, "Phase: %s\n", k)
-		fmt.Fprintf(w, "  Phase Total TPS       : %.2f\n", pm.TPS())
-		fmt.Fprintf(w, "  p95 Partition TPS     : %.2f\n", percentile(tpsValues, 0.95))
-		fmt.Fprintf(w, "  p99 Partition TPS     : %.2f\n", percentile(tpsValues, 0.99))
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintf(w, "Phase: %s\n", k)
+		_, _ = fmt.Fprintf(w, "  Phase Total TPS       : %.2f\n", pm.TPS())
+		_, _ = fmt.Fprintf(w, "  p95 Partition TPS     : %.2f\n", percentile(tpsValues, 0.95))
+		_, _ = fmt.Fprintf(w, "  p99 Partition TPS     : %.2f\n", percentile(tpsValues, 0.99))
 
 		for _, id := range pIDs {
 			p := pm.partitions[id]
-			fmt.Fprintf(w, "    #%-2d total=%-8d avgTPS=%.1f\n", p.ID, atomic.LoadInt64(&p.totalMsgs), p.TPS())
+			_, _ = fmt.Fprintf(w, "    #%-2d total=%-8d avgTPS=%.1f\n", p.ID, atomic.LoadInt64(&p.totalMsgs), p.TPS())
 		}
 	}
 
-	fmt.Fprintln(w, consumerSep)
+	_, _ = fmt.Fprintln(w, consumerSep)
 }
 
 // PrintSummary writes the summary to stdout.
 func (m *ConsumerMetrics) PrintSummary() {
-	fmt.Fprintln(os.Stdout, "Benchmark completed successfully!")
+	_, _ = fmt.Fprintln(os.Stdout, "Benchmark completed successfully!")
 	m.PrintSummaryTo(os.Stdout)
 }

--- a/sdk/bench/producer_metrics.go
+++ b/sdk/bench/producer_metrics.go
@@ -107,34 +107,34 @@ func PrintBenchmarkSummaryFixedTo(
 
 	p95, p99 := CalculateLatencyPercentiles(allLatencies)
 
-	fmt.Fprint(w, "\r\n")
-	fmt.Fprintln(w, producerSep)
-	fmt.Fprintln(w, "PRODUCER BENCHMARK SUMMARY")
-	fmt.Fprintf(w, "%-28s : %d\n", "Partitions", len(partitionStats))
-	fmt.Fprintf(w, "%-28s : %d\n", "Total Batches", totalBatches)
-	fmt.Fprintf(w, "%-28s : %d / %d (rate: %.2f%%)\n", "Total Messages", publishedMessages, targetCount, successRate)
-	fmt.Fprintf(w, "%-28s : %d\n", "Failed messages", failedCount)
-	fmt.Fprintf(w, "%-28s : %d\n", "Retry Count", retryCount)
-	fmt.Fprintf(w, "%-28s : %.3fs\n", "Publish Elapsed Time", seconds)
-	fmt.Fprintf(w, "%-28s : %.2f batches/s\n", "Batch Throughput", batchesPerSec)
-	fmt.Fprintf(w, "%-28s : %.2f msg/s\n", "Message Throughput", messagesPerSec)
-	fmt.Fprintf(w, "%-28s : %.2f ms\n", "Latency P95", float64(p95.Microseconds())/1000.0)
-	fmt.Fprintf(w, "%-28s : %.2f ms\n", "Latency P99", float64(p99.Microseconds())/1000.0)
-	fmt.Fprint(w, "\r\n")
+	_, _ = fmt.Fprint(w, "\r\n")
+	_, _ = fmt.Fprintln(w, producerSep)
+	_, _ = fmt.Fprintln(w, "PRODUCER BENCHMARK SUMMARY")
+	_, _ = fmt.Fprintf(w, "%-28s : %d\n", "Partitions", len(partitionStats))
+	_, _ = fmt.Fprintf(w, "%-28s : %d\n", "Total Batches", totalBatches)
+	_, _ = fmt.Fprintf(w, "%-28s : %d / %d (rate: %.2f%%)\n", "Total Messages", publishedMessages, targetCount, successRate)
+	_, _ = fmt.Fprintf(w, "%-28s : %d\n", "Failed messages", failedCount)
+	_, _ = fmt.Fprintf(w, "%-28s : %d\n", "Retry Count", retryCount)
+	_, _ = fmt.Fprintf(w, "%-28s : %.3fs\n", "Publish Elapsed Time", seconds)
+	_, _ = fmt.Fprintf(w, "%-28s : %.2f batches/s\n", "Batch Throughput", batchesPerSec)
+	_, _ = fmt.Fprintf(w, "%-28s : %.2f msg/s\n", "Message Throughput", messagesPerSec)
+	_, _ = fmt.Fprintf(w, "%-28s : %.2f ms\n", "Latency P95", float64(p95.Microseconds())/1000.0)
+	_, _ = fmt.Fprintf(w, "%-28s : %.2f ms\n", "Latency P99", float64(p99.Microseconds())/1000.0)
+	_, _ = fmt.Fprint(w, "\r\n")
 
-	fmt.Fprintln(w, "Partition Breakdown:")
+	_, _ = fmt.Fprintln(w, "Partition Breakdown:")
 	for _, ps := range partitionStats {
-		fmt.Fprintf(w, "  #%-2d batches=%-4d avg_batch=%.2fms\n",
+		_, _ = fmt.Fprintf(w, "  #%-2d batches=%-4d avg_batch=%.2fms\n",
 			ps.PartitionID, ps.BatchCount, float64(ps.AvgDuration.Microseconds())/1000.0)
 	}
 
 	if len(errSummary) > 0 {
-		fmt.Fprintln(w, "\nError Root Cause Analysis:")
+		_, _ = fmt.Fprintln(w, "\nError Root Cause Analysis:")
 		for msg, count := range errSummary {
-			fmt.Fprintf(w, "  - [%d occurrences]: %s\n", count, msg)
+			_, _ = fmt.Fprintf(w, "  - [%d occurrences]: %s\n", count, msg)
 		}
 	}
-	fmt.Fprintln(w, producerSep)
+	_, _ = fmt.Fprintln(w, producerSep)
 
 	result := BenchmarkResult{
 		Timestamp:      time.Now(),

--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -137,7 +137,7 @@ func (es *EventStore) Append(key string, expectedVersion uint64, event *Event) (
 		sv = 1
 	}
 
-	cmd := fmt.Sprintf("APPEND_STREAM topic=%s key=%s expected_version=%d event_type=%s schema_version=%d producerId=%s",
+	cmd := fmt.Sprintf("APPEND_STREAM topic=%s key=%s version=%d event_type=%s schema_version=%d producerId=%s",
 		es.topic, key, expectedVersion, event.Type, sv, es.producerID)
 	if event.Metadata != "" {
 		cmd += fmt.Sprintf(" metadata=%s", event.Metadata)

--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -1,0 +1,305 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Event represents a domain event to be appended to a stream.
+type Event struct {
+	Type          string // e.g., "OrderCreated"
+	SchemaVersion uint32 // default 1
+	Payload       string // serialized event data
+	Metadata      string // optional JSON metadata
+}
+
+// StreamEvent is an event read from a stream, with version and offset.
+// NOTE: Type, SchemaVersion, and Metadata are not yet populated by ReadStream
+// because the current batch wire format (EncodeBatchMessages) does not carry
+// event sourcing fields. These will be filled once the batch protocol is extended.
+type StreamEvent struct {
+	Version       uint64
+	Offset        uint64
+	Type          string
+	SchemaVersion uint32
+	Payload       string
+	Metadata      string
+}
+
+// Snapshot holds a stored aggregate snapshot.
+type Snapshot struct {
+	Version uint64 `json:"version"`
+	Payload string `json:"payload"`
+}
+
+// StreamData is the result of reading a stream.
+type StreamData struct {
+	Snapshot *Snapshot
+	Events   []StreamEvent
+}
+
+// AppendResult is returned after successfully appending an event.
+type AppendResult struct {
+	Version   uint64
+	Offset    uint64
+	Partition int
+}
+
+// EventStore provides event sourcing operations against a Cursus broker.
+type EventStore struct {
+	topic      string
+	producerID string
+	addr       string
+	mu         sync.Mutex
+	conn       net.Conn
+}
+
+// NewEventStore creates an EventStore for the given topic.
+func NewEventStore(addr, topic, producerID string) *EventStore {
+	return &EventStore{
+		topic:      topic,
+		producerID: producerID,
+		addr:       addr,
+	}
+}
+
+// getConn returns an existing or new TCP connection.
+func (es *EventStore) getConn() (net.Conn, error) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+
+	if es.conn != nil {
+		return es.conn, nil
+	}
+
+	conn, err := net.DialTimeout("tcp", es.addr, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect to %s: %w", es.addr, err)
+	}
+	es.conn = conn
+	return conn, nil
+}
+
+// resetConn closes and clears the connection (for retry).
+func (es *EventStore) resetConn() {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.conn != nil {
+		_ = es.conn.Close()
+		es.conn = nil
+	}
+}
+
+// sendCommand sends a text command and returns the response string.
+func (es *EventStore) sendCommand(cmd string) (string, error) {
+	conn, err := es.getConn()
+	if err != nil {
+		return "", err
+	}
+
+	data := EncodeMessage("", cmd)
+	if err := WriteWithLength(conn, data); err != nil {
+		es.resetConn()
+		return "", fmt.Errorf("write: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		es.resetConn()
+		return "", fmt.Errorf("read: %w", err)
+	}
+
+	return string(resp), nil
+}
+
+// CreateTopic creates an event-sourcing-enabled topic if it doesn't exist.
+func (es *EventStore) CreateTopic(partitions int) error {
+	resp, err := es.sendCommand(fmt.Sprintf("CREATE topic=%s partitions=%d event_sourcing=true", es.topic, partitions))
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(resp, "ERROR") {
+		return fmt.Errorf("broker: %s", resp)
+	}
+	return nil
+}
+
+// Append appends an event to an aggregate stream with optimistic concurrency.
+// expectedVersion is the current version of the aggregate (0 for new aggregates).
+func (es *EventStore) Append(key string, expectedVersion uint64, event *Event) (*AppendResult, error) {
+	sv := event.SchemaVersion
+	if sv == 0 {
+		sv = 1
+	}
+
+	cmd := fmt.Sprintf("APPEND_STREAM topic=%s key=%s expected_version=%d event_type=%s schema_version=%d producerId=%s",
+		es.topic, key, expectedVersion, event.Type, sv, es.producerID)
+	if event.Metadata != "" {
+		cmd += fmt.Sprintf(" metadata=%s", event.Metadata)
+	}
+	cmd += fmt.Sprintf(" message=%s", event.Payload)
+
+	resp, err := es.sendCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.HasPrefix(resp, "ERROR:") {
+		return nil, fmt.Errorf("broker: %s", resp)
+	}
+
+	return parseAppendResponse(resp), nil
+}
+
+// parseAppendResponse parses "OK version=N offset=N partition=N" into AppendResult.
+func parseAppendResponse(resp string) *AppendResult {
+	result := &AppendResult{}
+	parts := strings.Fields(resp)
+	for _, p := range parts {
+		kv := strings.SplitN(p, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "version":
+			result.Version, _ = strconv.ParseUint(kv[1], 10, 64)
+		case "offset":
+			result.Offset, _ = strconv.ParseUint(kv[1], 10, 64)
+		case "partition":
+			result.Partition, _ = strconv.Atoi(kv[1])
+		}
+	}
+	return result
+}
+
+// ReadStream reads all events for an aggregate, automatically using snapshots.
+func (es *EventStore) ReadStream(key string) (*StreamData, error) {
+	return es.ReadStreamFrom(key, 0)
+}
+
+// ReadStreamFrom reads events starting from a specific version.
+// If fromVersion is 0, the broker auto-resolves using snapshots.
+func (es *EventStore) ReadStreamFrom(key string, fromVersion uint64) (*StreamData, error) {
+	cmd := fmt.Sprintf("READ_STREAM topic=%s key=%s", es.topic, key)
+	if fromVersion > 0 {
+		cmd += fmt.Sprintf(" from_version=%d", fromVersion)
+	}
+
+	conn, err := es.getConn()
+	if err != nil {
+		return nil, err
+	}
+
+	data := EncodeMessage("", cmd)
+	if err := WriteWithLength(conn, data); err != nil {
+		es.resetConn()
+		return nil, fmt.Errorf("write: %w", err)
+	}
+
+	// Frame 1: JSON envelope
+	envData, err := ReadWithLength(conn)
+	if err != nil {
+		es.resetConn()
+		return nil, fmt.Errorf("read envelope: %w", err)
+	}
+
+	var envelope struct {
+		Snapshot *Snapshot `json:"snapshot"`
+		Count    int       `json:"count"`
+	}
+	if err := json.Unmarshal(envData, &envelope); err != nil {
+		return nil, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+
+	// Frame 2: Binary batch
+	batchData, err := ReadWithLength(conn)
+	if err != nil {
+		es.resetConn()
+		return nil, fmt.Errorf("read batch: %w", err)
+	}
+
+	result := &StreamData{
+		Snapshot: envelope.Snapshot,
+	}
+
+	if len(batchData) > 0 {
+		msgs, _, _, err := DecodeBatchMessages(batchData)
+		if err != nil {
+			return nil, fmt.Errorf("decode batch: %w", err)
+		}
+		for _, m := range msgs {
+			result.Events = append(result.Events, StreamEvent{
+				Version:       m.AggregateVersion,
+				Offset:        m.Offset,
+				Type:          m.EventType,
+				SchemaVersion: m.SchemaVersion,
+				Payload:       m.Payload,
+				Metadata:      m.Metadata,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// SaveSnapshot saves a snapshot for an aggregate at the given version.
+func (es *EventStore) SaveSnapshot(key string, version uint64, payload string) error {
+	cmd := fmt.Sprintf("SAVE_SNAPSHOT topic=%s key=%s version=%d message=%s",
+		es.topic, key, version, payload)
+
+	resp, err := es.sendCommand(cmd)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(resp, "ERROR") {
+		return fmt.Errorf("broker: %s", resp)
+	}
+	return nil
+}
+
+// ReadSnapshot reads the latest snapshot for an aggregate.
+func (es *EventStore) ReadSnapshot(key string) (*Snapshot, error) {
+	resp, err := es.sendCommand(fmt.Sprintf("READ_SNAPSHOT topic=%s key=%s", es.topic, key))
+	if err != nil {
+		return nil, err
+	}
+	if resp == "NULL" || strings.Contains(resp, "NOT_FOUND") {
+		return nil, nil
+	}
+
+	var snap Snapshot
+	if err := json.Unmarshal([]byte(resp), &snap); err != nil {
+		return nil, fmt.Errorf("unmarshal snapshot: %w", err)
+	}
+	return &snap, nil
+}
+
+// StreamVersion returns the current version of an aggregate stream.
+func (es *EventStore) StreamVersion(key string) (uint64, error) {
+	resp, err := es.sendCommand(fmt.Sprintf("STREAM_VERSION topic=%s key=%s", es.topic, key))
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(resp), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse version: %w", err)
+	}
+	return v, nil
+}
+
+// Close closes the underlying connection.
+func (es *EventStore) Close() error {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.conn != nil {
+		err := es.conn.Close()
+		es.conn = nil
+		return err
+	}
+	return nil
+}

--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -71,17 +71,27 @@ func NewEventStore(addr, topic, producerID string) *EventStore {
 // getConn returns an existing or new TCP connection.
 func (es *EventStore) getConn() (net.Conn, error) {
 	es.mu.Lock()
-	defer es.mu.Unlock()
-
 	if es.conn != nil {
-		return es.conn, nil
+		c := es.conn
+		es.mu.Unlock()
+		return c, nil
 	}
+	es.mu.Unlock()
 
 	conn, err := net.DialTimeout("tcp", es.addr, 5*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("connect to %s: %w", es.addr, err)
 	}
+
+	es.mu.Lock()
+	if es.conn != nil {
+		// Another goroutine connected while we were dialing.
+		es.mu.Unlock()
+		_ = conn.Close()
+		return es.conn, nil
+	}
 	es.conn = conn
+	es.mu.Unlock()
 	return conn, nil
 }
 
@@ -270,6 +280,9 @@ func (es *EventStore) ReadSnapshot(key string) (*Snapshot, error) {
 	}
 	if resp == "NULL" || strings.Contains(resp, "NOT_FOUND") {
 		return nil, nil
+	}
+	if strings.HasPrefix(resp, "ERROR") {
+		return nil, fmt.Errorf("broker: %s", resp)
 	}
 
 	var snap Snapshot

--- a/sdk/eventstore_test.go
+++ b/sdk/eventstore_test.go
@@ -1,0 +1,120 @@
+package sdk
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAppendResponse(t *testing.T) {
+	resp := "OK version=3 offset=1024 partition=2"
+
+	result := parseAppendResponse(resp)
+
+	assert.Equal(t, uint64(3), result.Version)
+	assert.Equal(t, uint64(1024), result.Offset)
+	assert.Equal(t, 2, result.Partition)
+}
+
+func TestParseAppendResponse_Partial(t *testing.T) {
+	resp := "OK version=1"
+
+	result := parseAppendResponse(resp)
+
+	assert.Equal(t, uint64(1), result.Version)
+	assert.Equal(t, uint64(0), result.Offset)
+	assert.Equal(t, 0, result.Partition)
+}
+
+func TestParseAppendResponse_Empty(t *testing.T) {
+	result := parseAppendResponse("")
+	assert.Equal(t, uint64(0), result.Version)
+}
+
+func TestEventStore_NewAndClose(t *testing.T) {
+	es := NewEventStore("localhost:9000", "orders", "producer-1")
+	assert.Equal(t, "orders", es.topic)
+	assert.Equal(t, "producer-1", es.producerID)
+	assert.Equal(t, "localhost:9000", es.addr)
+	assert.Nil(t, es.conn)
+	assert.NoError(t, es.Close())
+}
+
+func TestEventStore_CloseIdempotent(t *testing.T) {
+	es := NewEventStore("localhost:9000", "orders", "producer-1")
+	assert.NoError(t, es.Close())
+	assert.NoError(t, es.Close())
+}
+
+func TestEvent_Defaults(t *testing.T) {
+	e := &Event{
+		Type:    "OrderCreated",
+		Payload: `{"customer":"alice"}`,
+	}
+	assert.Equal(t, uint32(0), e.SchemaVersion) // 0 means default; Append sets to 1
+	assert.Equal(t, "", e.Metadata)
+}
+
+func TestEvent_WithMetadata(t *testing.T) {
+	e := &Event{
+		Type:          "OrderShipped",
+		SchemaVersion: 2,
+		Payload:       `{"tracking":"XYZ123"}`,
+		Metadata:      `{"userId":"u-42"}`,
+	}
+	assert.Equal(t, uint32(2), e.SchemaVersion)
+	assert.NotEmpty(t, e.Metadata)
+}
+
+func TestSnapshot_JSON(t *testing.T) {
+	raw := `{"version":5,"payload":"{\"total\":100}"}`
+
+	var snap Snapshot
+	err := json.Unmarshal([]byte(raw), &snap)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(5), snap.Version)
+	assert.Contains(t, snap.Payload, "total")
+}
+
+func TestStreamData_EmptyEvents(t *testing.T) {
+	sd := &StreamData{
+		Snapshot: &Snapshot{Version: 3, Payload: "{}"},
+	}
+	assert.NotNil(t, sd.Snapshot)
+	assert.Empty(t, sd.Events)
+}
+
+// Helper: verify append command formatting matches the expected protocol.
+func TestAppendCommandFormat(t *testing.T) {
+	es := NewEventStore("localhost:9000", "orders", "p-1")
+
+	event := &Event{
+		Type:    "OrderCreated",
+		Payload: `{"id":1}`,
+	}
+
+	// Build the command the same way Append does.
+	sv := event.SchemaVersion
+	if sv == 0 {
+		sv = 1
+	}
+	cmd := "APPEND_STREAM topic=" + es.topic +
+		" key=order-1" +
+		" expected_version=" + strconv.FormatUint(0, 10) +
+		" event_type=" + event.Type +
+		" schema_version=" + strconv.FormatUint(uint64(sv), 10) +
+		" producerId=" + es.producerID +
+		" message=" + event.Payload
+
+	assert.True(t, strings.HasPrefix(cmd, "APPEND_STREAM"))
+	assert.Contains(t, cmd, "topic=orders")
+	assert.Contains(t, cmd, "key=order-1")
+	assert.Contains(t, cmd, "expected_version=0")
+	assert.Contains(t, cmd, "event_type=OrderCreated")
+	assert.Contains(t, cmd, "schema_version=1")
+	assert.Contains(t, cmd, "producerId=p-1")
+	assert.Contains(t, cmd, `message={"id":1}`)
+}

--- a/sdk/eventstore_test.go
+++ b/sdk/eventstore_test.go
@@ -103,7 +103,7 @@ func TestAppendCommandFormat(t *testing.T) {
 	}
 	cmd := "APPEND_STREAM topic=" + es.topic +
 		" key=order-1" +
-		" expected_version=" + strconv.FormatUint(0, 10) +
+		" version=" + strconv.FormatUint(0, 10) +
 		" event_type=" + event.Type +
 		" schema_version=" + strconv.FormatUint(uint64(sv), 10) +
 		" producerId=" + es.producerID +
@@ -112,7 +112,7 @@ func TestAppendCommandFormat(t *testing.T) {
 	assert.True(t, strings.HasPrefix(cmd, "APPEND_STREAM"))
 	assert.Contains(t, cmd, "topic=orders")
 	assert.Contains(t, cmd, "key=order-1")
-	assert.Contains(t, cmd, "expected_version=0")
+	assert.Contains(t, cmd, "version=0")
 	assert.Contains(t, cmd, "event_type=OrderCreated")
 	assert.Contains(t, cmd, "schema_version=1")
 	assert.Contains(t, cmd, "producerId=p-1")

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -174,8 +174,9 @@ func (pc *PartitionConsumer) pollAndProcess() {
 		return
 	}
 
-	// Empty data is a keepalive signal from the broker; skip backoff.
+	// Empty data is a keepalive signal from the broker; reset backoff.
 	if len(batchData) == 0 {
+		bo.reset()
 		return
 	}
 

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -169,8 +169,13 @@ func (pc *PartitionConsumer) pollAndProcess() {
 		return
 	}
 
-	if pc.handleBrokerError(batchData) || len(batchData) == 0 {
+	if pc.handleBrokerError(batchData) {
 		pc.waitWithBackoff(bo)
+		return
+	}
+
+	// Empty data is a keepalive signal from the broker; skip backoff.
+	if len(batchData) == 0 {
 		return
 	}
 
@@ -291,10 +296,15 @@ func (pc *PartitionConsumer) startStreamLoop() {
 				break
 			}
 
-			if len(batchData) == 0 || pc.handleBrokerError(batchData) {
+			if pc.handleBrokerError(batchData) {
 				if !pc.waitWithBackoff(bo) {
 					return
 				}
+				continue
+			}
+
+			// Empty data is a keepalive signal from the broker; continue without backoff.
+			if len(batchData) == 0 {
 				continue
 			}
 

--- a/sdk/protocol.go
+++ b/sdk/protocol.go
@@ -124,6 +124,31 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		if _, err := buf.Write(payloadBytes); err != nil {
 			return nil, fmt.Errorf("write payload bytes failed: %w", err)
 		}
+
+		// Event sourcing fields
+		eventTypeBytes := []byte(m.EventType)
+		if err := write(uint16(len(eventTypeBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(eventTypeBytes); err != nil {
+			return nil, err
+		}
+
+		if err := write(m.SchemaVersion); err != nil {
+			return nil, err
+		}
+
+		if err := write(m.AggregateVersion); err != nil {
+			return nil, err
+		}
+
+		metadataBytes := []byte(m.Metadata)
+		if err := write(uint16(len(metadataBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(metadataBytes); err != nil {
+			return nil, err
+		}
 	}
 
 	return buf.Bytes(), nil
@@ -334,6 +359,35 @@ func DecodeBatchMessages(data []byte) ([]Message, string, int, error) {
 			return nil, "", 0, fmt.Errorf("read payload[%d]: %w", i, err)
 		}
 		m.Payload = string(payloadBytes)
+
+		// Event sourcing fields
+		var eventTypeLen uint16
+		if err := binary.Read(reader, binary.BigEndian, &eventTypeLen); err != nil {
+			return nil, "", 0, fmt.Errorf("failed to read message[%d] event type length: %w", i, err)
+		}
+		eventTypeBytes := make([]byte, eventTypeLen)
+		if _, err := io.ReadFull(reader, eventTypeBytes); err != nil {
+			return nil, "", 0, fmt.Errorf("failed to read message[%d] event type: %w", i, err)
+		}
+		m.EventType = string(eventTypeBytes)
+
+		if err := binary.Read(reader, binary.BigEndian, &m.SchemaVersion); err != nil {
+			return nil, "", 0, fmt.Errorf("failed to read message[%d] schema version: %w", i, err)
+		}
+
+		if err := binary.Read(reader, binary.BigEndian, &m.AggregateVersion); err != nil {
+			return nil, "", 0, fmt.Errorf("failed to read message[%d] aggregate version: %w", i, err)
+		}
+
+		var metadataLen uint16
+		if err := binary.Read(reader, binary.BigEndian, &metadataLen); err != nil {
+			return nil, "", 0, fmt.Errorf("failed to read message[%d] metadata length: %w", i, err)
+		}
+		metadataBytes := make([]byte, metadataLen)
+		if _, err := io.ReadFull(reader, metadataBytes); err != nil {
+			return nil, "", 0, fmt.Errorf("failed to read message[%d] metadata: %w", i, err)
+		}
+		m.Metadata = string(metadataBytes)
 
 		messages = append(messages, m)
 	}

--- a/sdk/protocol.go
+++ b/sdk/protocol.go
@@ -127,6 +127,9 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 
 		// Event sourcing fields
 		eventTypeBytes := []byte(m.EventType)
+		if len(eventTypeBytes) > 0xFFFF {
+			return nil, fmt.Errorf("eventType too long: %d bytes", len(eventTypeBytes))
+		}
 		if err := write(uint16(len(eventTypeBytes))); err != nil {
 			return nil, err
 		}
@@ -143,6 +146,9 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		}
 
 		metadataBytes := []byte(m.Metadata)
+		if len(metadataBytes) > 0xFFFF {
+			return nil, fmt.Errorf("metadata too long: %d bytes", len(metadataBytes))
+		}
 		if err := write(uint16(len(metadataBytes))); err != nil {
 			return nil, err
 		}
@@ -314,6 +320,14 @@ func DecodeBatchMessages(data []byte) ([]Message, string, int, error) {
 	var msgCount int32
 	if err := binary.Read(reader, binary.BigEndian, &msgCount); err != nil {
 		return nil, "", 0, fmt.Errorf("failed to read message count: %w", err)
+	}
+
+	if msgCount < 0 {
+		return nil, "", 0, fmt.Errorf("invalid negative message count: %d", msgCount)
+	}
+	const maxBatchMessages = 100000
+	if msgCount > maxBatchMessages {
+		return nil, "", 0, fmt.Errorf("message count too high: %d (max: %d)", msgCount, maxBatchMessages)
 	}
 
 	messages := make([]Message, 0, msgCount)

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -14,6 +14,11 @@ type Message struct {
 	Key        string // optional: partition routing key
 	Epoch      int64
 
+	EventType        string
+	SchemaVersion    uint32
+	AggregateVersion uint64
+	Metadata         string
+
 	RetryCount int
 	Retry      bool
 }

--- a/test/consumer/subscriber/consumer.go
+++ b/test/consumer/subscriber/consumer.go
@@ -855,10 +855,10 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 	c.mu.RUnlock()
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("BATCH_COMMIT topic=%s group=%s generation=%d member=%s ", c.config.Topic, c.config.GroupID, generation, memberID))
+	fmt.Fprintf(&sb, "BATCH_COMMIT topic=%s group=%s generation=%d member=%s ", c.config.Topic, c.config.GroupID, generation, memberID)
 	parts := []string{}
 	for pid, off := range offsets {
-		parts = append(parts, fmt.Sprintf("%d:%d", pid, off))
+		parts = append(parts, fmt.Sprintf("P%d:%d", pid, off))
 	}
 	sb.WriteString(strings.Join(parts, ","))
 

--- a/util/buffer_test.go
+++ b/util/buffer_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestBufferReadWrite(t *testing.T) {
 	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
+	defer func() { _ = c1.Close() }()
+	defer func() { _ = c2.Close() }()
 
 	data := []byte("hello world")
 
@@ -26,8 +26,8 @@ func TestBufferReadWrite(t *testing.T) {
 
 func TestBufferErrorCases(t *testing.T) {
 	c1, c2 := net.Pipe()
-	c1.Close()
-	c2.Close()
+	_ = c1.Close()
+	_ = c2.Close()
 
 	_, err := ReadWithLength(c2)
 	assert.Error(t, err)

--- a/util/encode.go
+++ b/util/encode.go
@@ -137,6 +137,9 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 
 		// Event sourcing fields
 		eventTypeBytes := []byte(m.EventType)
+		if len(eventTypeBytes) > 0xFFFF {
+			return nil, fmt.Errorf("eventType too long: %d bytes", len(eventTypeBytes))
+		}
 		if err := write(uint16(len(eventTypeBytes))); err != nil {
 			return nil, err
 		}
@@ -153,6 +156,9 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		}
 
 		metadataBytes := []byte(m.Metadata)
+		if len(metadataBytes) > 0xFFFF {
+			return nil, fmt.Errorf("metadata too long: %d bytes", len(metadataBytes))
+		}
 		if err := write(uint16(len(metadataBytes))); err != nil {
 			return nil, err
 		}

--- a/util/encode.go
+++ b/util/encode.go
@@ -134,6 +134,31 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		if _, err := buf.Write(payloadBytes); err != nil {
 			return nil, fmt.Errorf("write payload bytes failed: %w", err)
 		}
+
+		// Event sourcing fields
+		eventTypeBytes := []byte(m.EventType)
+		if err := write(uint16(len(eventTypeBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(eventTypeBytes); err != nil {
+			return nil, err
+		}
+
+		if err := write(m.SchemaVersion); err != nil {
+			return nil, err
+		}
+
+		if err := write(m.AggregateVersion); err != nil {
+			return nil, err
+		}
+
+		metadataBytes := []byte(m.Metadata)
+		if err := write(uint16(len(metadataBytes))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(metadataBytes); err != nil {
+			return nil, err
+		}
 	}
 
 	return buf.Bytes(), nil
@@ -255,6 +280,35 @@ func DecodeBatchMessages(data []byte) (*types.Batch, error) {
 			return nil, fmt.Errorf("failed to read message[%d] payload bytes: %w", i, err)
 		}
 		m.Payload = string(payloadBytes)
+
+		// Event sourcing fields
+		var eventTypeLen uint16
+		if err := binary.Read(reader, binary.BigEndian, &eventTypeLen); err != nil {
+			return nil, fmt.Errorf("failed to read message[%d] event type length: %w", i, err)
+		}
+		eventTypeBytes := make([]byte, eventTypeLen)
+		if _, err := io.ReadFull(reader, eventTypeBytes); err != nil {
+			return nil, fmt.Errorf("failed to read message[%d] event type: %w", i, err)
+		}
+		m.EventType = string(eventTypeBytes)
+
+		if err := binary.Read(reader, binary.BigEndian, &m.SchemaVersion); err != nil {
+			return nil, fmt.Errorf("failed to read message[%d] schema version: %w", i, err)
+		}
+
+		if err := binary.Read(reader, binary.BigEndian, &m.AggregateVersion); err != nil {
+			return nil, fmt.Errorf("failed to read message[%d] aggregate version: %w", i, err)
+		}
+
+		var metadataLen uint16
+		if err := binary.Read(reader, binary.BigEndian, &metadataLen); err != nil {
+			return nil, fmt.Errorf("failed to read message[%d] metadata length: %w", i, err)
+		}
+		metadataBytes := make([]byte, metadataLen)
+		if _, err := io.ReadFull(reader, metadataBytes); err != nil {
+			return nil, fmt.Errorf("failed to read message[%d] metadata: %w", i, err)
+		}
+		m.Metadata = string(metadataBytes)
 
 		batch.Messages = append(batch.Messages, m)
 	}

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -172,6 +172,27 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 		return nil, err
 	}
 
+	eventTypeBytes := []byte(msg.EventType)
+	if err := binary.Write(&buf, binary.BigEndian, uint16(len(eventTypeBytes))); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(eventTypeBytes); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, msg.SchemaVersion); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, msg.AggregateVersion); err != nil {
+		return nil, err
+	}
+	metadataBytes := []byte(msg.Metadata)
+	if err := binary.Write(&buf, binary.BigEndian, uint16(len(metadataBytes))); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(metadataBytes); err != nil {
+		return nil, err
+	}
+
 	return buf.Bytes(), nil
 }
 
@@ -244,6 +265,32 @@ func DeserializeDiskMessage(data []byte) (types.DiskMessage, error) {
 		return msg, errors.New("data too short for payload")
 	}
 	msg.Payload = string(data[offset : offset+payloadLen])
+	offset += payloadLen
+
+	// Event sourcing fields (optional — backward compatible with old messages)
+	if offset+2 <= len(data) {
+		eventTypeLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
+		offset += 2
+		if offset+eventTypeLen <= len(data) {
+			msg.EventType = string(data[offset : offset+eventTypeLen])
+			offset += eventTypeLen
+		}
+	}
+	if offset+4 <= len(data) {
+		msg.SchemaVersion = binary.BigEndian.Uint32(data[offset : offset+4])
+		offset += 4
+	}
+	if offset+8 <= len(data) {
+		msg.AggregateVersion = binary.BigEndian.Uint64(data[offset : offset+8])
+		offset += 8
+	}
+	if offset+2 <= len(data) {
+		metadataLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
+		offset += 2
+		if offset+metadataLen <= len(data) {
+			msg.Metadata = string(data[offset : offset+metadataLen])
+		}
+	}
 
 	return msg, nil
 }

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -268,28 +268,40 @@ func DeserializeDiskMessage(data []byte) (types.DiskMessage, error) {
 	offset += payloadLen
 
 	// Event sourcing fields (optional — backward compatible with old messages)
-	if offset+2 <= len(data) {
+	// If event-sourcing trailer is present, all fields must be complete.
+	if offset < len(data) {
+		if offset+2 > len(data) {
+			return msg, fmt.Errorf("incomplete event-sourcing fields: truncated event type length")
+		}
 		eventTypeLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
 		offset += 2
-		if offset+eventTypeLen <= len(data) {
-			msg.EventType = string(data[offset : offset+eventTypeLen])
-			offset += eventTypeLen
+		if offset+eventTypeLen > len(data) {
+			return msg, fmt.Errorf("incomplete event-sourcing fields: truncated event type")
 		}
-	}
-	if offset+4 <= len(data) {
+		msg.EventType = string(data[offset : offset+eventTypeLen])
+		offset += eventTypeLen
+
+		if offset+4 > len(data) {
+			return msg, fmt.Errorf("incomplete event-sourcing fields: truncated schema version")
+		}
 		msg.SchemaVersion = binary.BigEndian.Uint32(data[offset : offset+4])
 		offset += 4
-	}
-	if offset+8 <= len(data) {
+
+		if offset+8 > len(data) {
+			return msg, fmt.Errorf("incomplete event-sourcing fields: truncated aggregate version")
+		}
 		msg.AggregateVersion = binary.BigEndian.Uint64(data[offset : offset+8])
 		offset += 8
-	}
-	if offset+2 <= len(data) {
+
+		if offset+2 > len(data) {
+			return msg, fmt.Errorf("incomplete event-sourcing fields: truncated metadata length")
+		}
 		metadataLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
 		offset += 2
-		if offset+metadataLen <= len(data) {
-			msg.Metadata = string(data[offset : offset+metadataLen])
+		if offset+metadataLen > len(data) {
+			return msg, fmt.Errorf("incomplete event-sourcing fields: truncated metadata")
 		}
+		msg.Metadata = string(data[offset : offset+metadataLen])
 	}
 
 	return msg, nil


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Cluster stability improvements, design refactoring, bug fixes, and native event sourcing support.

Bug Fixes
- **TOCTOU race condition**: Partition selection and enqueue now happen under a single RLock
- **HWM data race**: Added `GetHWM()` method, removed unprotected field access
- **Batch commit parsing**: Fixed `P0:100` format — `P` prefix was not stripped
- **Read deadline nullified**: Removed `SetReadDeadline(time.Time{})` that disabled 5s timeout
- **Double offset assignment**: Removed concurrent increment from `ReserveOffsets` + `EnqueueBatch`
- **Rebalance race**: `rebalanceRange` now called under lock in heartbeat timeout path
- **ValidateAndCommit**: Store in-memory before publish, rollback on failure
- Others: slice backing array sharing, FSM snapshot shallow copy, nil pointer deref, etc.

Design Refactoring
- **Break circular dependency**: Introduced `OffsetCommitter` interface (stream → coordinator)
- **Remove unused FSM dependency**: Dropped `dm *disk.DiskManager` field
- **Context propagation**: Added `context.Context` to Coordinator and ISRManager
- **Coordinator lock striping**: Per-group `gm.mu` lock for offset operations
- **RaftManager interface split**: 12 methods → 6 focused interfaces
- **Producer state eviction**: 30min TTL + 5min cleanup goroutine
- **Command router**: Switch/case → registry-based dispatch

Cluster Stability
- **HWM rollback on replication failure**: Prevents consumers from reading unreplicated data
- **Exponential backoff with jitter**: Replaces fixed-interval retries across forwarding paths
- **Deterministic partition leader election**: Sort ISR before selecting leader
- **json.Marshal error handling**: 4 locations now check errors instead of ignoring
- **Distributed guard centralization**: `isDistributed()` / `hasRouter()` helpers

Streaming Rewrite
- Replaced removed broadcast (push) with **event-driven pull** via `newMessageCh`
- Partition signals new messages → StreamConnection reacts immediately (<5ms latency)
- Keepalive separated into dedicated 5s ticker (was every 100ms poll tick)
- Offset gap detection with warning log
- SDK keepalive compatibility fix (continue instead of backoff on empty data)

Native Event Sourcing (New)
 - **Optimistic concurrency**: `CheckAndAppend` — atomic version check + index update under single lock
 - **Snapshots**: Broker manages as first-class concept
- **Wire format extension**: Batch format now includes EventType, SchemaVersion, AggregateVersion, Metadata

Documentation & Examples
- `docs/protocol-spec.md`: Complete wire protocol specification for SDK implementors
- `docs/user-guide/event-sourcing.md`: User guide for event sourcing feature
- `examples/event-sourcing/main.go`: Order aggregate domain model example

Checklist:

- [ ] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.