### PR TITLE
feat: replace fmt.Sprintf with string concatenation in hot-path key generation

### DIFF
--- a/pkg/cluster/controller/controller.go
+++ b/pkg/cluster/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -128,7 +129,7 @@ func (cc *ClusterController) IsAuthorized(topic string, partition int) bool {
 		return false
 	}
 
-	partitionKey := fmt.Sprintf("%s-%d", topic, partition)
+	partitionKey := topic + "-" + strconv.Itoa(partition)
 	meta := fsm.GetPartitionMetadata(partitionKey)
 	if meta == nil {
 		return false
@@ -143,7 +144,7 @@ func (cc *ClusterController) ReplicateToFollowers(topic string, partition int, m
 		return fmt.Errorf("FSM not available")
 	}
 
-	partitionKey := fmt.Sprintf("%s-%d", topic, partition)
+	partitionKey := topic + "-" + strconv.Itoa(partition)
 	meta := fsm.GetPartitionMetadata(partitionKey)
 	if meta == nil {
 		return fmt.Errorf("partition metadata not found")

--- a/pkg/cluster/controller/router.go
+++ b/pkg/cluster/controller/router.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"io"
 	"net"
 	"sort"
@@ -73,7 +74,7 @@ func (r *ClusterRouter) ForwardToPartitionLeader(topic string, partition int, re
 		return r.ForwardToLeader(req)
 	}
 
-	partitionKey := fmt.Sprintf("%s-%d", topic, partition)
+	partitionKey := topic + "-" + strconv.Itoa(partition)
 	meta := fsm.GetPartitionMetadata(partitionKey)
 	if meta == nil {
 		return r.ForwardToLeader(req)
@@ -186,7 +187,7 @@ func (r *ClusterRouter) ForwardDataToPartitionLeader(topic string, partition int
 		return r.ForwardDataToLeader(data)
 	}
 
-	partitionKey := fmt.Sprintf("%s-%d", topic, partition)
+	partitionKey := topic + "-" + strconv.Itoa(partition)
 	meta := fsm.GetPartitionMetadata(partitionKey)
 	if meta == nil {
 		return r.ForwardDataToLeader(data)

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -3,6 +3,7 @@ package fsm
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sort"
 	"strings"
 
@@ -84,7 +85,7 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 	ring.Add(brokers...)
 
 	for i := 0; i < topicCmd.Partitions; i++ {
-		key := fmt.Sprintf("%s-%d", topicCmd.Name, i)
+		key := topicCmd.Name + "-" + strconv.Itoa(i)
 
 		assignedLeader := topicCmd.LeaderID
 		var replicas []string

--- a/pkg/cluster/replication/fsm/fsm_replication.go
+++ b/pkg/cluster/replication/fsm/fsm_replication.go
@@ -3,6 +3,7 @@ package fsm
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
@@ -34,7 +35,7 @@ func (f *BrokerFSM) applyMessageBatch(cmd *types.MessageCommand) interface{} {
 	first := cmd.Messages[0]
 	last := cmd.Messages[len(cmd.Messages)-1]
 
-	partitionKey := fmt.Sprintf("%s-%d", cmd.Topic, cmd.Partition)
+	partitionKey := cmd.Topic + "-" + strconv.Itoa(cmd.Partition)
 
 	f.mu.Lock()
 	meta, topicExists := f.partitionMetadata[partitionKey]
@@ -138,7 +139,7 @@ func (f *BrokerFSM) validateMessageCommand(cmd *types.MessageCommand) error {
 	firstMsg := cmd.Messages[0]
 	lastMsg := cmd.Messages[len(cmd.Messages)-1]
 
-	partitionKey := fmt.Sprintf("%s-%d", cmd.Topic, cmd.Partition)
+	partitionKey := cmd.Topic + "-" + strconv.Itoa(cmd.Partition)
 
 	f.mu.Lock()
 	meta, topicExists := f.partitionMetadata[partitionKey]

--- a/pkg/cluster/replication/isr_manager.go
+++ b/pkg/cluster/replication/isr_manager.go
@@ -140,7 +140,7 @@ func (i *ISRManager) SetLeader(isLeader bool) {
 }
 
 func (i *ISRManager) ComputeISR(topic string, partition int) []string {
-	key := fmt.Sprintf("%s-%d", topic, partition)
+	key := topic + "-" + strconv.Itoa(partition)
 	var currentISR []string
 
 	i.mu.RLock()
@@ -277,7 +277,7 @@ func (i *ISRManager) isBrokerAlive(brokerID string) bool {
 }
 
 func (i *ISRManager) GetISR(topic string, partition int) []string {
-	key := fmt.Sprintf("%s-%d", topic, partition)
+	key := topic + "-" + strconv.Itoa(partition)
 	metadata := i.fsm.GetPartitionMetadata(key)
 	if metadata == nil {
 		return nil

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/cursus-io/cursus/pkg/types"
@@ -37,7 +38,7 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 	if err := c.topicHandler.Publish(c.offsetTopic, &types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
-		Key:        fmt.Sprintf("%s-%s-%d", groupName, topic, partition),
+		Key:        groupName + "-" + topic + "-" + strconv.Itoa(partition),
 	}); err != nil {
 		return err
 	}
@@ -198,7 +199,7 @@ func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, 
 	err = c.topicHandler.Publish(c.offsetTopic, &types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
-		Key:        fmt.Sprintf("%s-%s-%d", groupName, topic, partition),
+		Key:        groupName + "-" + topic + "-" + strconv.Itoa(partition),
 	})
 
 	if err != nil {

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -2,6 +2,7 @@ package disk
 
 import (
 	"fmt"
+	"strconv"
 	"os"
 	"sync"
 
@@ -28,7 +29,7 @@ func (dm *DiskManager) GetHandler(topic string, partitionID int) (types.StorageH
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
-	key := fmt.Sprintf("%s_%d", topic, partitionID)
+	key := topic + "_" + strconv.Itoa(partitionID)
 	if dh, ok := dm.handlers[key]; ok {
 		return dh, nil
 	}

--- a/pkg/eventsource/handler.go
+++ b/pkg/eventsource/handler.go
@@ -36,7 +36,7 @@ func NewHandler(tm *topic.TopicManager) *Handler {
 
 // getIndex returns the StreamIndex for the given topic and partition, creating it lazily.
 func (h *Handler) getIndex(topicName string, partitionID int) (*StreamIndex, error) {
-	key := fmt.Sprintf("%s:%d", topicName, partitionID)
+	key := topicName + ":" + strconv.Itoa(partitionID)
 
 	h.mu.RLock()
 	if h.closed {
@@ -71,7 +71,7 @@ func (h *Handler) getIndex(topicName string, partitionID int) (*StreamIndex, err
 
 // getSnapshot returns the SnapshotStore for the given topic and partition, creating it lazily.
 func (h *Handler) getSnapshot(topicName string, partitionID int) (*SnapshotStore, error) {
-	key := fmt.Sprintf("%s:%d", topicName, partitionID)
+	key := topicName + ":" + strconv.Itoa(partitionID)
 
 	h.mu.RLock()
 	if h.closed {

--- a/util/consistent_hash.go
+++ b/util/consistent_hash.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"fmt"
+	"strconv"
 	"hash/crc32"
 	"sort"
 )
@@ -34,7 +34,7 @@ func (m *ConsistentHashRing) IsEmpty() bool {
 func (m *ConsistentHashRing) Add(keys ...string) {
 	for _, key := range keys {
 		for i := 0; i < m.replicas; i++ {
-			hash := int(m.hash([]byte(fmt.Sprintf("%s:%d", key, i))))
+			hash := int(m.hash([]byte(key + ":" + strconv.Itoa(i))))
 			m.keys = append(m.keys, hash)
 			m.hashMap[hash] = key
 		}
@@ -44,7 +44,7 @@ func (m *ConsistentHashRing) Add(keys ...string) {
 
 func (m *ConsistentHashRing) Remove(key string) {
 	for i := 0; i < m.replicas; i++ {
-		hash := int(m.hash([]byte(fmt.Sprintf("%s:%d", key, i))))
+		hash := int(m.hash([]byte(key + ":" + strconv.Itoa(i))))
 		delete(m.hashMap, hash)
 	}
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes #39 

- Replace `fmt.Sprintf("%s-%d", ...)` with `topic + "-" + strconv.Itoa(partition)` across hot-path
  key generation
- Eliminates reflection overhead and unnecessary heap allocations from `fmt.Sprintf`

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [ ] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [ ] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.