### PR TITLE
feat: add data loss detection and consumer lag metric

### DIFF
--- a/pkg/cluster/controller/controller.go
+++ b/pkg/cluster/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/cluster/replication"
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/metrics"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
 	"github.com/hashicorp/raft"
@@ -138,6 +139,8 @@ func (cc *ClusterController) IsAuthorized(topic string, partition int) bool {
 }
 
 func (cc *ClusterController) ReplicateToFollowers(topic string, partition int, msgCmd types.MessageCommand, minISR int) error {
+	replicationStart := time.Now()
+
 	fsm := cc.RaftManager.GetFSM()
 	if fsm == nil {
 		return fmt.Errorf("FSM not available")
@@ -168,6 +171,7 @@ func (cc *ClusterController) ReplicateToFollowers(topic string, partition int, m
 	var mu sync.Mutex
 	errCh := make(chan error, len(targets))
 
+	partitionStr := fmt.Sprintf("%d", partition)
 	for _, targetID := range targets {
 		broker := fsm.GetBroker(targetID)
 		if broker == nil {
@@ -175,17 +179,18 @@ func (cc *ClusterController) ReplicateToFollowers(topic string, partition int, m
 		}
 
 		wg.Add(1)
-		go func(addr string) {
+		go func(addr, brokerID string) {
 			defer wg.Done()
 			_, err := cc.Router.forwardWithTimeout(addr, replicateCmd)
 			if err == nil {
 				mu.Lock()
 				successCount++
 				mu.Unlock()
+				metrics.ClusterReplicationLag.WithLabelValues(topic, partitionStr, brokerID).Observe(time.Since(replicationStart).Seconds())
 			} else {
 				errCh <- err
 			}
-		}(broker.Addr)
+		}(broker.Addr, targetID)
 	}
 
 	wg.Wait()

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/metrics"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/util"
 )
@@ -568,9 +569,9 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 		err := ch.Coordinator.CommitOffset(groupID, topicName, partition, offset)
 		if err != nil {
 			return fmt.Sprintf("ERROR: %v", err)
-		} else {
-			return "OK"
 		}
+		ch.recordConsumerLag(topicName, partition, offset, groupID)
+		return "OK"
 	}
 	return "offset manager not available"
 }
@@ -661,7 +662,28 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 		}
 	}
 
+	for _, item := range offsetList {
+		ch.recordConsumerLag(topicName, item.Partition, item.Offset, groupID)
+	}
+
 	return fmt.Sprintf("OK batched=%d", len(offsetList))
+}
+
+func (ch *CommandHandler) recordConsumerLag(topicName string, partition int, committedOffset uint64, groupID string) {
+	t := ch.TopicManager.GetTopic(topicName)
+	if t == nil {
+		return
+	}
+	p, err := t.GetPartition(partition)
+	if err != nil {
+		return
+	}
+	leo := p.NextOffset()
+	lag := float64(0)
+	if leo > committedOffset {
+		lag = float64(leo - committedOffset)
+	}
+	metrics.ConsumerLag.WithLabelValues(topicName, fmt.Sprintf("%d", partition), groupID).Set(lag)
 }
 
 // resolveOffset determines the starting offset for a consumer

--- a/pkg/metrics/broker.go
+++ b/pkg/metrics/broker.go
@@ -28,4 +28,19 @@ var (
 		Name: "broker_cleanup_count_total",
 		Help: "Total number of deduped message IDs cleaned up from memory",
 	})
+
+	SeqNumGapTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "broker_seqnum_gap_total",
+		Help: "Total number of sequence number gaps detected per producer",
+	}, []string{"topic", "partition", "producer_id"})
+
+	SeqNumDuplicateTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "broker_seqnum_duplicate_total",
+		Help: "Total number of duplicate sequence numbers detected",
+	}, []string{"topic", "partition"})
+
+	ConsumerLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "broker_consumer_lag",
+		Help: "Consumer lag per partition (LEO - committed offset)",
+	}, []string{"topic", "partition", "group"})
 )

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	prometheus.MustRegister(MessagesProcessed, MessagesPerSec, LatencyHist, QueueSize, CleanupCount)
+	prometheus.MustRegister(MessagesProcessed, MessagesPerSec, LatencyHist, QueueSize, CleanupCount, SeqNumGapTotal, SeqNumDuplicateTotal, ConsumerLag)
 	prometheus.MustRegister(ClusterBrokersTotal, PartitionLeadersTotal, ClusterReplicationLag, LeaderElectionTotal, ISRSize)
 	prometheus.MustRegister(ReplicationLagBytes, ISRChangesTotal, LeaderElectionFailures, BrokerHealthStatus, QuorumOperations, PartitionReassignments)
 }

--- a/pkg/metrics/metrics_ext_test.go
+++ b/pkg/metrics/metrics_ext_test.go
@@ -14,6 +14,9 @@ func TestAllMetricsRegistered(t *testing.T) {
 	assert.NotNil(t, LatencyHist)
 	assert.NotNil(t, QueueSize)
 	assert.NotNil(t, CleanupCount)
+	assert.NotNil(t, SeqNumGapTotal)
+	assert.NotNil(t, SeqNumDuplicateTotal)
+	assert.NotNil(t, ConsumerLag)
 
 	assert.NotNil(t, ClusterBrokersTotal)
 	assert.NotNil(t, PartitionLeadersTotal)
@@ -30,4 +33,8 @@ func TestMetricIncrements(t *testing.T) {
 	ClusterBrokersTotal.WithLabelValues("c1").Set(3)
 	PartitionLeadersTotal.WithLabelValues("b1").Inc()
 	ISRSize.WithLabelValues("t1", "0").Set(2)
+
+	SeqNumGapTotal.WithLabelValues("t1", "0", "producer-1").Inc()
+	SeqNumDuplicateTotal.WithLabelValues("t1", "0").Inc()
+	ConsumerLag.WithLabelValues("t1", "0", "g1").Set(42)
 }

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/metrics"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
 )
@@ -78,6 +79,7 @@ func (p *Partition) isDuplicate(msg *types.Message) bool {
 	if ok {
 		entry := val.(*producerEntry)
 		if msg.SeqNum <= entry.lastSeq {
+			metrics.SeqNumDuplicateTotal.WithLabelValues(p.topic, fmt.Sprintf("%d", p.id)).Inc()
 			return true
 		}
 	}
@@ -85,12 +87,24 @@ func (p *Partition) isDuplicate(msg *types.Message) bool {
 }
 
 func (p *Partition) updateProducerState(msg *types.Message) {
-	if msg.ProducerID != "" {
-		p.producerState.Store(msg.ProducerID, &producerEntry{
-			lastSeq:  msg.SeqNum,
-			lastSeen: time.Now(),
-		})
+	if msg.ProducerID == "" {
+		return
 	}
+	if msg.SeqNum > 0 {
+		if val, ok := p.producerState.Load(msg.ProducerID); ok {
+			entry := val.(*producerEntry)
+			if msg.SeqNum > entry.lastSeq+1 {
+				gap := msg.SeqNum - entry.lastSeq - 1
+				metrics.SeqNumGapTotal.WithLabelValues(p.topic, fmt.Sprintf("%d", p.id), msg.ProducerID).Add(float64(gap))
+				util.Warn("Partition %d: seqNum gap detected for producer %s: expected %d, got %d (gap=%d)",
+					p.id, msg.ProducerID, entry.lastSeq+1, msg.SeqNum, gap)
+			}
+		}
+	}
+	p.producerState.Store(msg.ProducerID, &producerEntry{
+		lastSeq:  msg.SeqNum,
+		lastSeen: time.Now(),
+	})
 }
 
 // Enqueue pushes a message into the partition queue.

--- a/sdk/metrics.go
+++ b/sdk/metrics.go
@@ -21,6 +21,7 @@ var (
 	consumerCommitErrors     *prometheus.CounterVec
 	consumerPollLatency      *prometheus.HistogramVec
 	consumerRebalanceTotal   *prometheus.CounterVec
+	consumerOffsetGapTotal   *prometheus.CounterVec
 )
 
 func initMetrics() {
@@ -109,6 +110,16 @@ func initMetrics() {
 			[]string{"topic", "group"},
 		)
 
+		consumerOffsetGapTotal = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "cursus",
+				Subsystem: "consumer",
+				Name:      "offset_gap_total",
+				Help:      "Total number of offset gaps detected during consumption.",
+			},
+			[]string{"topic", "group"},
+		)
+
 		metricsRegistry.MustRegister(
 			producerMessagesSent,
 			producerSendErrors,
@@ -118,6 +129,7 @@ func initMetrics() {
 			consumerCommitErrors,
 			consumerPollLatency,
 			consumerRebalanceTotal,
+			consumerOffsetGapTotal,
 		)
 	})
 }

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -204,6 +204,9 @@ func (pc *PartitionConsumer) pollAndProcess() {
 	if expectedOffset > 0 && firstOffset > expectedOffset {
 		LogError("Partition [%d] offset gap: expected %d, received %d (missing %d messages)",
 			pc.partitionID, expectedOffset, firstOffset, firstOffset-expectedOffset)
+		if cfg.EnableMetrics {
+			consumerOffsetGapTotal.WithLabelValues(cfg.Topic, cfg.GroupID).Add(float64(firstOffset - expectedOffset))
+		}
 	}
 
 	newOffset := messages[len(messages)-1].Offset + 1


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes #41 

Adds producer sequence number gap/duplicate detection, consumer lag monitoring, and SDK offset gap metrics for early data loss detection.

### Broker Metrics
- `broker_seqnum_gap_total`: per-producer sequence number gap counter
- `broker_seqnum_duplicate_total`: duplicate sequence number counter
- `broker_consumer_lag`: per-partition consumer lag gauge (LEO - committed offset)
- `ClusterReplicationLag`: per-target broker replication latency histogram

### Consumer Lag Tracking
- Record LEO vs committed offset delta on `CommitOffset` and `BatchCommit`

### SDK Metrics
- `cursus_consumer_offset_gap_total`: offset gap detection counter during consumption

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [ ] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.