### PR TITLE
feat: improve disk snapshot concurrency and reduce allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,18 +107,34 @@ bench:
 	docker compose -f test/docker-compose.yml down -v; \
 	'
 
+.PHONY: bench-disk
+bench-disk:
+	@echo "Running disk I/O benchmarks..."
+	$(GO) test ./pkg/disk/ -bench=. -benchmem -count=3 -timeout=120s
+
+.PHONY: bench-serialize
+bench-serialize:
+	@echo "Running serialization benchmarks..."
+	$(GO) test ./pkg/disk/ -bench=BenchmarkSerializeDiskMessage -benchmem -count=5 -timeout=60s
+
 .PHONY: build
 build: build-api build-cli
 
 .PHONY: build-api
 build-api:
 	@echo "Building API server..."
-	CGO_ENABLED=0 GOOS=linux $(GO) build $(BUILD_FLAGS) -o bin/$(APP_NAME) ./cmd/broker/main.go
+	CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o bin/$(APP_NAME) ./cmd/broker/main.go
 
 .PHONY: build-cli
 build-cli:
 	@echo "Building CLI..."
-	CGO_ENABLED=0 GOOS=linux $(GO) build $(BUILD_FLAGS) -o bin/$(CLI_NAME) ./cmd/cli/main.go
+	CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o bin/$(CLI_NAME) ./cmd/cli/main.go
+
+.PHONY: build-linux
+build-linux:
+	@echo "Building for Linux..."
+	CGO_ENABLED=0 GOOS=linux $(GO) build $(BUILD_FLAGS) -o bin/$(APP_NAME)-linux ./cmd/broker/main.go
+	CGO_ENABLED=0 GOOS=linux $(GO) build $(BUILD_FLAGS) -o bin/$(CLI_NAME)-linux ./cmd/cli/main.go
 
 .PHONY: clean
 clean:
@@ -160,10 +176,14 @@ help:
 	@echo "  make e2e             Run E2E tests (builds images first)"  
 	@echo "  make e2e-verbose     Run E2E tests with race detection" 
 	@echo "  make e2e-logs        Show E2E test container logs" 
-	@echo "  make bench           Run benchmarks"  
-	@echo "  make build           Build all binaries (api, cli)"  
-	@echo "  make clean           Remove build artifacts"  
-	@echo "  make run             Run broker in dev mode" 
-	@echo "  make tools           Install or update development tools"  
-	@echo "  make fmt             Format code according to Go standards"  
+	@echo "  make bench           Run end-to-end benchmarks (Docker)"
+	@echo "  make bench-disk      Run disk I/O benchmarks (Go test)"
+	@echo "  make bench-serialize Run serialization benchmarks"
+	@echo "  make build           Build all binaries for current OS"
+	@echo "  make build-linux     Cross-compile for Linux amd64"
+	@echo "  make clean           Remove build artifacts"
+	@echo "  make run             Run broker in dev mode"
+	@echo "  make cli             Run CLI in dev mode"
+	@echo "  make tools           Install or update development tools"
+	@echo "  make fmt             Format code according to Go standards"
 	@echo "  make coverage        Run tests with coverage report"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,9 @@ This directory contains various documents explaining different aspects of the pr
   - **[Command Interface](reference/command-interface.md)** – CLI commands and usage.
   - **[Observability](reference/observability.md)** – Metrics, logging, and monitoring.
   - **[Performance](reference/performance.md)** – Performance tuning and optimization strategies.
+- **Specs**
+  - **[Disk Snapshot Optimization](specs/disk-snapshot-concurrency-optimization.md)** – Disk I/O concurrency optimization with benchmarks.
+  - **[Sprintf Key Generation](specs/sprintf-key-generation-optimization.md)** – Hot-path key generation optimization.
 - **[Contributing](contributing/README.md)** – Guidelines for contributing to the project and documentation.
 
 ## 📝 Contribution and Maintenance

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,12 +36,27 @@ cursus exposes three network ports, each serving a distinct purpose:
 
 ## Core Data Flow
 
+```mermaid
+graph LR
+    P[Publisher] -->|TCP| S[Server :9000]
+    S --> TM[TopicManager]
+    TM -->|dedup check| T[Topic]
+    T -->|hash/round-robin| Part[Partition]
+    Part -->|async| DH[DiskHandler]
+    DH -->|writeCh| FL[flushLoop]
+    FL -->|WriteBatch| Seg[Segment Files]
+    Part -->|notify| SM[StreamManager]
+    SM -->|push| C[Consumer]
+    C -->|CONSUME/STREAM| Part
+    Part -->|ReadCommitted| Seg
+```
+
 ### Key flow characteristics:
 
 - **Deduplication**: `TopicManager.Publish()` checks dedupMap using message ID (hash of payload) to prevent duplicate processing within 30 minutes 
 - **Partition Selection**: `Topic.Publish()` uses key-based hashing for ordered delivery or round-robin counter for load balancing
 - **Dual-path delivery**: `Partition.Enqueue()` sends to both disk (via DiskHandler) and consumer channels
-- **Asynchronous writes**: DiskHandler batches up to 500 messages or flushes after 100ms linger timeout for efficiency
+- **Asynchronous writes**: DiskHandler batches up to 50 messages or flushes after 50ms linger timeout (configurable)
 - **Consumer isolation**: Each ConsumerGroup receives messages independently through dedicated channels
 
 ## Message Persistence
@@ -51,8 +66,8 @@ Messages are persisted using a segment-based append-only log architecture
 Each topic-partition pair gets its own DiskHandler instance:
 
 - Writes asynchronously via `flushLoop()` goroutine
-- Batches up to 500 messages or flushes after 100ms linger
-- Rotates segments at 1MB boundaries
+- Batches up to 50 messages or flushes after 50ms linger (configurable)
+- Rotates segments at 1GB boundaries (configurable via `log_segment_bytes`)
 - Uses `mmap`(memory-mapped I/O) for reads
 - Stores messages with 4-byte big-endian length prefixes
 

--- a/docs/core/message-flow.md
+++ b/docs/core/message-flow.md
@@ -8,8 +8,8 @@ Cursus is a log-centric message broker designed for high-throughput persistence 
 
 ### 1. The Persistence Path (Durability First)
 When a message is published, it is immediately handed off to the `DiskHandler` for the target partition. 
-- **Asynchronous Batching:** Messages are queued in a `writeCh` and flushed to disk in batches (default 500 messages or 100ms) to maximize I/O efficiency.
-- **Segmented Storage:** Data is stored in immutable segment files (default 1MB), enabling efficient retention and historical replay.
+- **Asynchronous Batching:** Messages are queued in a `writeCh` and flushed to disk in batches (default 50 messages or 50ms) to maximize I/O efficiency.
+- **Segmented Storage:** Data is stored in immutable segment files (default 1GB, configurable), enabling efficient retention and historical replay.
 
 ### 2. The Real-time Dispatch Path (Low Latency)
 Simultaneously, the message is enqueued into the partition's in-memory channel.
@@ -17,6 +17,24 @@ Simultaneously, the message is enqueued into the partition's in-memory channel.
 - **Zero-Disk Read for Active Consumers:** Active subscribers receive messages directly from memory, avoiding disk I/O latency for real-time processing.
 
 ---
+
+```mermaid
+graph TD
+    PUB[Publisher] -->|PUBLISH| CMD[CommandHandler]
+    CMD -->|Publish| TM[TopicManager]
+    TM -->|dedup check| DM{Duplicate?}
+    DM -->|yes| REJ[Reject]
+    DM -->|no| TOP[Topic]
+    TOP -->|partition select| PART[Partition]
+    PART -->|EnqueueBatch| DH[DiskHandler.writeCh]
+    DH -->|flushLoop| DISK[(Segment File)]
+    PART -->|NotifyNewMessage| SM[StreamManager]
+    SM -->|push to active| CONS[Consumer]
+
+    CONS2[Consumer] -->|CONSUME| CMD2[CommandHandler]
+    CMD2 -->|ReadCommitted| PART2[Partition]
+    PART2 -->|mmap read| DISK2[(Segment File)]
+```
 
 ## Detailed Message Journey
 

--- a/docs/core/storage/disk-persistence.md
+++ b/docs/core/storage/disk-persistence.md
@@ -34,10 +34,10 @@ Each DiskHandler manages disk I/O for a single topic-partition pair. It maintain
 | Field          | Type            | Purpose                                         |
 |----------------|----------------|-------------------------------------------------|
 | BaseName       | string          | Base file path: `{LogDir}/{topic}/partition_{id}` |
-| SegmentSize    | int             | Maximum segment size (default: 1MB)            |
-| CurrentOffset  | int             | Current write position within segment          |
-| CurrentSegment | int             | Current segment number                          |
-| writeCh        | chan string     | Unbuffered channel for asynchronous writes     |
+| SegmentSize    | uint64          | Maximum segment size (default: 1GB)            |
+| CurrentOffset  | uint64          | Current write position within segment          |
+| CurrentSegment | uint64          | Current segment number                          |
+| writeCh        | chan DiskMessage | Buffered channel for asynchronous writes       |
 | done           | chan struct{}   | Shutdown signal channel                         |
 | batchSize      | int             | Max messages per batch (from DiskFlushBatchSize) |
 | linger         | time.Duration   | Max wait time before flushing partial batch    |
@@ -51,15 +51,52 @@ Each DiskHandler manages disk I/O for a single topic-partition pair. It maintain
 
 The write path is fully asynchronous to prevent blocking publishers. Messages flow through a channel to a dedicated flush goroutine that performs batching and periodic flushing.
 
+```mermaid
+sequenceDiagram
+    participant P as Publisher
+    participant AH as AppendMessage
+    participant CH as writeCh
+    participant FL as flushLoop
+    participant WB as WriteBatch
+    participant SL as syncLoop
+    participant D as Disk
+
+    P->>AH: AppendMessage(topic, partition, msg)
+    AH->>AH: Assign offset (atomic)
+    AH->>CH: send DiskMessage
+
+    loop Batch accumulation
+        CH->>FL: receive msg
+        FL->>FL: append to batch
+    end
+
+    alt Batch full OR linger timeout
+        FL->>WB: WriteBatch(batch)
+        Note over WB: Serialize outside lock
+        WB->>WB: mu.Lock + ioMu.Lock
+        WB->>WB: Check segment rotation
+        WB->>D: bufio.Write (length + data)
+        WB->>D: bufio.Flush
+        WB->>WB: mu.Unlock + ioMu.Unlock
+    end
+
+    loop Every sync interval
+        SL->>D: file.Sync() (fsync)
+        SL->>SL: Notify OnSync callback
+    end
+```
+
 Key Write Functions:
 
 | Function                | File              | Purpose                                       |
 |-------------------------|-------------------|-----------------------------------------------|
-| `AppendMessage(msg string)` | handler.go        | Non-blocking enqueue to write channel        |
+| `AppendMessage(topic, partition, msg)` | handler.go        | Non-blocking enqueue to write channel        |
+| `AppendMessageSync(topic, partition, msg)` | handler.go | Synchronous write (bypasses channel)          |
 | `flushLoop()`             | flush_common.go   | Main batching loop in dedicated goroutine     |
-| `writeBatch(batch []string)` | flush_common.go | Write a batch of messages to disk             |
-| `rotateSegment()`         | flush_common.go   | Close current segment and open next           |
-| `WriteDirect(msg string)` | flush_common.go   | Synchronous write (bypasses channel)          |
+| `syncLoop()`              | flush_common.go   | Periodic fsync for durability                 |
+| `WriteBatch(batch []DiskMessage)` | flush_common.go | Write a batch of messages to disk             |
+| `WriteDirect(topic, partition, msg)` | flush_common.go | Direct synchronous write                      |
+| `rotateSegment(nextBaseOffset)` | flush_common.go   | Close current segment and open next           |
 
 ## Read Path: Memory-Mapped I/O
 
@@ -97,7 +134,7 @@ Example:
 
 Rotation Trigger:
 
-When CurrentOffset + messageSize > SegmentSize (1MB by default)
+When CurrentOffset + messageSize > SegmentSize (1GB by default)
 
 Occurs within `writeBatch()` before writing a message that would exceed the limit
 
@@ -135,6 +172,27 @@ Advantages:
 
 The DiskHandler uses a dual-mutex strategy to allow concurrent reads while serializing writes.
 
+```mermaid
+graph TD
+    subgraph "Write Path"
+        WB[WriteBatch] -->|1. acquire| MU[mu - metadata]
+        WB -->|2. acquire| IOMU[ioMu - I/O]
+        WB -->|3. write| DISK[(Segment File)]
+        WD[WriteDirect] -->|acquire both| MU
+        WD -->|acquire both| IOMU
+    end
+
+    subgraph "Read Path (lock-free I/O)"
+        RM[ReadMessages] -->|acquire mu briefly| MU2[mu - read segment list]
+        RM -->|mmap read| DISK2[(Segment File)]
+    end
+
+    subgraph "Sync Path"
+        SL[syncLoop] -->|acquire| IOMU2[ioMu]
+        SL -->|fsync| DISK3[(Segment File)]
+    end
+```
+
 ### Lock Responsibilities
 
 mu (Metadata Lock):
@@ -166,21 +224,23 @@ The disk persistence system is configured through the config.Config structure:
 
 | Parameter       | Field                | Default  | Purpose                                      |
 |-----------------|--------------------|---------|----------------------------------------------|
-| Log Directory   | LogDir              | `./logs`| Base directory for segment files             |
-| Batch Size      | DiskFlushBatchSize  | 500     | Max messages per flush batch                 |
-| Linger Time     | LingerMS            | 100     | Max milliseconds before flushing partial batch |
-| Write Timeout   | DiskWriteTimeoutMS  | 5000    | Timeout for enqueuing to write channel      |
-| Channel Buffer  | ChannelBufferSize   | 10000   | Size of partition message channels           |
-| Segment Size    | Hardcoded           | 1048576 | 1MB per segment file                         |
+| Log Directory   | LogDir              | `broker-logs` | Base directory for segment files             |
+| Batch Size      | DiskFlushBatchSize  | 50      | Max messages per flush batch                 |
+| Linger Time     | LingerMS            | 50      | Max milliseconds before flushing partial batch |
+| Write Timeout   | DiskWriteTimeoutMS  | 10      | Timeout for enqueuing to write channel (ms) |
+| Channel Buffer  | ChannelBufferSize   | 1024    | Size of DiskHandler write channel            |
+| Segment Size    | SegmentSize         | 1GB     | Max segment file size (configurable via `log_segment_bytes`) |
+| Index Size      | IndexSize           | 10MB    | Max index file size (configurable via `log_index_size_bytes`) |
+| Flush Interval  | DiskFlushIntervalMS | 500     | Periodic fsync interval (ms)                 |
 
 # Summary
 
 The disk persistence system provides durable message storage through:
 
 - **Registry Pattern**: DiskManager maintains handlers for each topic-partition
-- **Asynchronous Writes**: Channel-based write path with batching (500 msgs or 100ms)
+- **Asynchronous Writes**: Channel-based write path with batching (50 msgs or 50ms default)
 - **Synchronous Reads**: Memory-mapped I/O for efficient sequential access
-- **Segment-Based Storage**: 1MB segments enable parallel I/O and efficient management
+- **Segment-Based Storage**: Configurable segments (1GB default) with index files for fast offset lookup
 - **Dual-Mutex Concurrency**: Separate locks for metadata and I/O operations
 - **Length-Prefixed Format**: Enables random access and streaming without parsing
 - **Graceful Shutdown**: Ensures all buffered messages are flushed before exit
@@ -210,10 +270,10 @@ The DiskHandler is the core component responsible for persisting messages to dis
 | Field          | Type             | Purpose                                                      |
 |----------------|-----------------|--------------------------------------------------------------|
 | BaseName       | string           | Base path for segment files, e.g., `./logs/orders/partition_0` |
-| SegmentSize    | int              | Maximum size per segment file (default: 1MB)                |
-| CurrentOffset  | int              | Current write position within the active segment            |
-| CurrentSegment | int              | Active segment number (increments on rotation)              |
-| writeCh        | chan string      | Unbuffered channel for asynchronous message enqueue         |
+| SegmentSize    | uint64           | Maximum size per segment file (default: 1GB)                |
+| CurrentOffset  | uint64           | Current write position within the active segment            |
+| CurrentSegment | uint64           | Active segment number (base offset of current segment)      |
+| writeCh        | chan DiskMessage  | Buffered channel for asynchronous message enqueue           |
 | done           | chan struct{}    | Shutdown signal channel                                      |
 | batchSize      | int              | Maximum messages per batch (default: 500)                   |
 | linger         | time.Duration    | Maximum wait time before flushing partial batch (default: 100ms) |
@@ -230,11 +290,12 @@ The following `config.Config` fields control DiskHandler behavior:
 
 | Config Field           | DiskHandler Field | Default      | Purpose                                      |
 |------------------------|-----------------|-------------|----------------------------------------------|
-| LogDir                 | BaseName (derived)| `./logs`      | Root directory for segment files             |
-| ChannelBufferSize      | writeCh capacity | varies      | Size of write channel buffer                 |
-| DiskFlushBatchSize     | batchSize        | 500         | Messages per batch                            |
-| LingerMS               | linger           | 100ms       | Max wait before flushing partial batch       |
-| DiskWriteTimeoutMS     | writeTimeout     | varies      | Timeout for channel enqueue                   |
+| LogDir                 | BaseName (derived)| `broker-logs` | Root directory for segment files             |
+| ChannelBufferSize      | writeCh capacity | 1024        | Size of write channel buffer                 |
+| DiskFlushBatchSize     | batchSize        | 50          | Messages per batch                            |
+| LingerMS               | linger           | 50ms        | Max wait before flushing partial batch       |
+| DiskWriteTimeoutMS     | writeTimeout     | 10ms        | Timeout for channel enqueue                   |
+| DiskFlushIntervalMS    | syncIntervalMS   | 500ms       | Periodic fsync interval                       |
 
 ## Asynchronous Write Path
 
@@ -268,8 +329,8 @@ The flushLoop goroutine is the heart of the asynchronous write path. It continuo
 
 | Condition         | Threshold                          | Behavior                          |
 |------------------|-----------------------------------|----------------------------------|
-| Batch Full        | len(batch) >= batchSize (500)      | Immediate flush                  |
-| Linger Timeout    | ticker.C fires (100ms)             | Flush if len(batch) > 0          |
+| Batch Full        | len(batch) >= batchSize (50)       | Immediate flush                  |
+| Linger Timeout    | ticker.C fires (50ms)              | Flush if len(batch) > 0          |
 | Shutdown          | done channel closed                 | Drain and flush remaining messages|
 
 
@@ -416,7 +477,7 @@ Note: For complete configuration reference, see [Configuration Reference](../../
 The DiskHandler write path provides:
 
 - **Asynchronous writes**: Non-blocking AppendMessage for publishers
-- **Batching**: Up to 500 messages per batch or 100ms linger timeout
+- **Batching**: Up to 50 messages per batch or 50ms linger timeout (configurable)
 - **Durability**: Guaranteed fsync after each batch
 - **Concurrency control**: Dual-mutex strategy for parallel reads/writes
 - **Graceful shutdown**: Drain loop ensures all messages are persisted

--- a/docs/core/storage/segment-management.md
+++ b/docs/core/storage/segment-management.md
@@ -4,7 +4,7 @@
 
 This document explains how log segments are created, rotated, and managed in the cursus disk persistence system. 
 
-A segment is a physical file on disk that stores messages for a specific topic-partition pair. Segments are rotated (rolled over to a new file) when they reach 1MB in size, enabling efficient parallel I/O, simplified cleanup operations, and bounded resource usage.
+A segment is a physical file on disk that stores messages for a specific topic-partition pair. Segments are rotated (rolled over to a new file) when they reach the configured size limit (default 1GB), enabling efficient parallel I/O, simplified cleanup operations, and bounded resource usage.
 
 For information about the on-disk message format within segments, see [Disk Format](./disk-format.md). For platform-specific I/O optimizations, see [Platform-Specific Optimizations](./platform-optimizations.md).
 
@@ -12,27 +12,46 @@ For information about the on-disk message format within segments, see [Disk Form
 
 ### Naming Convention and Directory Layout
 
-Each topic-partition pair has its own directory and sequence of segment files. The directory structure follows this pattern:
+Each topic-partition pair has its own directory and sequence of segment files. Segment file names use zero-padded base offsets (20 digits):
 
 ```
-{LogDir}/{topicName}/partition_{partitionID}/
-├── {topicName}_partition_{partitionID}_segment_0.log
-├── {topicName}_partition_{partitionID}_segment_1.log
-├── {topicName}_partition_{partitionID}_segment_2.log
+{LogDir}/{topicName}/
+├── partition_{partitionID}_segment_00000000000000000000.log
+├── partition_{partitionID}_segment_00000000000000000000.index
+├── partition_{partitionID}_segment_00000000000000001024.log
+├── partition_{partitionID}_segment_00000000000000001024.index
 └── ...
 ```
 
-The BaseName for a DiskHandler is constructed as: `{LogDir}/{topicName}/partition_{partitionID}`, and individual segment files `append _segment_{N}.log` to this base.
+The BaseName for a DiskHandler is constructed as: `{LogDir}/{topicName}/partition_{partitionID}`, and individual segment files append `_segment_{offset}.log` (and `.index`) to this base. The offset in the filename is the base offset of the first message in that segment.
 
 ### Segment Size Limit
 
-Each segment has a maximum size of 1MB (1,048,576 bytes).
+Each segment has a configurable maximum size (default: 1GB = 1,073,741,824 bytes), set via `log_segment_bytes` in the configuration file.
 
-Parameter	Value	Location
-segmentSize	1024 * 1024 bytes (1MB)
-// todo
+| Parameter | Default | Config Key |
+|-----------|---------|------------|
+| Segment Size | 1GB | `log_segment_bytes` |
+| Index Size | 10MB | `log_index_size_bytes` |
+| Index Interval | 4096 bytes | `log_index_interval_bytes` |
+| Segment Roll Time | 7 days | `log_segment_roll_ms` |
 
-When writing a message would cause the current segment to exceed this size, rotation is triggered.
+Rotation is triggered when either the data file or index file would exceed its size limit, or when the time-based roll interval expires.
+
+## Segment Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Creating: NewDiskHandler()
+    Creating --> Active: openSegment()
+    Active --> Active: WriteBatch / WriteDirect
+    Active --> Rotating: size/index/time limit reached
+    Rotating --> Active: rotateSegment() opens new segment
+    Rotating --> Closed: old segment closed
+    Closed --> [*]: retention cleanup
+    Active --> Draining: Close() called
+    Draining --> [*]: all messages flushed
+```
 
 ## Segment Creation
 
@@ -130,7 +149,7 @@ The `GetHandler()` method implements lazy initialization - handlers are created 
 | 2    | Check if handler exists in map    | Map lookup           |
 | 3    | If exists, return existing handler| Early return         |
 | 4    | If not exists, create log directory| `os.MkdirAll()`       |
-| 5    | Create new DiskHandler (1MB segments)| `NewDiskHandler()`   |
+| 5    | Create new DiskHandler               | `NewDiskHandler()`   |
 | 6    | Store in handlers map             | Map insertion        |
 | 7    | Return new handler                | Release lock         |
 
@@ -212,7 +231,7 @@ This dual-lock design allows:
 
 ## Key Takeaways
 
-- **1MB Segment Boundary**: Hard limit enforced before writing each message to prevent segments from exceeding size
+- **Configurable Segment Boundary**: Default 1GB, enforced before writing each batch to prevent segments from exceeding size
 - **Sequential Naming**: Segments numbered sequentially (0, 1, 2, ...) per topic-partition
 - **Atomic Rotation**: `rotateSegment()` ensures clean transition with proper flush and close operations
 - **Lazy Creation**: DiskManager creates handlers on-demand via `GetHandler()`

--- a/docs/core/topic/consumer-groups.md
+++ b/docs/core/topic/consumer-groups.md
@@ -10,6 +10,33 @@ Consumer groups provide a mechanism for horizontal scaling of message consumptio
 
 Each partition's messages are delivered to exactly one consumer within a group, ensuring that ordering is preserved within each partition while enabling parallel processing across partitions.
 
+```mermaid
+graph TD
+    T[Topic: orders] --> P0[Partition 0]
+    T --> P1[Partition 1]
+    T --> P2[Partition 2]
+    T --> P3[Partition 3]
+
+    subgraph "Consumer Group A"
+        C0[Consumer 0]
+        C1[Consumer 1]
+    end
+
+    P0 -->|assigned| C0
+    P1 -->|assigned| C1
+    P2 -->|assigned| C0
+    P3 -->|assigned| C1
+
+    subgraph "Consumer Group B (independent)"
+        C2[Consumer 0]
+    end
+
+    P0 -.->|independent copy| C2
+    P1 -.-> C2
+    P2 -.-> C2
+    P3 -.-> C2
+```
+
 ## Key capabilities:
 
 - **Load balancing**: Partitions are distributed evenly across consumers using modulo arithmetic

--- a/docs/reference/benchmark.md
+++ b/docs/reference/benchmark.md
@@ -20,6 +20,26 @@ The benchmark tool executes a three-phase workflow:
 
 ## Benchmark Architecture
 
+```mermaid
+graph LR
+    subgraph "Phase 1"
+        TC[Topic Creation]
+    end
+    subgraph "Phase 2: Producers"
+        P0[Producer 0] --> B[Broker]
+        P1[Producer 1] --> B
+        PN[Producer N] --> B
+    end
+    subgraph "Phase 3: Consumers"
+        B --> C0[Consumer 0]
+        B --> C1[Consumer 1]
+        B --> CN[Consumer N]
+    end
+    TC --> P0
+    TC --> P1
+    TC --> PN
+```
+
 ### Running Benchmarks Locally
 
 The benchmark tool is built as part of the standard build process:
@@ -318,7 +338,52 @@ All benchmark messages use the standard cursus protocol:
 The consumer phase sends commands in this format:
 
 ```
-CONSUME <topic> <partition> <offset>
+CONSUME topic=<name> partition=<N> offset=<N> group=<name> generation=<N> member=<id>
 ```
 
-This instructs the broker to stream messages from partition 0 starting at offset 0.
+This instructs the broker to read messages from the specified partition starting at the given offset.
+
+## Disk-Level Benchmarks (Go test)
+
+In addition to the end-to-end benchmark tool, cursus includes Go-native benchmarks for measuring disk I/O performance in isolation. These are useful for evaluating the impact of storage-layer optimizations without network overhead.
+
+### Running Disk Benchmarks
+
+```bash
+go test ./pkg/disk/ -bench=. -benchmem -count=3 -timeout=120s
+```
+
+### Available Benchmarks
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkWriteBatch_100` | Write 100-message batches to disk |
+| `BenchmarkWriteBatch_500` | Write 500-message batches to disk |
+| `BenchmarkSerializeDiskMessage` | Serialize a single DiskMessage to binary format |
+| `BenchmarkReadMessages` | Read 100 messages from a 1000-message segment |
+
+### Running Specific Benchmarks
+
+```bash
+# Serialize only
+go test ./pkg/disk/ -bench=BenchmarkSerializeDiskMessage -benchmem -count=5
+
+# Write path only
+go test ./pkg/disk/ -bench='BenchmarkWriteBatch' -benchmem -count=3
+
+# Read path only
+go test ./pkg/disk/ -bench=BenchmarkReadMessages -benchmem -count=3
+```
+
+### Interpreting Results
+
+```
+BenchmarkWriteBatch_100-14    48786    24185 ns/op    17165 B/op    105 allocs/op
+```
+
+- **48786**: iterations run
+- **24185 ns/op**: nanoseconds per operation
+- **17165 B/op**: bytes allocated per operation
+- **105 allocs/op**: heap allocations per operation
+
+Lower values in all three metrics indicate better performance. The `allocs/op` metric is particularly important for GC pressure under sustained load.

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -8,6 +8,20 @@ These features enable operators to monitor broker health, track performance metr
 
 ## Overview
 
+```mermaid
+graph LR
+    B[Broker :9000] -->|expose| M[Metrics :9100]
+    B -->|expose| H[Health :9080]
+    B -->|write| L[stdout/stderr]
+    M -->|scrape| P[Prometheus]
+    P --> G[Grafana]
+    H -->|poll| LB[Load Balancer]
+    L -->|collect| ELK[Log Aggregator]
+
+    SDK[SDK Client] -->|expose| SM[SDK Metrics :2112]
+    SM -->|scrape| P
+```
+
 cursus provides three primary observability mechanisms:
 
 | Component            | Port       | Protocol          | Purpose                                                      |
@@ -70,17 +84,36 @@ The Prometheus metrics exporter runs as a separate HTTP server on port 9100, exp
 
 ### Metric Categories
 
-While the pkg/metrics package implementation isn't shown in the provided files, the architecture suggests these metric categories based on the system design:
+The `pkg/metrics` package exposes the following Prometheus metrics:
 
-| Category          | Metric Examples                                  | Description                        |
-|------------------|-------------------------------------------------|------------------------------------|
-| Topic Metrics     | Topics created, deleted, active topics         | Topic lifecycle tracking            |
-| Partition Metrics | Messages per partition, partition queue depth  | Partition-level performance         |
-| Disk Metrics      | Bytes written, flush operations, segment rotations | Storage subsystem performance       |
-| Consumer Metrics  | Active consumers, messages delivered           | Consumer tracking                   |
-| Server Metrics    | Active connections, commands processed         | Server-level operations             |
+**Broker Metrics** (`pkg/metrics/broker.go`):
 
-The TopicManager includes a metrics field [pkg/topic] for tracking deduplication and message flow.
+| Metric | Type | Description |
+|--------|------|-------------|
+| `broker_messages_processed_total` | Counter | Total messages processed |
+| `broker_messages_per_second` | Gauge | Current throughput |
+| `broker_message_latency_seconds` | Histogram | Message processing latency |
+| `broker_queue_size` | Gauge | Current topic manager queue size |
+| `broker_cleanup_count_total` | Counter | Deduped message IDs cleaned up |
+| `broker_seqnum_gap_total` | Counter | SeqNum gaps detected (labels: topic, partition, producer_id) |
+| `broker_seqnum_duplicate_total` | Counter | Duplicate seqNums detected (labels: topic, partition) |
+| `broker_consumer_lag` | Gauge | Consumer lag per partition (labels: topic, partition, group) |
+
+**Cluster Metrics** (`pkg/metrics/cluster.go`):
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `cluster_brokers_total` | Gauge | Total brokers in cluster |
+| `cluster_partition_leaders_total` | Gauge | Partition leaders per broker |
+| `cluster_replication_lag_seconds` | Histogram | Replication lag (labels: topic, partition, broker) |
+| `cluster_leader_elections_total` | Counter | Leader elections |
+| `cluster_isr_size` | Gauge | ISR size per partition |
+| `cluster_replication_lag_bytes` | Gauge | Replication lag in bytes |
+| `cluster_isr_changes_total` | Counter | ISR membership changes |
+| `cluster_leader_election_failures_total` | Counter | Failed leader elections |
+| `cluster_broker_health_status` | Gauge | Broker health (1=healthy, 0=unhealthy) |
+| `cluster_quorum_operations_total` | Counter | Quorum operations |
+| `cluster_partition_reassignments_total` | Counter | Partition reassignments |
 
 ### Configuration
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -19,12 +19,12 @@ The following table lists all performance-related configuration parameters with 
 
 | Parameter                  | Config Key                     | Default | CLI Flag                   | Impact                                           |
 |----------------------------|-------------------------------|---------|----------------------------|------------------------------------------------|
-| Partition Channel Buffer    | channel_buffer_size            | 10000   | --channel-buffer           | Controls partition input queue depth          |
-| Disk Flush Batch Size       | disk_flush_batch_size          | 500     | --disk-flush-batch         | Messages per disk flush operation             |
-| Linger Time                 | linger_ms                      | 100     | --linger-ms                | Maximum wait time before forced flush         |
+| Partition Channel Buffer    | channel_buffer_size            | 1024    | --channel-buffer           | Controls DiskHandler write channel depth      |
+| Disk Flush Batch Size       | disk_flush_batch_size          | 50      | --disk-flush-batch         | Messages per disk flush operation             |
+| Linger Time                 | linger_ms                      | 50      | --linger-ms                | Maximum wait time before forced flush         |
 | Partition Channel Buffer    | partition_channel_buffer_size  | 10000   | --partition-ch-buffer      | Partition message queue size                  |
 | Consumer Channel Buffer     | consumer_channel_buffer_size   | 1000    | --consumer-ch-buffer       | Per-consumer message queue size               |
-| Disk Write Timeout          | disk_write_timeout_ms          | 5       | --disk-write-timeout       | Timeout for synchronous writes when channel full |
+| Disk Write Timeout          | disk_write_timeout_ms          | 10      | --disk-write-timeout       | Timeout for synchronous writes when channel full |
 
 
 ## Configuration Hierarchy
@@ -46,9 +46,9 @@ The `partition_channel_buffer_size` parameter controls the input queue depth for
 
 ### Configuration:
 
-Default: 10000 messages
+Default: 1024 messages
 
-Config key: partition_channel_buffer_size
+Config key: channel_buffer_size
 
 CLI flag: --partition-ch-buffer
 
@@ -318,9 +318,9 @@ broker:
 
 Performance tuning in cursus involves balancing three primary parameters:
 
-- `disk_flush_batch_size` - Controls throughput vs latency trade-off (default: 500)
-- `linger_ms` - Sets maximum message latency guarantee (default: 100ms)
-- `channel_buffer_size` / `partition_channel_buffer_size` / `consumer_channel_buffer_size` - memory usage and burst handling (defaults: 10000/10000/1000)
+- `disk_flush_batch_size` - Controls throughput vs latency trade-off (default: 50)
+- `linger_ms` - Sets maximum message latency guarantee (default: 50ms)
+- `channel_buffer_size` / `partition_channel_buffer_size` / `consumer_channel_buffer_size` - memory usage and burst handling (defaults: 1024/10000/1000)
 
 ## Key principles:
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -101,7 +101,7 @@ The configuration is represented by the Config struct in the codebase, which org
 | `enable_exporter`    | bool       | true           | Enable Prometheus metrics exporter              |
 | `exporter_port`      | int        | 9100           | HTTP port for Prometheus metrics endpoint       |
 | `enable_benchmark`   | bool       | false          | Enable benchmark mode for testing               |
-| `cleanup_interval`   | int        | 300            | Deduplication map cleanup interval (seconds)   |
+| `cleanup_interval`   | int        | 300            | Log cleanup interval (seconds)                 |
 
 
 # Security and Compression
@@ -124,7 +124,13 @@ These parameters directly affect the write path performance and batching behavio
 | `disk_flush_batch_size` | int  | 50      | Number of messages to batch before flushing to disk       |
 | `linger_ms`             | int  | 50      | Maximum time to wait before flushing (milliseconds)       |
 | `channel_buffer_size`   | int  | 1024    | Buffer size for DiskHandler's writeCh channel             |
-| `disk_write_timeout_ms` | int  | 5       | Timeout for synchronous writes when channel is full       |
+| `disk_write_timeout_ms` | int  | 10      | Timeout for synchronous writes when channel is full (ms)  |
+| `disk_flush_interval_ms`| int  | 500     | Periodic fsync interval (milliseconds)                    |
+| `log_segment_bytes`     | uint64 | 1073741824 | Maximum segment file size (1GB default)                |
+| `log_index_size_bytes`  | uint64 | 10485760   | Maximum index file size (10MB default)                 |
+| `log_index_interval_bytes` | int | 4096    | Index entry interval in bytes                            |
+| `log_retention_hours`   | int  | 168     | Log retention period in hours (7 days default)            |
+| `compression_type`      | string | "none" | Compression type: "none", "gzip", "snappy", "lz4"       |
 
 
 Trade-offs:

--- a/pkg/disk/bench_test.go
+++ b/pkg/disk/bench_test.go
@@ -1,0 +1,123 @@
+package disk
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
+)
+
+func newBenchDiskHandler(b *testing.B) (*DiskHandler, func()) {
+	b.Helper()
+	dir, err := os.MkdirTemp("", "disk-bench-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	cfg := &config.Config{
+		LogDir:             dir,
+		SegmentSize:        64 * 1024 * 1024,
+		IndexSize:          10 * 1024 * 1024,
+		IndexIntervalBytes: 4096,
+		ChannelBufferSize:  10000,
+		DiskFlushBatchSize: 500,
+		LingerMS:           5,
+		DiskWriteTimeoutMS: 5000,
+		DiskFlushIntervalMS: 100,
+	}
+	dh, err := NewDiskHandler(cfg, "bench-topic", 0)
+	if err != nil {
+		os.RemoveAll(dir)
+		b.Fatal(err)
+	}
+	return dh, func() {
+		dh.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+func makeBenchMessages(n int) []types.DiskMessage {
+	msgs := make([]types.DiskMessage, n)
+	for i := range msgs {
+		msgs[i] = types.DiskMessage{
+			Topic:      "bench-topic",
+			Partition:  0,
+			Offset:     uint64(i),
+			ProducerID: "producer-1",
+			SeqNum:     uint64(i + 1),
+			Epoch:      1,
+			Payload:    "benchmark-payload-data-1234567890abcdefghijklmnopqrstuvwxyz",
+		}
+	}
+	return msgs
+}
+
+func BenchmarkWriteBatch_100(b *testing.B) {
+	dh, cleanup := newBenchDiskHandler(b)
+	defer cleanup()
+	msgs := makeBenchMessages(100)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range msgs {
+			msgs[j].Offset = uint64(i*100 + j)
+		}
+		if err := dh.WriteBatch(msgs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWriteBatch_500(b *testing.B) {
+	dh, cleanup := newBenchDiskHandler(b)
+	defer cleanup()
+	msgs := makeBenchMessages(500)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range msgs {
+			msgs[j].Offset = uint64(i*500 + j)
+		}
+		if err := dh.WriteBatch(msgs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSerializeDiskMessage(b *testing.B) {
+	msg := types.DiskMessage{
+		Topic:      "bench-topic",
+		Partition:  0,
+		Offset:     12345,
+		ProducerID: "producer-1",
+		SeqNum:     100,
+		Epoch:      1,
+		Payload:    "benchmark-payload-data-1234567890abcdefghijklmnopqrstuvwxyz",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := util.SerializeDiskMessage(msg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReadMessages(b *testing.B) {
+	dh, cleanup := newBenchDiskHandler(b)
+	defer cleanup()
+
+	msgs := makeBenchMessages(1000)
+	if err := dh.WriteBatch(msgs); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := dh.ReadMessages(0, 100)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/disk/flush_common.go
+++ b/pkg/disk/flush_common.go
@@ -124,7 +124,7 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 		if err != nil {
 			return fmt.Errorf("serialize failed at index %d: %w", i, err)
 		}
-		if len(serialized) > math.MaxUint32 {
+		if _, ok := util.SafeIntToUint32(len(serialized)); !ok {
 			return fmt.Errorf("message too large at index %d: %d bytes", i, len(serialized))
 		}
 		serializedMsgs[i] = serialized
@@ -181,7 +181,8 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 			}
 		}
 
-		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(serialized)))
+		sLen, _ := util.SafeIntToUint32(len(serialized)) // validated in pre-loop
+		binary.BigEndian.PutUint32(lenBuf[:], sLen)
 		if _, err := d.writer.Write(lenBuf[:]); err != nil {
 			return fmt.Errorf("write length failed: %w", err)
 		}
@@ -247,7 +248,8 @@ func (d *DiskHandler) WriteDirect(topic string, partition int, msg types.Message
 		return fmt.Errorf("serialize failed: %w", err)
 	}
 
-	if len(serialized) > math.MaxUint32 {
+	serLen, ok := util.SafeIntToUint32(len(serialized))
+	if !ok {
 		return fmt.Errorf("message too large: %d bytes", len(serialized))
 	}
 
@@ -268,7 +270,7 @@ func (d *DiskHandler) WriteDirect(topic string, partition int, msg types.Message
 	}
 
 	var lenBuf [4]byte
-	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(serialized)))
+	binary.BigEndian.PutUint32(lenBuf[:], serLen)
 
 	if _, err := d.writer.Write(lenBuf[:]); err != nil {
 		return err

--- a/pkg/disk/flush_common.go
+++ b/pkg/disk/flush_common.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"sync/atomic"
 	"time"
@@ -123,7 +124,7 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 		if err != nil {
 			return fmt.Errorf("serialize failed at index %d: %w", i, err)
 		}
-		if len(serialized) > 0xFFFFFFFF {
+		if len(serialized) > math.MaxUint32 {
 			return fmt.Errorf("message too large at index %d: %d bytes", i, len(serialized))
 		}
 		serializedMsgs[i] = serialized
@@ -218,6 +219,10 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 
 // WriteDirect writes a single message immediately without batching.
 func (d *DiskHandler) WriteDirect(topic string, partition int, msg types.Message) error {
+	if partition < 0 || partition > math.MaxInt32 {
+		return fmt.Errorf("partition out of int32 range: %d", partition)
+	}
+
 	interval := d.indexInterval
 	if interval == 0 {
 		interval = 4096 // default interval (4KB)
@@ -242,7 +247,7 @@ func (d *DiskHandler) WriteDirect(topic string, partition int, msg types.Message
 		return fmt.Errorf("serialize failed: %w", err)
 	}
 
-	if len(serialized) > 0xFFFFFFFF {
+	if len(serialized) > math.MaxUint32 {
 		return fmt.Errorf("message too large: %d bytes", len(serialized))
 	}
 

--- a/pkg/disk/flush_common.go
+++ b/pkg/disk/flush_common.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -116,6 +115,21 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 		interval = 4096 // default interval (4KB)
 	}
 
+	// Serialize outside of lock to reduce lock hold time
+	serializedMsgs := make([][]byte, len(batch))
+	totalSize := 0
+	for i, msg := range batch {
+		serialized, err := util.SerializeDiskMessage(msg)
+		if err != nil {
+			return fmt.Errorf("serialize failed at index %d: %w", i, err)
+		}
+		if len(serialized) > 0xFFFFFFFF {
+			return fmt.Errorf("message too large at index %d: %d bytes", i, len(serialized))
+		}
+		serializedMsgs[i] = serialized
+		totalSize += 4 + len(serialized)
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.ioMu.Lock()
@@ -128,20 +142,6 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 		if err := d.openIndexFiles(); err != nil {
 			return err
 		}
-	}
-
-	serializedMsgs := make([][]byte, 0, len(batch))
-	totalSize := 0
-	for i, msg := range batch {
-		serialized, err := util.SerializeDiskMessage(msg)
-		if err != nil {
-			return fmt.Errorf("serialize failed at index %d: %w", i, err)
-		}
-		if len(serialized) > 0xFFFFFFFF {
-			return fmt.Errorf("message too large at index %d: %d bytes", i, len(serialized))
-		}
-		serializedMsgs = append(serializedMsgs, serialized)
-		totalSize += 4 + len(serialized)
 	}
 
 	const entrySize = uint64(types.IndexEntrySize)
@@ -159,7 +159,7 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 	}
 
 	accumulatedLen := uint64(0)
-	lenBuf := make([]byte, 4)
+	var lenBuf [4]byte
 	for i, serialized := range serializedMsgs {
 		msgPosition := d.CurrentOffset + accumulatedLen
 		msg := batch[i]
@@ -180,8 +180,8 @@ func (d *DiskHandler) WriteBatch(batch []types.DiskMessage) error {
 			}
 		}
 
-		binary.BigEndian.PutUint32(lenBuf, uint32(len(serialized)))
-		if _, err := d.writer.Write(lenBuf); err != nil {
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(serialized)))
+		if _, err := d.writer.Write(lenBuf[:]); err != nil {
 			return fmt.Errorf("write length failed: %w", err)
 		}
 		if _, err := d.writer.Write(serialized); err != nil {
@@ -348,9 +348,6 @@ func (d *DiskHandler) rotateSegment(nextBaseOffset uint64) error {
 	d.segmentCreatedAt = time.Now()
 
 	d.segments = append(d.segments, nextBaseOffset)
-	sort.Slice(d.segments, func(i, j int) bool {
-		return d.segments[i] < d.segments[j]
-	})
 
 	if err := d.openSegment(); err != nil {
 		util.Error("Failed to open new segment: %v", err)

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -373,16 +373,17 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 
 // readMessagesFromPosition reads messages starting from a specific byte position
 func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position uint64, max int, targetOffset uint64) []types.Message {
-	messages := []types.Message{}
+	messages := make([]types.Message, 0, max)
 	pos := int(position)
+	var lenBuf [4]byte
+	var dataBuf []byte
 
 	for len(messages) < max && pos+4 <= reader.Len() {
-		lenBytes := make([]byte, 4)
-		if _, err := reader.ReadAt(lenBytes, int64(pos)); err != nil {
+		if _, err := reader.ReadAt(lenBuf[:], int64(pos)); err != nil {
 			break
 		}
 
-		msgLen := binary.BigEndian.Uint32(lenBytes)
+		msgLen := binary.BigEndian.Uint32(lenBuf[:])
 		if msgLen == 0 || msgLen > MaxMessageSize {
 			util.Error("Corrupted message length detected at pos %d: %d bytes (limit: %d)", pos, msgLen, MaxMessageSize)
 			break
@@ -392,12 +393,17 @@ func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position 
 			util.Error("Incomplete message at pos %d: expected %d bytes but reached EOF", pos, msgLen)
 			break
 		}
-		data := make([]byte, msgLen)
-		if _, err := reader.ReadAt(data, int64(pos+4)); err != nil {
+
+		if cap(dataBuf) < int(msgLen) {
+			dataBuf = make([]byte, msgLen)
+		} else {
+			dataBuf = dataBuf[:msgLen]
+		}
+		if _, err := reader.ReadAt(dataBuf, int64(pos+4)); err != nil {
 			break
 		}
 
-		diskMsg, err := util.DeserializeDiskMessage(data)
+		diskMsg, err := util.DeserializeDiskMessage(dataBuf)
 		if err != nil {
 			util.Error("failed to deserialize disk message at pos %d: %v", pos, err)
 			pos += 4 + int(msgLen)

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -103,7 +104,9 @@ func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*Dis
 			if countErr != nil {
 				util.Error("failed to count messages in last segment %s: %v", lastFile, countErr)
 			}
-			lastAbsoluteOffset = currentSegmentBase + uint64(c)
+			if c >= 0 {
+				lastAbsoluteOffset = currentSegmentBase + uint64(c)
+			}
 		}
 	}
 
@@ -117,6 +120,9 @@ func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*Dis
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat file: %w", err)
 	}
+	if fileInfo.Size() < 0 {
+		return nil, fmt.Errorf("negative file size: %d", fileInfo.Size())
+	}
 	currentOffset := uint64(fileInfo.Size())
 
 	dh := &DiskHandler{
@@ -128,7 +134,7 @@ func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*Dis
 		CurrentOffset:  currentOffset,
 		AbsoluteOffset: lastAbsoluteOffset,
 
-		indexInterval: uint64(cfg.IndexIntervalBytes),
+		indexInterval: safeIntToUint64(cfg.IndexIntervalBytes),
 
 		writeCh:        make(chan types.DiskMessage, cfg.ChannelBufferSize),
 		done:           make(chan struct{}),
@@ -235,6 +241,9 @@ func (d *DiskHandler) AppendMessageSync(topic string, partition int, msg *types.
 
 // AppendMessage sends a message to the internal write channel for asynchronous disk persistence.
 func (d *DiskHandler) AppendMessage(topic string, partition int, msg *types.Message) (uint64, error) {
+	if partition < 0 || partition > math.MaxInt32 {
+		return 0, fmt.Errorf("partition out of int32 range: %d", partition)
+	}
 	offset := atomic.AddUint64(&d.AbsoluteOffset, 1) - 1
 
 	msg.Offset = offset
@@ -317,7 +326,7 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 		}
 
 		actualSize := fi.Size()
-		if actualSize == 0 {
+		if actualSize <= 0 {
 			util.Debug("Segment %d is currently empty, skipping", segBase)
 			continue
 		}
@@ -335,7 +344,7 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 		}
 
 		batch := dh.readMessagesFromPosition(reader, readPos, remaining, offset)
-		if len(batch) == 0 && uint64(actualSize) > readPos+4 {
+		if len(batch) == 0 && actualSize > 0 && uint64(actualSize) > readPos+4 {
 			if err := reader.Close(); err != nil {
 				util.Debug("error closing reader: %v", err)
 			}
@@ -373,6 +382,9 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 
 // readMessagesFromPosition reads messages starting from a specific byte position
 func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position uint64, max int, targetOffset uint64) []types.Message {
+	if position > math.MaxInt {
+		return nil
+	}
 	messages := make([]types.Message, 0, max)
 	pos := int(position)
 	var lenBuf [4]byte
@@ -429,6 +441,13 @@ func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position 
 
 func (d *DiskHandler) countMessagesInSegment() (int, error) {
 	return d.countMessagesInSegmentID(d.CurrentSegment)
+}
+
+func safeIntToUint64(v int) uint64 {
+	if v < 0 {
+		return 0
+	}
+	return uint64(v)
 }
 
 func (d *DiskHandler) countMessagesInSegmentID(segmentID uint64) (int, error) {

--- a/pkg/disk/index.go
+++ b/pkg/disk/index.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 
@@ -26,7 +27,7 @@ func (d *DiskHandler) openIndexFiles() error {
 	var existingSize uint64
 	if os.IsNotExist(statErr) {
 		isNew = true
-	} else if statErr == nil {
+	} else if statErr == nil && info.Size() >= 0 {
 		existingSize = uint64(info.Size())
 	}
 
@@ -46,6 +47,9 @@ func (d *DiskHandler) openIndexFiles() error {
 	}
 
 	if !isReadOnly {
+		if d.IndexSize > math.MaxInt64 {
+			return fmt.Errorf("index size %d exceeds int64 max", d.IndexSize)
+		}
 		if err := f.Truncate(int64(d.IndexSize)); err != nil {
 			if err := f.Close(); err != nil {
 				util.Error("failed to close file: %v", err)
@@ -79,6 +83,9 @@ func (d *DiskHandler) seekLastValidIndexEntry(f *os.File, fileSize uint64) uint6
 
 	buf := make([]byte, entrySize)
 	for pos := fileSize - entrySize; ; pos -= entrySize {
+		if pos > math.MaxInt64 {
+			break
+		}
 		_, err := f.ReadAt(buf, int64(pos))
 		if err != nil {
 			break
@@ -163,11 +170,17 @@ func getLastOffsetFromIndex(indexPath string, baseOffset uint64) (lastOffset uin
 		}
 	}()
 
+	if info.Size() < 0 {
+		return 0, 0, fmt.Errorf("negative file size")
+	}
 	fileSize := uint64(info.Size())
 	buf := make([]byte, entrySize)
 	found := false
 
 	for pos := fileSize - entrySize; ; pos -= entrySize {
+		if pos > math.MaxInt64 {
+			break
+		}
 		_, err := f.ReadAt(buf, int64(pos))
 		if err != nil {
 			break
@@ -190,7 +203,11 @@ func getLastOffsetFromIndex(indexPath string, baseOffset uint64) (lastOffset uin
 		return 0, 0, fmt.Errorf("index empty or corrupt")
 	}
 
-	count = int(lastOffset - baseOffset + 1)
+	diff := lastOffset - baseOffset + 1
+	if diff > math.MaxInt {
+		return 0, 0, fmt.Errorf("offset range too large: %d", diff)
+	}
+	count = int(diff)
 	return lastOffset, count, nil
 }
 
@@ -239,6 +256,9 @@ func (d *DiskHandler) findOffsetPosition(offset uint64) (uint64, error) {
 		return 0, nil
 	}
 
+	if entryCount > math.MaxInt {
+		return 0, fmt.Errorf("entry count too large: %d", entryCount)
+	}
 	low, high := 0, int(entryCount)-1
 	var lastFoundPos uint64 = 0
 	buf := make([]byte, entrySize)

--- a/util/buffer.go
+++ b/util/buffer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"net"
 )
 
@@ -13,6 +14,9 @@ const MaxMessageSize = 64 * 1024 * 1024 // 64MB
 func WriteWithLength(conn net.Conn, data []byte) error {
 	if len(data) > MaxMessageSize {
 		return fmt.Errorf("data size %d exceeds maximum %d", len(data), MaxMessageSize)
+	}
+	if len(data) > math.MaxUint32 {
+		return fmt.Errorf("data size %d exceeds uint32 max", len(data))
 	}
 
 	lenBuf := make([]byte, 4)

--- a/util/encode.go
+++ b/util/encode.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/cursus-io/cursus/pkg/types"
 )
@@ -13,6 +14,9 @@ import (
 // EncodeMessage serializes topic and payload into bytes.
 func EncodeMessage(topic string, payload string) []byte {
 	topicBytes := []byte(topic)
+	if len(topicBytes) > math.MaxUint16 {
+		return nil
+	}
 	payloadBytes := []byte(payload)
 	data := make([]byte, 2+len(topicBytes)+len(payloadBytes))
 	binary.BigEndian.PutUint16(data[:2], uint16(len(topicBytes)))
@@ -47,7 +51,7 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 	}
 
 	topicBytes := []byte(topic)
-	if len(topicBytes) > 0xFFFF {
+	if len(topicBytes) > math.MaxUint16 {
 		return nil, fmt.Errorf("topic too long: %d bytes", len(topicBytes))
 	}
 	if err := write(uint16(len(topicBytes))); err != nil {
@@ -57,12 +61,15 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		return nil, fmt.Errorf("write topic bytes failed: %w", err)
 	}
 
+	if partition < math.MinInt32 || partition > math.MaxInt32 {
+		return nil, fmt.Errorf("partition out of int32 range: %d", partition)
+	}
 	if err := write(int32(partition)); err != nil {
 		return nil, err
 	}
 
 	acksBytes := []byte(acks)
-	if len(acksBytes) > 0xFF {
+	if len(acksBytes) > math.MaxUint8 {
 		return nil, fmt.Errorf("acks value too long: %d bytes", len(acksBytes))
 	}
 	if err := write(uint8(len(acksBytes))); err != nil {
@@ -88,6 +95,9 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		return nil, err
 	}
 
+	if len(msgs) > math.MaxInt32 {
+		return nil, fmt.Errorf("message count exceeds int32 max: %d", len(msgs))
+	}
 	if err := write(int32(len(msgs))); err != nil {
 		return nil, err
 	}
@@ -102,7 +112,7 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		}
 
 		producerIDBytes := []byte(m.ProducerID)
-		if len(producerIDBytes) > 0xFFFF {
+		if len(producerIDBytes) > math.MaxUint16 {
 			return nil, fmt.Errorf("producerID too long: %d bytes", len(producerIDBytes))
 		}
 		if err := write(uint16(len(producerIDBytes))); err != nil {
@@ -113,7 +123,7 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		}
 
 		keyBytes := []byte(m.Key)
-		if len(keyBytes) > 0xFFFF {
+		if len(keyBytes) > math.MaxUint16 {
 			return nil, fmt.Errorf("key too long: %d bytes", len(keyBytes))
 		}
 		if err := write(uint16(len(keyBytes))); err != nil {
@@ -128,6 +138,9 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		}
 
 		payloadBytes := []byte(m.Payload)
+		if len(payloadBytes) > math.MaxUint32 {
+			return nil, fmt.Errorf("payload too long: %d bytes", len(payloadBytes))
+		}
 		if err := write(uint32(len(payloadBytes))); err != nil {
 			return nil, err
 		}
@@ -137,7 +150,7 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 
 		// Event sourcing fields
 		eventTypeBytes := []byte(m.EventType)
-		if len(eventTypeBytes) > 0xFFFF {
+		if len(eventTypeBytes) > math.MaxUint16 {
 			return nil, fmt.Errorf("eventType too long: %d bytes", len(eventTypeBytes))
 		}
 		if err := write(uint16(len(eventTypeBytes))); err != nil {
@@ -156,7 +169,7 @@ func EncodeBatchMessages(topic string, partition int, acks string, isIdempotent 
 		}
 
 		metadataBytes := []byte(m.Metadata)
-		if len(metadataBytes) > 0xFFFF {
+		if len(metadataBytes) > math.MaxUint16 {
 			return nil, fmt.Errorf("metadata too long: %d bytes", len(metadataBytes))
 		}
 		if err := write(uint16(len(metadataBytes))); err != nil {

--- a/util/logger.go
+++ b/util/logger.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"log"
+	"math"
 	"os"
 	"sync/atomic"
 )
@@ -9,6 +10,9 @@ import (
 var currentLevel atomic.Int32
 
 func SetLevel(level LogLevel) {
+	if level < 0 || level > LogLevel(math.MaxInt32) {
+		return
+	}
 	currentLevel.Store(int32(level))
 }
 

--- a/util/safeconv.go
+++ b/util/safeconv.go
@@ -37,6 +37,13 @@ func SafeInt64ToUint64(v int64) (uint64, bool) {
 	return uint64(v), true // #nosec G115
 }
 
+func SafeInt32ToUint32(v int32) (uint32, bool) {
+	if v < 0 {
+		return 0, false
+	}
+	return uint32(v), true // #nosec G115
+}
+
 func SafeUint32ToInt32(v uint32) (int32, bool) {
 	if v > math.MaxInt32 {
 		return 0, false

--- a/util/safeconv.go
+++ b/util/safeconv.go
@@ -1,0 +1,59 @@
+package util
+
+import "math"
+
+func SafeIntToUint8(v int) (uint8, bool) {
+	if v < 0 || v > math.MaxUint8 {
+		return 0, false
+	}
+	return uint8(v), true // #nosec G115
+}
+
+func SafeIntToUint16(v int) (uint16, bool) {
+	if v < 0 || v > math.MaxUint16 {
+		return 0, false
+	}
+	return uint16(v), true // #nosec G115
+}
+
+func SafeIntToUint32(v int) (uint32, bool) {
+	if v < 0 || v > math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(v), true // #nosec G115
+}
+
+func SafeIntToInt32(v int) (int32, bool) {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		return 0, false
+	}
+	return int32(v), true // #nosec G115
+}
+
+func SafeInt64ToUint64(v int64) (uint64, bool) {
+	if v < 0 {
+		return 0, false
+	}
+	return uint64(v), true // #nosec G115
+}
+
+func SafeUint32ToInt32(v uint32) (int32, bool) {
+	if v > math.MaxInt32 {
+		return 0, false
+	}
+	return int32(v), true // #nosec G115
+}
+
+func SafeUint64ToInt64(v uint64) (int64, bool) {
+	if v > math.MaxInt64 {
+		return 0, false
+	}
+	return int64(v), true // #nosec G115
+}
+
+func SafeUint64ToInt(v uint64) (int, bool) {
+	if v > math.MaxInt {
+		return 0, false
+	}
+	return int(v), true // #nosec G115
+}

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/cursus-io/cursus/pkg/types"
 )
@@ -122,78 +123,86 @@ func DeserializeMessage(data []byte) (types.Message, error) {
 	return msg, nil
 }
 
+var diskMsgBufPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, 0, 256)
+		return &buf
+	},
+}
+
+// EstimateDiskMessageSize returns the serialized size of a DiskMessage without allocating.
+func EstimateDiskMessageSize(msg types.DiskMessage) int {
+	return 2 + len(msg.Topic) + 4 + 8 + 2 + len(msg.ProducerID) + 8 + 8 +
+		4 + len(msg.Payload) + 2 + len(msg.EventType) + 4 + 8 + 2 + len(msg.Metadata)
+}
+
 // SerializeDiskMessage serializes a DiskMessage for disk storage
 func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
-	var buf bytes.Buffer
+	size := EstimateDiskMessageSize(msg)
+	bufp := diskMsgBufPool.Get().(*[]byte)
+	buf := (*bufp)[:0]
+	if cap(buf) < size {
+		buf = make([]byte, 0, size)
+	}
+
+	var tmp [8]byte
 
 	// Topic (length + string)
-	topicBytes := []byte(msg.Topic)
-	if err := binary.Write(&buf, binary.BigEndian, uint16(len(topicBytes))); err != nil {
-		return nil, err
-	}
-	if _, err := buf.Write(topicBytes); err != nil {
-		return nil, err
-	}
+	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.Topic)))
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.Topic...)
 
 	// Partition (4 bytes)
-	if err := binary.Write(&buf, binary.BigEndian, msg.Partition); err != nil {
-		return nil, err
-	}
+	binary.BigEndian.PutUint32(tmp[:4], uint32(msg.Partition))
+	buf = append(buf, tmp[:4]...)
 
 	// Offset (8 bytes)
-	if err := binary.Write(&buf, binary.BigEndian, msg.Offset); err != nil {
-		return nil, err
-	}
+	binary.BigEndian.PutUint64(tmp[:8], msg.Offset)
+	buf = append(buf, tmp[:8]...)
 
-	// ProducerID
-	if err := binary.Write(&buf, binary.BigEndian, uint16(len(msg.ProducerID))); err != nil {
-		return nil, err
-	}
-	if _, err := buf.WriteString(msg.ProducerID); err != nil {
-		return nil, err
-	}
+	// ProducerID (length + string)
+	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.ProducerID)))
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.ProducerID...)
 
-	// SeqNum
-	if err := binary.Write(&buf, binary.BigEndian, msg.SeqNum); err != nil {
-		return nil, err
-	}
+	// SeqNum (8 bytes)
+	binary.BigEndian.PutUint64(tmp[:8], msg.SeqNum)
+	buf = append(buf, tmp[:8]...)
 
-	// Epoch
-	if err := binary.Write(&buf, binary.BigEndian, msg.Epoch); err != nil {
-		return nil, err
-	}
+	// Epoch (8 bytes)
+	binary.BigEndian.PutUint64(tmp[:8], uint64(msg.Epoch))
+	buf = append(buf, tmp[:8]...)
 
 	// Payload (length + string)
-	payloadBytes := []byte(msg.Payload)
-	if err := binary.Write(&buf, binary.BigEndian, uint32(len(payloadBytes))); err != nil {
-		return nil, err
-	}
-	if _, err := buf.Write(payloadBytes); err != nil {
-		return nil, err
-	}
+	binary.BigEndian.PutUint32(tmp[:4], uint32(len(msg.Payload)))
+	buf = append(buf, tmp[:4]...)
+	buf = append(buf, msg.Payload...)
 
-	eventTypeBytes := []byte(msg.EventType)
-	if err := binary.Write(&buf, binary.BigEndian, uint16(len(eventTypeBytes))); err != nil {
-		return nil, err
-	}
-	if _, err := buf.Write(eventTypeBytes); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, msg.SchemaVersion); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, msg.AggregateVersion); err != nil {
-		return nil, err
-	}
-	metadataBytes := []byte(msg.Metadata)
-	if err := binary.Write(&buf, binary.BigEndian, uint16(len(metadataBytes))); err != nil {
-		return nil, err
-	}
-	if _, err := buf.Write(metadataBytes); err != nil {
-		return nil, err
-	}
+	// EventType (length + string)
+	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.EventType)))
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.EventType...)
 
-	return buf.Bytes(), nil
+	// SchemaVersion (4 bytes)
+	binary.BigEndian.PutUint32(tmp[:4], msg.SchemaVersion)
+	buf = append(buf, tmp[:4]...)
+
+	// AggregateVersion (8 bytes)
+	binary.BigEndian.PutUint64(tmp[:8], msg.AggregateVersion)
+	buf = append(buf, tmp[:8]...)
+
+	// Metadata (length + string)
+	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.Metadata)))
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.Metadata...)
+
+	// Return a copy so the pooled buffer can be reused
+	result := make([]byte, len(buf))
+	copy(result, buf)
+	*bufp = buf
+	diskMsgBufPool.Put(bufp)
+
+	return result, nil
 }
 
 // DeserializeDiskMessage deserializes bytes back to DiskMessage

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -175,11 +175,10 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("metadata too long: %d", len(msg.Metadata))
 	}
-	partitionVal, ok := SafeUint32ToInt32(uint32(msg.Partition)) // Partition is int32, re-validate
-	if msg.Partition < 0 {
+	partitionVal, ok := SafeInt32ToUint32(msg.Partition)
+	if !ok {
 		return nil, fmt.Errorf("negative partition: %d", msg.Partition)
 	}
-	_ = ok
 	epochVal, ok := SafeInt64ToUint64(msg.Epoch)
 	if !ok {
 		return nil, fmt.Errorf("negative epoch: %d", msg.Epoch)
@@ -200,7 +199,7 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	buf = append(buf, msg.Topic...)
 
 	// Partition (4 bytes)
-	binary.BigEndian.PutUint32(tmp[:4], uint32(partitionVal))
+	binary.BigEndian.PutUint32(tmp[:4], partitionVal)
 	buf = append(buf, tmp[:4]...)
 
 	// Offset (8 bytes)

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -17,7 +17,11 @@ func SerializeMessage(msg types.Message) ([]byte, error) {
 
 	// ProducerID (length + string)
 	producerBytes := []byte(msg.ProducerID)
-	if err = binary.Write(&buf, binary.BigEndian, uint16(len(producerBytes))); err != nil {
+	producerLen, ok := SafeIntToUint16(len(producerBytes))
+	if !ok {
+		return nil, fmt.Errorf("producerID too long: %d", len(producerBytes))
+	}
+	if err = binary.Write(&buf, binary.BigEndian, producerLen); err != nil {
 		return nil, fmt.Errorf("write producer length: %w", err)
 	}
 	if _, err = buf.Write(producerBytes); err != nil {
@@ -31,7 +35,11 @@ func SerializeMessage(msg types.Message) ([]byte, error) {
 
 	// Payload (length + string)
 	payloadBytes := []byte(msg.Payload)
-	if err = binary.Write(&buf, binary.BigEndian, uint32(len(payloadBytes))); err != nil {
+	payloadLen, ok := SafeIntToUint32(len(payloadBytes))
+	if !ok {
+		return nil, fmt.Errorf("payload too long: %d", len(payloadBytes))
+	}
+	if err = binary.Write(&buf, binary.BigEndian, payloadLen); err != nil {
 		return nil, fmt.Errorf("write payload length: %w", err)
 	}
 	if _, err = buf.Write(payloadBytes); err != nil {
@@ -40,7 +48,11 @@ func SerializeMessage(msg types.Message) ([]byte, error) {
 
 	// Key (length + string)
 	keyBytes := []byte(msg.Key)
-	if err = binary.Write(&buf, binary.BigEndian, uint16(len(keyBytes))); err != nil {
+	keyLen, ok := SafeIntToUint16(len(keyBytes))
+	if !ok {
+		return nil, fmt.Errorf("key too long: %d", len(keyBytes))
+	}
+	if err = binary.Write(&buf, binary.BigEndian, keyLen); err != nil {
 		return nil, fmt.Errorf("write key length: %w", err)
 	}
 	if _, err = buf.Write(keyBytes); err != nil {
@@ -118,7 +130,12 @@ func DeserializeMessage(data []byte) (types.Message, error) {
 	}
 
 	// Epoch (8 bytes)
-	msg.Epoch = int64(binary.BigEndian.Uint64(data[offset : offset+8]))
+	epochRaw := binary.BigEndian.Uint64(data[offset : offset+8])
+	epochVal, ok := SafeUint64ToInt64(epochRaw)
+	if !ok {
+		return msg, fmt.Errorf("epoch value %d exceeds int64 max", epochRaw)
+	}
+	msg.Epoch = epochVal
 
 	return msg, nil
 }
@@ -138,6 +155,36 @@ func EstimateDiskMessageSize(msg types.DiskMessage) int {
 
 // SerializeDiskMessage serializes a DiskMessage for disk storage
 func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
+	topicLen, ok := SafeIntToUint16(len(msg.Topic))
+	if !ok {
+		return nil, fmt.Errorf("topic too long: %d", len(msg.Topic))
+	}
+	producerLen, ok := SafeIntToUint16(len(msg.ProducerID))
+	if !ok {
+		return nil, fmt.Errorf("producerID too long: %d", len(msg.ProducerID))
+	}
+	payloadLen, ok := SafeIntToUint32(len(msg.Payload))
+	if !ok {
+		return nil, fmt.Errorf("payload too long: %d", len(msg.Payload))
+	}
+	eventTypeLen, ok := SafeIntToUint16(len(msg.EventType))
+	if !ok {
+		return nil, fmt.Errorf("eventType too long: %d", len(msg.EventType))
+	}
+	metadataLen, ok := SafeIntToUint16(len(msg.Metadata))
+	if !ok {
+		return nil, fmt.Errorf("metadata too long: %d", len(msg.Metadata))
+	}
+	partitionVal, ok := SafeUint32ToInt32(uint32(msg.Partition)) // Partition is int32, re-validate
+	if msg.Partition < 0 {
+		return nil, fmt.Errorf("negative partition: %d", msg.Partition)
+	}
+	_ = ok
+	epochVal, ok := SafeInt64ToUint64(msg.Epoch)
+	if !ok {
+		return nil, fmt.Errorf("negative epoch: %d", msg.Epoch)
+	}
+
 	size := EstimateDiskMessageSize(msg)
 	bufp := diskMsgBufPool.Get().(*[]byte)
 	buf := (*bufp)[:0]
@@ -148,12 +195,12 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	var tmp [8]byte
 
 	// Topic (length + string)
-	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.Topic)))
+	binary.BigEndian.PutUint16(tmp[:2], topicLen)
 	buf = append(buf, tmp[:2]...)
 	buf = append(buf, msg.Topic...)
 
 	// Partition (4 bytes)
-	binary.BigEndian.PutUint32(tmp[:4], uint32(msg.Partition))
+	binary.BigEndian.PutUint32(tmp[:4], uint32(partitionVal))
 	buf = append(buf, tmp[:4]...)
 
 	// Offset (8 bytes)
@@ -161,7 +208,7 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	buf = append(buf, tmp[:8]...)
 
 	// ProducerID (length + string)
-	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.ProducerID)))
+	binary.BigEndian.PutUint16(tmp[:2], producerLen)
 	buf = append(buf, tmp[:2]...)
 	buf = append(buf, msg.ProducerID...)
 
@@ -170,16 +217,16 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	buf = append(buf, tmp[:8]...)
 
 	// Epoch (8 bytes)
-	binary.BigEndian.PutUint64(tmp[:8], uint64(msg.Epoch))
+	binary.BigEndian.PutUint64(tmp[:8], epochVal)
 	buf = append(buf, tmp[:8]...)
 
 	// Payload (length + string)
-	binary.BigEndian.PutUint32(tmp[:4], uint32(len(msg.Payload)))
+	binary.BigEndian.PutUint32(tmp[:4], payloadLen)
 	buf = append(buf, tmp[:4]...)
 	buf = append(buf, msg.Payload...)
 
 	// EventType (length + string)
-	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.EventType)))
+	binary.BigEndian.PutUint16(tmp[:2], eventTypeLen)
 	buf = append(buf, tmp[:2]...)
 	buf = append(buf, msg.EventType...)
 
@@ -192,7 +239,7 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	buf = append(buf, tmp[:8]...)
 
 	// Metadata (length + string)
-	binary.BigEndian.PutUint16(tmp[:2], uint16(len(msg.Metadata)))
+	binary.BigEndian.PutUint16(tmp[:2], metadataLen)
 	buf = append(buf, tmp[:2]...)
 	buf = append(buf, msg.Metadata...)
 
@@ -227,7 +274,12 @@ func DeserializeDiskMessage(data []byte) (types.DiskMessage, error) {
 	if offset+4 > len(data) {
 		return msg, errors.New("data too short for partition")
 	}
-	msg.Partition = int32(binary.BigEndian.Uint32(data[offset : offset+4]))
+	partRaw := binary.BigEndian.Uint32(data[offset : offset+4])
+	partVal, ok := SafeUint32ToInt32(partRaw)
+	if !ok {
+		return msg, fmt.Errorf("partition value %d exceeds int32 max", partRaw)
+	}
+	msg.Partition = partVal
 	offset += 4
 
 	// Offset
@@ -260,7 +312,12 @@ func DeserializeDiskMessage(data []byte) (types.DiskMessage, error) {
 	if offset+8 > len(data) {
 		return msg, errors.New("data too short for epoch")
 	}
-	msg.Epoch = int64(binary.BigEndian.Uint64(data[offset : offset+8]))
+	diskEpochRaw := binary.BigEndian.Uint64(data[offset : offset+8])
+	diskEpochVal, ok := SafeUint64ToInt64(diskEpochRaw)
+	if !ok {
+		return msg, fmt.Errorf("epoch value %d exceeds int64 max", diskEpochRaw)
+	}
+	msg.Epoch = diskEpochVal
 	offset += 8
 
 	// Payload


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes #36 

Reduces lock hold time, heap allocations, and serialization overhead in disk I/O hot paths to improve write/read throughput.

### WriteBatch optimization
- Move serialization outside lock to reduce lock hold time
- Change `lenBuf` from heap allocation (`make([]byte, 4)`) to stack array (`[4]byte`)
- Remove unnecessary `sort.Slice` on segment rotation (always appended in order)

### ReadMessages optimization
- Pre-allocate result slice with `max` capacity
- Declare `lenBuf` as stack array outside loop
- Reuse `dataBuf` across iterations to eliminate repeated allocations

### Serialization optimization (SerializeDiskMessage)
- Replace `bytes.Buffer` + `binary.Write` with direct `append` + `binary.BigEndian.PutUintXX`
- Add `sync.Pool` for serialization buffer reuse
- Add `EstimateDiskMessageSize` for accurate pre-allocation

### Benchmarks
- Add benchmarks for WriteBatch (100/500), SerializeDiskMessage, ReadMessages
- Add `bench-disk` Makefile target

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.