### PR TITLE
feat: add durable consumer group offset resume

### DIFF
--- a/pkg/cluster/replication/fsm/fsm_test.go
+++ b/pkg/cluster/replication/fsm/fsm_test.go
@@ -30,8 +30,14 @@ func (m *MockStorageHandler) AppendMessage(topic string, partition int, msg *typ
 	msg.Offset = m.offset
 	return m.offset, nil
 }
+func (m *MockStorageHandler) AppendMessageSync(topic string, partition int, msg *types.Message) (uint64, error) {
+	return m.AppendMessage(topic, partition, msg)
+}
 func (m *MockStorageHandler) AppendMessageWithOffset(topic string, partition int, msg *types.Message) error {
 	return nil
+}
+func (m *MockStorageHandler) ReadMessages(offset uint64, max int) ([]types.Message, error) {
+	return nil, nil
 }
 func (m *MockStorageHandler) GetAbsoluteOffset() uint64 { return m.offset }
 func (m *MockStorageHandler) GetFlushedOffset() uint64  { return m.offset }
@@ -41,6 +47,7 @@ func (m *MockStorageHandler) ReserveOffsets(n int) uint64 {
 	m.offset += uint64(n)
 	return start
 }
+func (m *MockStorageHandler) Flush()       {}
 func (m *MockStorageHandler) Close() error { return nil }
 
 type MockHandlerProvider struct{}

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -103,9 +103,7 @@ func (ch *CommandHandler) readFromTopic(topicName string, cArgs CommonArgs, ctx 
 
 	cacheKey := fmt.Sprintf("%s-%d", topicName, cArgs.PartitionID)
 	var currentOffset uint64
-	if cArgs.HasOffset {
-		currentOffset = cArgs.Offset
-	} else if cached, ok := ctx.OffsetCache[cacheKey]; ok {
+	if cached, ok := ctx.OffsetCache[cacheKey]; ok {
 		currentOffset = cached
 	} else {
 		actualOffset, err := ch.resolveOffset(p, topicName, cArgs)

--- a/pkg/controller/handler_consume_test.go
+++ b/pkg/controller/handler_consume_test.go
@@ -136,7 +136,7 @@ func TestCommandHandler_ConsumeUsesCommittedOffsetBeforeExplicitOffset(t *testin
 		errCh <- err
 	}()
 
-	_ = client.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
 	data, err := util.ReadWithLength(client)
 	require.NoError(t, err)
 	batch, err := util.DecodeBatchMessages(data)

--- a/pkg/controller/handler_consume_test.go
+++ b/pkg/controller/handler_consume_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/cursus-io/cursus/pkg/controller"
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommandHandler_ConsumeFull(t *testing.T) {
@@ -103,4 +106,111 @@ func TestCommandHandler_StreamSyntax(t *testing.T) {
 
 	resp = ch.HandleCommand("STREAM topic=t1", nil)
 	assert.Contains(t, resp, "ERROR: invalid STREAM syntax")
+}
+
+func TestCommandHandler_ConsumeUsesCommittedOffsetBeforeExplicitOffset(t *testing.T) {
+	cfg := config.DefaultConfig()
+	storage := &sequenceStorage{messages: []types.Message{
+		{Offset: 0, Payload: "m0"},
+		{Offset: 1, Payload: "m1"},
+		{Offset: 2, Payload: "m2"},
+		{Offset: 3, Payload: "m3"},
+	}}
+	tm := topic.NewTopicManager(cfg, &singleStorageProvider{storage: storage}, nil)
+	require.NoError(t, tm.CreateTopic("topic1", 1, false, false))
+
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &DummyPublisher{})
+	require.NoError(t, coord.RegisterGroup("topic1", "g1", 1))
+	require.NoError(t, coord.CommitOffset("g1", "topic1", 0, 2))
+
+	ch := controller.NewCommandHandler(tm, cfg, coord, nil, nil)
+	ctx := controller.NewClientContext("g1", 0)
+
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	defer func() { _ = client.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := ch.HandleConsumeCommand(server, "CONSUME topic=topic1 partition=0 offset=0 group=g1 member=m1 batch=10", ctx)
+		errCh <- err
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	data, err := util.ReadWithLength(client)
+	require.NoError(t, err)
+	batch, err := util.DecodeBatchMessages(data)
+	require.NoError(t, err)
+	require.Len(t, batch.Messages, 2)
+	assert.Equal(t, uint64(2), batch.Messages[0].Offset)
+	assert.Equal(t, uint64(3), batch.Messages[1].Offset)
+
+	_ = client.Close()
+	err = <-errCh
+	if err != nil && !strings.Contains(err.Error(), "closed pipe") && !strings.Contains(err.Error(), "EOF") {
+		t.Fatalf("HandleConsumeCommand failed: %v", err)
+	}
+}
+
+type sequenceStorage struct {
+	messages []types.Message
+}
+
+func (s *sequenceStorage) ReadMessages(offset uint64, max int) ([]types.Message, error) {
+	var out []types.Message
+	for _, msg := range s.messages {
+		if msg.Offset >= offset {
+			out = append(out, msg)
+			if len(out) == max {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *sequenceStorage) GetAbsoluteOffset() uint64 {
+	return uint64(len(s.messages))
+}
+
+func (s *sequenceStorage) GetFlushedOffset() uint64 {
+	return uint64(len(s.messages))
+}
+
+func (s *sequenceStorage) GetLatestOffset() uint64 {
+	return uint64(len(s.messages))
+}
+
+func (s *sequenceStorage) GetSegmentPath(uint64) string {
+	return ""
+}
+
+func (s *sequenceStorage) AppendMessage(string, int, *types.Message) (uint64, error) {
+	return 0, nil
+}
+
+func (s *sequenceStorage) AppendMessageSync(string, int, *types.Message) (uint64, error) {
+	return 0, nil
+}
+
+func (s *sequenceStorage) AppendMessageWithOffset(string, int, *types.Message) error {
+	return nil
+}
+
+func (s *sequenceStorage) WriteBatch([]types.DiskMessage) error {
+	return nil
+}
+
+func (s *sequenceStorage) Flush() {}
+
+func (s *sequenceStorage) Close() error {
+	return nil
+}
+
+type singleStorageProvider struct {
+	storage types.StorageHandler
+}
+
+func (p *singleStorageProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	return p.storage, nil
 }

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -32,6 +32,14 @@ type TopicHandler interface {
 	CreateTopic(topic string, partitionCount int, idempotent bool, eventSourcing bool) error
 }
 
+type OffsetLogReader interface {
+	ReadTopicPartition(topic string, partitionID int, offset uint64, max int) ([]types.Message, error)
+}
+
+type syncPublisher interface {
+	PublishWithAck(topic string, msg *types.Message) error
+}
+
 // GroupMetadata holds metadata for a single consumer group.
 type GroupMetadata struct {
 	mu            sync.RWMutex               // Per-group lock for offset operations
@@ -117,6 +125,11 @@ func NewCoordinator(ctx context.Context, cfg *config.Config, handler TopicHandle
 
 	if err := handler.CreateTopic(c.offsetTopic, c.offsetTopicPartitionCount, false, false); err != nil {
 		util.Error("Coordinator: failed to create offset topic '%s': %v", c.offsetTopic, err)
+	}
+	if reader, ok := handler.(OffsetLogReader); ok {
+		if err := c.LoadOffsetsFromLog(reader); err != nil {
+			util.Error("Coordinator: failed to load committed offsets from '%s': %v", c.offsetTopic, err)
+		}
 	}
 	return c
 }
@@ -282,7 +295,7 @@ func (gm *GroupMetadata) getOffsetSafe(topic string, partition int) (uint64, boo
 }
 
 // storeOffset writes an offset into the group's per-group offset map.
-// GUARDED_BY(gm.mu) — caller must hold gm.mu.Lock (exclusive).
+// GUARDED_BY(gm.mu) - caller must hold gm.mu.Lock (exclusive).
 func (gm *GroupMetadata) storeOffset(topic string, partition int, offset uint64) {
 	if gm.Offsets == nil {
 		gm.Offsets = make(map[string]map[int]uint64)
@@ -291,6 +304,17 @@ func (gm *GroupMetadata) storeOffset(topic string, partition int, offset uint64)
 		gm.Offsets[topic] = make(map[int]uint64)
 	}
 	gm.Offsets[topic][partition] = offset
+}
+
+// storeOffsetMonotonic writes an offset only if it does not move the committed
+// position backwards. Equal offsets are idempotent and accepted.
+// GUARDED_BY(gm.mu) — caller must hold gm.mu.Lock (exclusive).
+func (gm *GroupMetadata) storeOffsetMonotonic(groupName, topic string, partition int, offset uint64) error {
+	if current, ok := gm.getOffsetSafe(topic, partition); ok && offset < current {
+		return fmt.Errorf("offset regression for group=%s topic=%s partition=%d: current=%d attempted=%d", groupName, topic, partition, current, offset)
+	}
+	gm.storeOffset(topic, partition, offset)
+	return nil
 }
 
 // ExportState returns a serializable snapshot of all consumer groups.

--- a/pkg/coordinator/coordinator_durable_external_test.go
+++ b/pkg/coordinator/coordinator_durable_external_test.go
@@ -1,0 +1,55 @@
+package coordinator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoordinator_DurableOffsetReplayFromDisk(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.IndexSize = 1024
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dm := disk.NewDiskManager(cfg)
+	tm := topic.NewTopicManager(cfg, dm, nil)
+	cd := coordinator.NewCoordinator(ctx, cfg, tm)
+
+	require.NoError(t, cd.RegisterGroup("topic1", "groupA", 2))
+	require.NoError(t, cd.RegisterGroup("topic1", "groupB", 2))
+	require.NoError(t, cd.CommitOffset("groupA", "topic1", 0, 7))
+	require.NoError(t, cd.CommitOffset("groupA", "topic1", 1, 11))
+	require.NoError(t, cd.CommitOffset("groupB", "topic1", 0, 3))
+	require.ErrorContains(t, cd.CommitOffset("groupA", "topic1", 0, 6), "offset regression")
+	dm.CloseAllHandlers()
+
+	restartedDM := disk.NewDiskManager(cfg)
+	restartedTM := topic.NewTopicManager(cfg, restartedDM, nil)
+	restarted := coordinator.NewCoordinator(ctx, cfg, restartedTM)
+	defer restartedDM.CloseAllHandlers()
+
+	offset, ok := restarted.GetOffset("groupA", "topic1", 0)
+	require.True(t, ok)
+	require.Equal(t, uint64(7), offset)
+
+	offset, ok = restarted.GetOffset("groupA", "topic1", 1)
+	require.True(t, ok)
+	require.Equal(t, uint64(11), offset)
+
+	offset, ok = restarted.GetOffset("groupB", "topic1", 0)
+	require.True(t, ok)
+	require.Equal(t, uint64(3), offset)
+
+	require.ErrorContains(t, restarted.CommitOffset("groupA", "topic1", 0, 6), "offset regression")
+	offset, ok = restarted.GetOffset("groupA", "topic1", 0)
+	require.True(t, ok)
+	require.Equal(t, uint64(7), offset)
+}

--- a/pkg/coordinator/coordinator_ext_test.go
+++ b/pkg/coordinator/coordinator_ext_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCoordinator_StatusAndList(t *testing.T) {
@@ -85,6 +87,94 @@ func TestCoordinator_Offsets(t *testing.T) {
 		off, _ := c.GetOffset("group1", "topic1", 0)
 		assert.Equal(t, uint64(500), off)
 	})
+
+	t.Run("RejectLowerOffset", func(t *testing.T) {
+		err := c.CommitOffset("group1", "topic1", 0, 499)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "offset regression")
+
+		off, _ := c.GetOffset("group1", "topic1", 0)
+		assert.Equal(t, uint64(500), off)
+	})
+}
+
+func TestCoordinator_DurableOffsetReplayAndIsolation(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ConsumerSessionTimeoutMS = 30000
+	cfg.ConsumerHeartbeatCheckMS = 5000
+
+	offsetLog := newPersistentOffsetLog()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewCoordinator(ctx, cfg, offsetLog)
+	require.NoError(t, c.RegisterGroup("topic1", "groupA", 2))
+	require.NoError(t, c.RegisterGroup("topic1", "groupB", 2))
+
+	require.NoError(t, c.CommitOffset("groupA", "topic1", 0, 3))
+	require.NoError(t, c.CommitOffset("groupA", "topic1", 1, 8))
+	require.NoError(t, c.CommitOffset("groupB", "topic1", 0, 1))
+	assert.ErrorContains(t, c.CommitOffset("groupA", "topic1", 0, 2), "offset regression")
+
+	restarted := NewCoordinator(ctx, cfg, offsetLog)
+
+	offset, ok := restarted.GetOffset("groupA", "topic1", 0)
+	require.True(t, ok)
+	assert.Equal(t, uint64(3), offset)
+
+	offset, ok = restarted.GetOffset("groupA", "topic1", 1)
+	require.True(t, ok)
+	assert.Equal(t, uint64(8), offset)
+
+	offset, ok = restarted.GetOffset("groupB", "topic1", 0)
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), offset)
+
+	assert.ErrorContains(t, restarted.CommitOffset("groupA", "topic1", 0, 2), "offset regression")
+	offset, _ = restarted.GetOffset("groupA", "topic1", 0)
+	assert.Equal(t, uint64(3), offset)
+
+	require.NoError(t, restarted.RegisterGroup("topic1", "groupA", 2))
+	_, err := restarted.AddConsumer("groupA", "member-1")
+	require.NoError(t, err)
+}
+
+type persistentOffsetLog struct {
+	partitions map[int][]types.Message
+}
+
+func newPersistentOffsetLog() *persistentOffsetLog {
+	return &persistentOffsetLog{partitions: make(map[int][]types.Message)}
+}
+
+func (p *persistentOffsetLog) CreateTopic(string, int, bool, bool) error {
+	return nil
+}
+
+func (p *persistentOffsetLog) Publish(topic string, msg *types.Message) error {
+	return p.PublishWithAck(topic, msg)
+}
+
+func (p *persistentOffsetLog) PublishWithAck(_ string, msg *types.Message) error {
+	cp := *msg
+	cp.Offset = uint64(len(p.partitions[0]))
+	p.partitions[0] = append(p.partitions[0], cp)
+	return nil
+}
+
+func (p *persistentOffsetLog) ReadTopicPartition(_ string, partitionID int, offset uint64, max int) ([]types.Message, error) {
+	records := p.partitions[partitionID]
+	if int(offset) >= len(records) {
+		return nil, nil
+	}
+	end := int(offset) + max
+	if end > len(records) {
+		end = len(records)
+	}
+	start := int(offset)
+	out := make([]types.Message, end-start)
+	copy(out, records[start:end])
+	return out, nil
 }
 
 func TestCoordinator_MemberAssignments(t *testing.T) {

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -168,6 +168,7 @@ func (c *Coordinator) LoadOffsetsFromLog(reader OffsetLogReader) error {
 		for {
 			messages, err := reader.ReadTopicPartition(c.offsetTopic, partition, next, batchSize)
 			if err != nil {
+				util.Warn("Coordinator: error reading offset log partition=%d offset=%d: %v", partition, next, err)
 				break
 			}
 			if len(messages) == 0 {

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -22,6 +22,13 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 		return fmt.Errorf("group '%s' not found", groupName)
 	}
 
+	gm.mu.RLock()
+	if current, ok := gm.getOffsetSafe(topic, partition); ok && offset < current {
+		gm.mu.RUnlock()
+		return fmt.Errorf("offset regression for group=%s topic=%s partition=%d: current=%d attempted=%d", groupName, topic, partition, current, offset)
+	}
+	gm.mu.RUnlock()
+
 	offsetMsg := OffsetCommitMessage{
 		Group:     groupName,
 		Topic:     topic,
@@ -35,7 +42,7 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 		return fmt.Errorf("failed to marshal offset commit: %w", err)
 	}
 
-	if err := c.topicHandler.Publish(c.offsetTopic, &types.Message{
+	if err := c.publishOffsetMessage(&types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
 		Key:        groupName + "-" + topic + "-" + strconv.Itoa(partition),
@@ -44,10 +51,10 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 	}
 
 	gm.mu.Lock()
-	gm.storeOffset(topic, partition, offset)
+	err = gm.storeOffsetMonotonic(groupName, topic, partition, offset)
 	gm.mu.Unlock()
 
-	return nil
+	return err
 }
 
 func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []OffsetItem) error {
@@ -59,6 +66,15 @@ func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []Offse
 	if gm == nil {
 		return fmt.Errorf("group '%s' not found", groupName)
 	}
+
+	gm.mu.RLock()
+	for _, item := range offsets {
+		if current, ok := gm.getOffsetSafe(topic, item.Partition); ok && item.Offset < current {
+			gm.mu.RUnlock()
+			return fmt.Errorf("offset regression for group=%s topic=%s partition=%d: current=%d attempted=%d", groupName, topic, item.Partition, current, item.Offset)
+		}
+	}
+	gm.mu.RUnlock()
 
 	bulkMsg := BulkOffsetMsg{
 		Group:     groupName,
@@ -72,7 +88,7 @@ func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []Offse
 		return fmt.Errorf("failed to marshal: %w", err)
 	}
 
-	if err := c.topicHandler.Publish(c.offsetTopic, &types.Message{
+	if err := c.publishOffsetMessage(&types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
 		Key:        fmt.Sprintf("%s-%s-bulk", groupName, topic),
@@ -81,12 +97,15 @@ func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []Offse
 	}
 
 	gm.mu.Lock()
+	var firstErr error
 	for _, item := range offsets {
-		gm.storeOffset(topic, item.Partition, item.Offset)
+		if err := gm.storeOffsetMonotonic(groupName, topic, item.Partition, item.Offset); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 	gm.mu.Unlock()
 
-	return nil
+	return firstErr
 }
 
 func (c *Coordinator) ApplyOffsetUpdateFromFSM(groupName, topic string, offsets []OffsetItem) error {
@@ -99,9 +118,16 @@ func (c *Coordinator) ApplyOffsetUpdateFromFSM(groupName, topic string, offsets 
 	gm, ok := c.groups[groupName]
 	if !ok {
 		gm = &GroupMetadata{
-			Offsets: make(map[string]map[int]uint64),
+			TopicName: topic,
+			Members:   make(map[string]*MemberMetadata),
+			Offsets:   make(map[string]map[int]uint64),
 		}
 		c.groups[groupName] = gm
+	} else if gm.TopicName == "" {
+		gm.TopicName = topic
+		if gm.Members == nil {
+			gm.Members = make(map[string]*MemberMetadata)
+		}
 	}
 	c.mu.Unlock()
 
@@ -109,15 +135,82 @@ func (c *Coordinator) ApplyOffsetUpdateFromFSM(groupName, topic string, offsets 
 	if gm.Offsets == nil {
 		gm.Offsets = make(map[string]map[int]uint64)
 	}
-	if _, exists := gm.Offsets[topic]; !exists {
-		gm.Offsets[topic] = make(map[int]uint64)
-	}
+	var firstErr error
 	for _, item := range offsets {
-		gm.Offsets[topic][item.Partition] = item.Offset
+		if err := gm.storeOffsetMonotonic(groupName, topic, item.Partition, item.Offset); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 	gm.mu.Unlock()
 
+	return firstErr
+}
+
+func (c *Coordinator) publishOffsetMessage(msg *types.Message) error {
+	if sp, ok := c.topicHandler.(syncPublisher); ok {
+		return sp.PublishWithAck(c.offsetTopic, msg)
+	}
+	if err := c.topicHandler.Publish(c.offsetTopic, msg); err != nil {
+		return err
+	}
+	if flusher, ok := c.topicHandler.(interface{ Flush() }); ok {
+		flusher.Flush()
+	}
 	return nil
+}
+
+func (c *Coordinator) LoadOffsetsFromLog(reader OffsetLogReader) error {
+	const batchSize = 1024
+
+	applied := 0
+	for partition := 0; partition < c.offsetTopicPartitionCount; partition++ {
+		next := uint64(0)
+		for {
+			messages, err := reader.ReadTopicPartition(c.offsetTopic, partition, next, batchSize)
+			if err != nil {
+				break
+			}
+			if len(messages) == 0 {
+				break
+			}
+
+			for _, msg := range messages {
+				if err := c.applyOffsetLogPayload(msg.Payload); err != nil {
+					util.Warn("Coordinator: skipping invalid offset log record at partition=%d offset=%d: %v", partition, msg.Offset, err)
+					continue
+				}
+				applied++
+				next = msg.Offset + 1
+			}
+			if len(messages) < batchSize {
+				break
+			}
+		}
+	}
+
+	if applied > 0 {
+		util.Info("Coordinator: loaded %d committed offset records from '%s'", applied, c.offsetTopic)
+	}
+	return nil
+}
+
+func (c *Coordinator) applyOffsetLogPayload(payload string) error {
+	var bulk BulkOffsetMsg
+	if err := json.Unmarshal([]byte(payload), &bulk); err == nil && bulk.Group != "" && bulk.Topic != "" && len(bulk.Offsets) > 0 {
+		return c.ApplyOffsetUpdateFromFSM(bulk.Group, bulk.Topic, bulk.Offsets)
+	}
+
+	var single OffsetCommitMessage
+	if err := json.Unmarshal([]byte(payload), &single); err != nil {
+		return err
+	}
+	if single.Group == "" || single.Topic == "" {
+		return fmt.Errorf("missing group or topic")
+	}
+	return c.ApplyOffsetUpdateFromFSM(single.Group, single.Topic, []OffsetItem{{
+		Partition: single.Partition,
+		Offset:    single.Offset,
+	}})
 }
 
 func (c *Coordinator) GetOffset(groupName, topic string, partition int) (uint64, bool) {
@@ -179,7 +272,10 @@ func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, 
 	// Store offset under per-group lock
 	group.mu.Lock()
 	prevOffset, hadPrev := group.getOffsetSafe(topic, partition)
-	group.storeOffset(topic, partition, offset)
+	if err := group.storeOffsetMonotonic(groupName, topic, partition, offset); err != nil {
+		group.mu.Unlock()
+		return err
+	}
 	group.mu.Unlock()
 
 	offsetMsg := OffsetCommitMessage{
@@ -196,7 +292,7 @@ func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, 
 		return fmt.Errorf("failed to marshal offset: %w", err)
 	}
 
-	err = c.topicHandler.Publish(c.offsetTopic, &types.Message{
+	err = c.publishOffsetMessage(&types.Message{
 		ProducerID: "broker",
 		Payload:    string(payload),
 		Key:        groupName + "-" + topic + "-" + strconv.Itoa(partition),

--- a/pkg/coordinator/rebalancer.go
+++ b/pkg/coordinator/rebalancer.go
@@ -18,6 +18,19 @@ func (c *Coordinator) RegisterGroup(topicName, groupName string, partitionCount 
 
 	if existing, exists := c.groups[groupName]; exists {
 		currPartitions := len(existing.Partitions)
+		if currPartitions == 0 {
+			partitions := make([]int, partitionCount)
+			for i := 0; i < partitionCount; i++ {
+				partitions[i] = i
+			}
+			existing.TopicName = topicName
+			existing.Partitions = partitions
+			if existing.Members == nil {
+				existing.Members = make(map[string]*MemberMetadata)
+			}
+			c.mu.Unlock()
+			return nil
+		}
 		c.mu.Unlock()
 		if currPartitions != partitionCount {
 			return fmt.Errorf("partition count mismatch (existing: %d, requested: %d)", currPartitions, partitionCount)

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -105,6 +105,18 @@ func (tm *TopicManager) GetLastOffset(topicName string, partitionID int) uint64 
 	return p.dh.GetAbsoluteOffset()
 }
 
+func (tm *TopicManager) ReadTopicPartition(topicName string, partitionID int, offset uint64, max int) ([]types.Message, error) {
+	t := tm.GetTopic(topicName)
+	if t == nil {
+		return nil, fmt.Errorf("topic '%s' does not exist", topicName)
+	}
+	p, err := t.GetPartition(partitionID)
+	if err != nil {
+		return nil, err
+	}
+	return p.dh.ReadMessages(offset, max)
+}
+
 // Async (acks=0)
 func (tm *TopicManager) Publish(topicName string, msg *types.Message) error {
 	t := tm.GetTopic(topicName)


### PR DESCRIPTION
## Summary

Adds broker-managed durable consumer group offset commit/resume.

Consumer offsets are now stored by `(topic, group, partition)` as `nextOffset`, persisted through the internal `__consumer_offsets` log, and replayed when the broker starts.

## Changes

- Persist `COMMIT_OFFSET` / `BATCH_COMMIT` updates through the broker offset log.
- Replay committed offsets on broker startup.
- Reject offset regression commits so committed offsets cannot move backward.
- Make `CONSUME` resume from the committed offset when one exists.
- Document the offset lifecycle, commit timing, and delivery guarantees.

## Tests

- `go test ./pkg/...`
- `go test ./cmd/... ./examples/... ./sdk ./util`
- `git diff --check`

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [ ] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.
