### PR TITLE
fix: enforce strict sdk response parsing

### DIFF
--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -125,8 +125,7 @@ func (c *Consumer) Start(handler func(Message) error) error {
 	for _, pid := range assignments {
 		offset, err := c.fetchOffset(pid)
 		if err != nil {
-			LogWarn("Failed to fetch offset for P%d: %v, starting from 0", pid, err)
-			offset = 0
+			return fmt.Errorf("fetch offset for P%d failed: %w", pid, err)
 		}
 		offsetMap[pid] = offset
 	}
@@ -686,16 +685,28 @@ func (c *Consumer) fetchOffset(partition int) (uint64, error) {
 		return 0, fmt.Errorf("fetch offset response: %w", err)
 	}
 
-	respStr := string(resp)
-	if strings.HasPrefix(respStr, "ERROR") {
+	respStr := strings.TrimSpace(string(resp))
+	return parseFetchOffsetResponse(respStr)
+}
+
+func parseFetchOffsetResponse(respStr string) (uint64, error) {
+	if strings.HasPrefix(respStr, "ERROR:") {
 		return 0, fmt.Errorf("fetch offset broker error: %s", respStr)
 	}
 
-	offset, err := strconv.ParseUint(strings.TrimSpace(respStr), 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid offset response: %s", respStr)
+	if !strings.HasPrefix(respStr, "OK") {
+		return 0, fmt.Errorf("unexpected offset response: %s", respStr)
 	}
-	return offset, nil
+	for _, part := range strings.Fields(respStr) {
+		if strings.HasPrefix(part, "offset=") {
+			offset, err := strconv.ParseUint(strings.TrimPrefix(part, "offset="), 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid offset response: %s", respStr)
+			}
+			return offset, nil
+		}
+	}
+	return 0, fmt.Errorf("missing offset in response: %s", respStr)
 }
 
 // ─── Close ────────────────────────────────────────────────────────────────────

--- a/sdk/consumer_group.go
+++ b/sdk/consumer_group.go
@@ -266,8 +266,8 @@ drainDone:
 	for _, pid := range assignments {
 		offset, err := c.fetchOffset(pid)
 		if err != nil {
-			LogWarn("Rebalance: offset fetch failed for P%d: %v, starting from 0", pid, err)
-			offset = 0
+			LogError("Rebalance: offset fetch failed for P%d: %v", pid, err)
+			return
 		}
 		c.partitionConsumers[pid] = &PartitionConsumer{
 			partitionID:  pid,

--- a/sdk/consumer_test.go
+++ b/sdk/consumer_test.go
@@ -276,3 +276,17 @@ func TestConsumer_GetOrDialHeartbeatConn_NilConnGetLeaderFails(t *testing.T) {
 	conn := c.getOrDialHeartbeatConn()
 	assert.Nil(t, conn)
 }
+
+func TestParseFetchOffsetResponse_StrictContract(t *testing.T) {
+	offset, err := parseFetchOffsetResponse("OK offset=42")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), offset)
+
+	_, err = parseFetchOffsetResponse("42")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected offset response")
+
+	_, err = parseFetchOffsetResponse("OK")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing offset")
+}

--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -19,9 +19,7 @@ type Event struct {
 }
 
 // StreamEvent is an event read from a stream, with version and offset.
-// NOTE: Type, SchemaVersion, and Metadata are not yet populated by ReadStream
-// because the current batch wire format (EncodeBatchMessages) does not carry
-// event sourcing fields. These will be filled once the batch protocol is extended.
+// StreamEvent metadata is populated from the broker batch wire format.
 type StreamEvent struct {
 	Version       uint64
 	Offset        uint64
@@ -133,8 +131,12 @@ func (es *EventStore) CreateTopic(partitions int) error {
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(resp, "ERROR") {
-		return fmt.Errorf("broker: %s", resp)
+	respStr := strings.TrimSpace(resp)
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return fmt.Errorf("broker: %s", respStr)
+	}
+	if !strings.HasPrefix(respStr, "OK") {
+		return fmt.Errorf("unexpected create response: %s", respStr)
 	}
 	return nil
 }
@@ -147,8 +149,9 @@ func (es *EventStore) Append(key string, expectedVersion uint64, event *Event) (
 		sv = 1
 	}
 
+	nextVersion := expectedVersion + 1
 	cmd := fmt.Sprintf("APPEND_STREAM topic=%s key=%s version=%d event_type=%s schema_version=%d producerId=%s",
-		es.topic, key, expectedVersion, event.Type, sv, es.producerID)
+		es.topic, key, nextVersion, event.Type, sv, es.producerID)
 	if event.Metadata != "" {
 		cmd += fmt.Sprintf(" metadata=%s", event.Metadata)
 	}
@@ -163,28 +166,60 @@ func (es *EventStore) Append(key string, expectedVersion uint64, event *Event) (
 		return nil, fmt.Errorf("broker: %s", resp)
 	}
 
-	return parseAppendResponse(resp), nil
+	result, err := parseAppendResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // parseAppendResponse parses "OK version=N offset=N partition=N" into AppendResult.
-func parseAppendResponse(resp string) *AppendResult {
+func parseAppendResponse(resp string) (*AppendResult, error) {
+	respStr := strings.TrimSpace(resp)
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return nil, fmt.Errorf("broker: %s", respStr)
+	}
+	if !strings.HasPrefix(respStr, "OK") {
+		return nil, fmt.Errorf("unexpected append response: %s", respStr)
+	}
+
 	result := &AppendResult{}
-	parts := strings.Fields(resp)
-	for _, p := range parts {
+	hasVersion := false
+	hasOffset := false
+	hasPartition := false
+	for _, p := range strings.Fields(respStr) {
 		kv := strings.SplitN(p, "=", 2)
 		if len(kv) != 2 {
 			continue
 		}
 		switch kv[0] {
 		case "version":
-			result.Version, _ = strconv.ParseUint(kv[1], 10, 64)
+			v, err := strconv.ParseUint(kv[1], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid append version in response: %s", respStr)
+			}
+			result.Version = v
+			hasVersion = true
 		case "offset":
-			result.Offset, _ = strconv.ParseUint(kv[1], 10, 64)
+			o, err := strconv.ParseUint(kv[1], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid append offset in response: %s", respStr)
+			}
+			result.Offset = o
+			hasOffset = true
 		case "partition":
-			result.Partition, _ = strconv.Atoi(kv[1])
+			partition, err := strconv.Atoi(kv[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid append partition in response: %s", respStr)
+			}
+			result.Partition = partition
+			hasPartition = true
 		}
 	}
-	return result
+	if !hasVersion || !hasOffset || !hasPartition {
+		return nil, fmt.Errorf("missing append fields in response: %s", respStr)
+	}
+	return result, nil
 }
 
 // ReadStream reads all events for an aggregate, automatically using snapshots.
@@ -219,11 +254,22 @@ func (es *EventStore) ReadStreamFrom(key string, fromVersion uint64) (*StreamDat
 	}
 
 	var envelope struct {
+		Status   string    `json:"status"`
+		Error    string    `json:"error"`
 		Snapshot *Snapshot `json:"snapshot"`
 		Count    int       `json:"count"`
 	}
 	if err := json.Unmarshal(envData, &envelope); err != nil {
 		return nil, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if envelope.Status == "ERROR" {
+		if envelope.Error == "" {
+			envelope.Error = "read stream failed"
+		}
+		return nil, fmt.Errorf("broker: %s", envelope.Error)
+	}
+	if envelope.Status != "OK" {
+		return nil, fmt.Errorf("unexpected read stream status: %s", envelope.Status)
 	}
 
 	// Frame 2: Binary batch
@@ -266,8 +312,12 @@ func (es *EventStore) SaveSnapshot(key string, version uint64, payload string) e
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(resp, "ERROR") {
-		return fmt.Errorf("broker: %s", resp)
+	respStr := strings.TrimSpace(resp)
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return fmt.Errorf("broker: %s", respStr)
+	}
+	if !strings.HasPrefix(respStr, "OK") {
+		return fmt.Errorf("unexpected save snapshot response: %s", respStr)
 	}
 	return nil
 }
@@ -278,15 +328,17 @@ func (es *EventStore) ReadSnapshot(key string) (*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resp == "NULL" || strings.Contains(resp, "NOT_FOUND") {
-		return nil, nil
+	respStr := strings.TrimSpace(resp)
+	snapshotJSON, ok, err := parseSnapshotResponse(respStr)
+	if err != nil {
+		return nil, err
 	}
-	if strings.HasPrefix(resp, "ERROR") {
-		return nil, fmt.Errorf("broker: %s", resp)
+	if !ok {
+		return nil, nil
 	}
 
 	var snap Snapshot
-	if err := json.Unmarshal([]byte(resp), &snap); err != nil {
+	if err := json.Unmarshal([]byte(snapshotJSON), &snap); err != nil {
 		return nil, fmt.Errorf("unmarshal snapshot: %w", err)
 	}
 	return &snap, nil
@@ -298,11 +350,40 @@ func (es *EventStore) StreamVersion(key string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	v, err := strconv.ParseUint(strings.TrimSpace(resp), 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse version: %w", err)
+	respStr := strings.TrimSpace(resp)
+	return parseStreamVersionResponse(respStr)
+}
+
+func parseSnapshotResponse(respStr string) (string, bool, error) {
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return "", false, fmt.Errorf("broker: %s", respStr)
 	}
-	return v, nil
+	if respStr == "OK snapshot=null" {
+		return "", false, nil
+	}
+	if strings.HasPrefix(respStr, "OK snapshot=") {
+		return strings.TrimPrefix(respStr, "OK snapshot="), true, nil
+	}
+	return "", false, fmt.Errorf("unexpected snapshot response: %s", respStr)
+}
+
+func parseStreamVersionResponse(respStr string) (uint64, error) {
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return 0, fmt.Errorf("broker: %s", respStr)
+	}
+	if !strings.HasPrefix(respStr, "OK") {
+		return 0, fmt.Errorf("unexpected version response: %s", respStr)
+	}
+	for _, part := range strings.Fields(respStr) {
+		if strings.HasPrefix(part, "version=") {
+			v, err := strconv.ParseUint(strings.TrimPrefix(part, "version="), 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("parse version: %w", err)
+			}
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("missing version in response: %s", respStr)
 }
 
 // Close closes the underlying connection.

--- a/sdk/eventstore_test.go
+++ b/sdk/eventstore_test.go
@@ -7,31 +7,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseAppendResponse(t *testing.T) {
 	resp := "OK version=3 offset=1024 partition=2"
 
-	result := parseAppendResponse(resp)
+	result, err := parseAppendResponse(resp)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint64(3), result.Version)
 	assert.Equal(t, uint64(1024), result.Offset)
 	assert.Equal(t, 2, result.Partition)
 }
 
-func TestParseAppendResponse_Partial(t *testing.T) {
-	resp := "OK version=1"
-
-	result := parseAppendResponse(resp)
-
-	assert.Equal(t, uint64(1), result.Version)
-	assert.Equal(t, uint64(0), result.Offset)
-	assert.Equal(t, 0, result.Partition)
+func TestParseAppendResponse_MissingFields(t *testing.T) {
+	_, err := parseAppendResponse("OK version=1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing append fields")
 }
 
-func TestParseAppendResponse_Empty(t *testing.T) {
-	result := parseAppendResponse("")
-	assert.Equal(t, uint64(0), result.Version)
+func TestParseAppendResponse_UnexpectedResponse(t *testing.T) {
+	_, err := parseAppendResponse("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected append response")
 }
 
 func TestEventStore_NewAndClose(t *testing.T) {
@@ -96,16 +95,17 @@ func TestEventStore_ResetConn_Nil(t *testing.T) {
 
 func TestParseAppendResponse_UnknownFields(t *testing.T) {
 	resp := "OK version=7 unknown=foo offset=42 partition=1 extra=bar"
-	result := parseAppendResponse(resp)
+	result, err := parseAppendResponse(resp)
+	require.NoError(t, err)
 	assert.Equal(t, uint64(7), result.Version)
 	assert.Equal(t, uint64(42), result.Offset)
 	assert.Equal(t, 1, result.Partition)
 }
 
 func TestParseAppendResponse_NoEquals(t *testing.T) {
-	resp := "OK done"
-	result := parseAppendResponse(resp)
-	assert.Equal(t, uint64(0), result.Version)
+	_, err := parseAppendResponse("OK done")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing append fields")
 }
 
 func TestAppendCommandFormat(t *testing.T) {
@@ -121,9 +121,11 @@ func TestAppendCommandFormat(t *testing.T) {
 	if sv == 0 {
 		sv = 1
 	}
+	expectedVersion := uint64(0)
+	nextVersion := expectedVersion + 1
 	cmd := "APPEND_STREAM topic=" + es.topic +
 		" key=order-1" +
-		" version=" + strconv.FormatUint(0, 10) +
+		" version=" + strconv.FormatUint(nextVersion, 10) +
 		" event_type=" + event.Type +
 		" schema_version=" + strconv.FormatUint(uint64(sv), 10) +
 		" producerId=" + es.producerID +
@@ -132,9 +134,42 @@ func TestAppendCommandFormat(t *testing.T) {
 	assert.True(t, strings.HasPrefix(cmd, "APPEND_STREAM"))
 	assert.Contains(t, cmd, "topic=orders")
 	assert.Contains(t, cmd, "key=order-1")
-	assert.Contains(t, cmd, "version=0")
+	assert.Contains(t, cmd, "version=1")
 	assert.Contains(t, cmd, "event_type=OrderCreated")
 	assert.Contains(t, cmd, "schema_version=1")
 	assert.Contains(t, cmd, "producerId=p-1")
 	assert.Contains(t, cmd, `message={"id":1}`)
+}
+func TestParseSnapshotResponse_StrictContract(t *testing.T) {
+	snapshotJSON, ok, err := parseSnapshotResponse(`OK snapshot={"version":1,"payload":"x"}`)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, `{"version":1,"payload":"x"}`, snapshotJSON)
+
+	snapshotJSON, ok, err = parseSnapshotResponse("OK snapshot=null")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, snapshotJSON)
+
+	_, _, err = parseSnapshotResponse("NULL")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected snapshot response")
+
+	_, _, err = parseSnapshotResponse(`{"version":1,"payload":"x"}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected snapshot response")
+}
+
+func TestParseStreamVersionResponse_StrictContract(t *testing.T) {
+	version, err := parseStreamVersionResponse("OK version=7")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7), version)
+
+	_, err = parseStreamVersionResponse("7")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected version response")
+
+	_, err = parseStreamVersionResponse("OK")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing version")
 }


### PR DESCRIPTION
Fixes N/A

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

This PR makes the Go SDK reject legacy or ambiguous server responses instead of falling back to inconsistent defaults. It aligns consumer offset fetches and event-store response parsing with the normalized response contract used by the other clients.

Changes:
- Require `OK offset=<N>` for committed offset fetches.
- Require `OK snapshot=<json|null>` and `OK version=<N>` for event-store reads.
- Require structured `APPEND_STREAM` responses with version, offset, and partition.
- Reject error or malformed `READ_STREAM` envelopes.
- Add/adjust SDK tests for strict response handling.

Validation:
- `go test ./sdk`
