### PR TITLE
fix: fail benchmark on incomplete runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ bench:
 	fi; \
 	echo "[MAKE] Benchmark logs:"; \
 	$$compose logs | tee "$$log_file" || true; \
-	if grep -Eiq "benchmark incomplete|verify failed|Failed messages[[:space:]]*: [1-9][0-9]*|Message missing[[:space:]]*: [1-9][0-9]*|Duplicate \\(MessageID\\)[[:space:]]*: [1-9][0-9]*|Duplicate \\(Offset\\)[[:space:]]*: [1-9][0-9]*|panic:|fatal" "$$log_file"; then \
+	if grep -Eiq "benchmark incomplete|verify failed|Failed messages[[:space:]]*: [1-9][0-9]*|Message missing[[:space:]]*: [1-9][0-9]*|Duplicate \\(MessageID\\)[[:space:]]*: [1-9][0-9]*|Duplicate \\(Offset\\)[[:space:]]*: [1-9][0-9]*|(^|[[:space:]])(panic:|\\[FATAL\\]|FATAL:|fatal error:|level=fatal)([[:space:]]|$$)" "$$log_file"; then \
 		echo "[MAKE] Benchmark failure marker found in logs"; \
 		status=1; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,54 @@ e2e-logs:
 .PHONY: bench
 bench:
 	@bash -c '\
-	set +e; \
+	set -euo pipefail; \
+	compose="docker compose -f test/docker-compose.yml"; \
+	status=0; \
+	log_file=$$(mktemp); \
 	echo "[MAKE] Running benchmark with docker-compose..."; \
-	timeout 180s docker compose -f test/docker-compose.yml up --build --remove-orphans; \
-	echo "[MAKE] Containers finished or timed out"; \
-	docker compose -f test/docker-compose.yml logs; \
-	docker compose -f test/docker-compose.yml down -v; \
+	$$compose down -v --remove-orphans >/dev/null 2>&1 || true; \
+	$$compose up -d --build --remove-orphans || status=$$?; \
+	if [ "$$status" -eq 0 ]; then \
+		deadline=$$((SECONDS + 180)); \
+		while true; do \
+			publisher_status=$$(docker inspect -f "{{.State.Status}}" bench-publisher 2>/dev/null || echo missing); \
+			consumer_status=$$(docker inspect -f "{{.State.Status}}" bench-consumer 2>/dev/null || echo missing); \
+			if [ "$$publisher_status" = "exited" ] && [ "$$consumer_status" = "exited" ]; then \
+				break; \
+			fi; \
+			if [ "$$SECONDS" -ge "$$deadline" ]; then \
+				echo "[MAKE] Benchmark timed out: publisher=$$publisher_status consumer=$$consumer_status"; \
+				status=124; \
+				break; \
+			fi; \
+			sleep 2; \
+		done; \
+	fi; \
+	if [ "$$status" -eq 0 ]; then \
+		publisher_code=$$(docker inspect -f "{{.State.ExitCode}}" bench-publisher 2>/dev/null || echo 127); \
+		consumer_code=$$(docker inspect -f "{{.State.ExitCode}}" bench-consumer 2>/dev/null || echo 127); \
+		if [ "$$publisher_code" != "0" ] || [ "$$consumer_code" != "0" ]; then \
+			echo "[MAKE] Benchmark container failure: publisher=$$publisher_code consumer=$$consumer_code"; \
+			status=1; \
+		fi; \
+	fi; \
+	echo "[MAKE] Benchmark logs:"; \
+	$$compose logs | tee "$$log_file" || true; \
+	if grep -Eiq "benchmark incomplete|verify failed|Failed messages[[:space:]]*: [1-9][0-9]*|Message missing[[:space:]]*: [1-9][0-9]*|Duplicate \\(MessageID\\)[[:space:]]*: [1-9][0-9]*|Duplicate \\(Offset\\)[[:space:]]*: [1-9][0-9]*|panic:|fatal" "$$log_file"; then \
+		echo "[MAKE] Benchmark failure marker found in logs"; \
+		status=1; \
+	fi; \
+	rm -f "$$log_file"; \
+	cleanup_status=0; \
+	$$compose down -v --remove-orphans || cleanup_status=$$?; \
+	if [ "$$cleanup_status" -ne 0 ]; then \
+		echo "[MAKE] Benchmark cleanup failed: status=$$cleanup_status"; \
+		if [ "$$status" -eq 0 ]; then \
+			status=$$cleanup_status; \
+		fi; \
+	fi; \
+	exit "$$status"; \
 	'
-
 .PHONY: bench-disk
 bench-disk:
 	@echo "Running disk I/O benchmarks..."

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -114,7 +114,7 @@ func (p *Partition) isDuplicate(msg *types.Message) bool {
 }
 
 func (p *Partition) updateProducerState(msg *types.Message) {
-	if msg.ProducerID == "" {
+	if !p.isIdempotent || msg.ProducerID == "" {
 		return
 	}
 	if msg.SeqNum > 0 {

--- a/pkg/topic/topic_ext_test.go
+++ b/pkg/topic/topic_ext_test.go
@@ -127,6 +127,18 @@ func TestPartition_Basic(t *testing.T) {
 		assert.Equal(t, uint64(14), p.NextOffset()) // Offset didn't increase
 	})
 
+	t.Run("ProducerStateOnlyTracksIdempotentTopics", func(t *testing.T) {
+		nonIdempotent := NewPartition(1, "bench-topic", mh, sm, cfg)
+		nonIdempotent.updateProducerState(&types.Message{ProducerID: "producer-1", SeqNum: 10})
+		_, found := nonIdempotent.producerState.Load("producer-1")
+		assert.False(t, found)
+
+		idempotent := NewPartition(2, "idem-topic", mh, sm, cfg)
+		idempotent.isIdempotent = true
+		idempotent.updateProducerState(&types.Message{ProducerID: "producer-1", SeqNum: 10})
+		_, found = idempotent.producerState.Load("producer-1")
+		assert.True(t, found)
+	})
 	t.Run("ReadCommitted", func(t *testing.T) {
 		p.SetHWM(20)
 		mh.On("GetFlushedOffset").Return(uint64(20)).Maybe()

--- a/test/e2e-benchmark/benchmark_test.go
+++ b/test/e2e-benchmark/benchmark_test.go
@@ -1,16 +1,25 @@
 package e2e_benchmark
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
 
 const benchmarkTimeout = 5 * time.Minute
+
+var severeBenchmarkLogPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(^|[\s|])(?:panic:|\[fatal\]|fatal:|fatal error:|level=fatal)(\s|$)`),
+	regexp.MustCompile(`(?i)benchmark incomplete`),
+	regexp.MustCompile(`(?i)verify failed`),
+}
 
 func getComposeCommand() []string {
 	if _, err := exec.LookPath("docker-compose"); err == nil {
@@ -53,15 +62,42 @@ func TestRunComposePlacesProjectNameAfterComposeSubcommand(t *testing.T) {
 		t.Fatalf("docker-compose project name must be first argument, got %v", args)
 	}
 }
+func TestBenchmarkFailurePatternsAvoidBroadFatalMatches(t *testing.T) {
+	benign := "bench-consumer | nonfatal retry message\nbench-broker | fatality is not a log level"
+	for _, pattern := range severeBenchmarkLogPatterns {
+		if pattern.MatchString(benign) {
+			t.Fatalf("pattern %q matched benign log", pattern.String())
+		}
+	}
+
+	severe := "bench-consumer | fatal error: benchmark worker aborted"
+	matched := false
+	for _, pattern := range severeBenchmarkLogPatterns {
+		matched = matched || pattern.MatchString(severe)
+	}
+	if !matched {
+		t.Fatal("expected severe fatal log to match")
+	}
+}
+
+func TestBenchmarkCounterParsesMultiDigitFailures(t *testing.T) {
+	logs := "bench-consumer | Message missing       : 12\nbench-consumer | Duplicate (Offset)    : 0"
+	missing, ok := benchmarkCounter(logs, "Message missing")
+	if !ok || missing != 12 {
+		t.Fatalf("expected missing=12, got %d ok=%t", missing, ok)
+	}
+
+	dupOffset, ok := benchmarkCounter(logs, "Duplicate (Offset)")
+	if !ok || dupOffset != 0 {
+		t.Fatalf("expected duplicate offset=0, got %d ok=%t", dupOffset, ok)
+	}
+}
 
 func composeDown(t *testing.T, file string) {
-	// Force remove containers first to handle conflicts from compose files that
-	// declare fixed container_name values outside project-name isolation.
+	// Fixed container_name values bypass compose project-name isolation. Remove
+	// only containers that Docker labels as belonging to these benchmark compose files.
 	for _, name := range fixedBenchmarkContainers(file) {
-		cmd := exec.Command("docker", "rm", "-f", "-v", name)
-		if output, err := cmd.CombinedOutput(); err != nil && !strings.Contains(string(output), "No such container") {
-			t.Logf("docker rm warning for %s: %v\n%s", name, err, string(output))
-		}
+		removeFixedBenchmarkContainer(t, file, name)
 	}
 
 	cmd := runCompose("-f", file, "rm", "-f", "-s", "-v")
@@ -80,6 +116,43 @@ func fixedBenchmarkContainers(file string) []string {
 		return []string{"broker-1", "broker-2", "broker-3", "broker-publisher", "broker-consumer", "prometheus"}
 	}
 	return []string{"bench-broker", "bench-publisher", "bench-consumer"}
+}
+
+func removeFixedBenchmarkContainer(t *testing.T, file, name string) {
+	if !isFixedBenchmarkContainer(t, file, name) {
+		return
+	}
+
+	cmd := exec.Command("docker", "rm", "-f", "-v", name)
+	if output, err := cmd.CombinedOutput(); err != nil && !strings.Contains(string(output), "No such container") {
+		t.Logf("docker rm warning for %s: %v\n%s", name, err, string(output))
+	}
+}
+
+func isFixedBenchmarkContainer(t *testing.T, file, name string) bool {
+	format := strings.Join([]string{
+		`{{ index .Config.Labels "com.docker.compose.project" }}`,
+		`{{ index .Config.Labels "com.docker.compose.project.config_files" }}`,
+		`{{ index .Config.Labels "com.docker.compose.project.working_dir" }}`,
+	}, "\n")
+	cmd := exec.Command("docker", "inspect", "-f", format, name)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+
+	absFile, err := filepath.Abs(file)
+	if err != nil {
+		t.Logf("failed to resolve compose file %s: %v", file, err)
+		return false
+	}
+
+	labels := filepath.ToSlash(string(output))
+	expectedFile := filepath.ToSlash(absFile)
+	expectedDir := filepath.ToSlash(filepath.Dir(absFile))
+	return strings.Contains(labels, "cursus-benchmark") ||
+		strings.Contains(labels, expectedFile) ||
+		strings.Contains(labels, expectedDir)
 }
 
 func composeUp(t *testing.T, file string) {
@@ -123,48 +196,49 @@ func waitForContainerExit(t *testing.T, file, service, container string, timeout
 func assertBenchmarkSuccess(t *testing.T, logs string, component string) {
 	t.Helper()
 
-	lower := strings.ToLower(logs)
-	failureMarkers := []string{
-		"fatal",
-		"panic",
-		"benchmark incomplete",
-		"verify failed",
-		"failed messages              : 1",
-		"failed messages              : 2",
-		"failed messages              : 3",
-		"failed messages              : 4",
-		"failed messages              : 5",
-		"failed messages              : 6",
-		"failed messages              : 7",
-		"failed messages              : 8",
-		"failed messages              : 9",
-		"message missing       : 1",
-		"message missing       : 2",
-		"message missing       : 3",
-		"message missing       : 4",
-		"message missing       : 5",
-		"message missing       : 6",
-		"message missing       : 7",
-		"message missing       : 8",
-		"message missing       : 9",
+	for _, pattern := range severeBenchmarkLogPatterns {
+		if pattern.MatchString(logs) {
+			t.Fatalf("%s benchmark reported failure marker %q:\n%s", component, pattern.String(), lastLines(logs, 40))
+		}
 	}
-	for _, marker := range failureMarkers {
-		if strings.Contains(lower, marker) {
-			t.Fatalf("%s benchmark reported failure marker %q:\n%s", component, marker, lastLines(logs, 40))
+
+	for _, label := range []string{"Failed messages", "Message missing", "Duplicate (MessageID)", "Duplicate (Offset)"} {
+		if count, ok := benchmarkCounter(logs, label); ok && count > 0 {
+			t.Fatalf("%s benchmark reported %s=%d:\n%s", component, label, count, lastLines(logs, 40))
 		}
 	}
 
 	if component == "Publisher" {
-		if !strings.Contains(logs, "Failed messages              : 0") || !strings.Contains(logs, "rate: 100.00%") {
+		failed, ok := benchmarkCounter(logs, "Failed messages")
+		if !ok || failed != 0 || !strings.Contains(logs, "rate: 100.00%") {
 			t.Fatalf("publisher did not report a complete publish:\n%s", lastLines(logs, 40))
 		}
 	} else if component == "Consumer" {
-		if !strings.Contains(logs, "All messages consumed") || !strings.Contains(logs, "Message missing       : 0") {
+		if !strings.Contains(logs, "All messages consumed") {
 			t.Fatalf("consumer did not report complete consumption:\n%s", lastLines(logs, 40))
+		}
+		for _, label := range []string{"Message missing", "Duplicate (MessageID)", "Duplicate (Offset)"} {
+			count, ok := benchmarkCounter(logs, label)
+			if !ok || count != 0 {
+				t.Fatalf("consumer did not report %s=0:\n%s", label, lastLines(logs, 40))
+			}
 		}
 	}
 
 	t.Logf("%s benchmark completed successfully", component)
+}
+
+func benchmarkCounter(logs, label string) (int, bool) {
+	pattern := regexp.MustCompile(fmt.Sprintf(`(?im)%s[[:space:]]*:[[:space:]]*([0-9]+)`, regexp.QuoteMeta(label)))
+	match := pattern.FindStringSubmatch(logs)
+	if match == nil {
+		return 0, false
+	}
+	count, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, false
+	}
+	return count, true
 }
 
 func lastLines(s string, n int) string {

--- a/test/e2e-benchmark/benchmark_test.go
+++ b/test/e2e-benchmark/benchmark_test.go
@@ -55,8 +55,15 @@ func TestRunComposePlacesProjectNameAfterComposeSubcommand(t *testing.T) {
 }
 
 func composeDown(t *testing.T, file string) {
-	// Force remove containers first to handle conflicts from other compose projects
-	// sharing the same container names
+	// Force remove containers first to handle conflicts from compose files that
+	// declare fixed container_name values outside project-name isolation.
+	for _, name := range fixedBenchmarkContainers(file) {
+		cmd := exec.Command("docker", "rm", "-f", "-v", name)
+		if output, err := cmd.CombinedOutput(); err != nil && !strings.Contains(string(output), "No such container") {
+			t.Logf("docker rm warning for %s: %v\n%s", name, err, string(output))
+		}
+	}
+
 	cmd := runCompose("-f", file, "rm", "-f", "-s", "-v")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Logf("compose rm warning: %v\n%s", err, string(output))
@@ -66,6 +73,13 @@ func composeDown(t *testing.T, file string) {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Logf("compose down warning: %v\n%s", err, string(output))
 	}
+}
+
+func fixedBenchmarkContainers(file string) []string {
+	if strings.Contains(filepath.ToSlash(file), "/cluster/") {
+		return []string{"broker-1", "broker-2", "broker-3", "broker-publisher", "broker-consumer", "prometheus"}
+	}
+	return []string{"bench-broker", "bench-publisher", "bench-consumer"}
 }
 
 func composeUp(t *testing.T, file string) {


### PR DESCRIPTION
Fixes benchmark CI false-green / noisy benchmark logs.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed. No docs change needed; this is benchmark CI/test hardening.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

## Summary

- Makes `make bench` fail on benchmark timeout, non-zero publisher/consumer exit codes, and benchmark failure markers in logs.
- Restricts partition producer sequence state/gap tracking to idempotent topics only, avoiding false `seqNum gap detected` warnings for non-idempotent benchmark publishers that use global sequence numbers across partitions.
- Hardens e2e benchmark cleanup for compose files with fixed `container_name` values so stale local/CI containers do not cause false cluster benchmark failures.

## Validation

- `go test ./pkg/topic -count=1`
- `docker compose -f test/docker-compose.yml up --build --remove-orphans` locally confirmed 100,000 produced and 100,000 consumed, with duplicate/missing counts at 0 and no `seqNum gap detected` marker.
- `go test -v -timeout 15m ./test/e2e-benchmark -run TestClusterBenchmark -count=1`
- `go test -v -timeout 15m ./test/e2e-benchmark/...`

## Notes

Local Windows does not have `make` installed, so the exact `make bench` entrypoint was not executed locally. The Docker compose benchmark path that `make bench` wraps was executed locally before opening this PR.