### PR TITLE
feat: add broker transaction semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage-server/
 *.out
 
 bin/
+pkg/controller/broker-logs/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ flowchart TB
 
 ## What is cursus?
 
-cursus is a lightweight message broker inspired by Kafka's design philosophy of **logically separated but physically distributed data management**. 
+cursus is a lightweight message broker built around **logically separated but physically distributed data management**.
 
 It provides publish-subscribe messaging with topic partitioning, consumer groups, and durable disk persistence, designed for single-node deployments with minimal operational complexity.
 
@@ -169,7 +169,7 @@ This architecture enables parallel I/O across partitions and efficient sequentia
 
 ## Cluster Architecture
 
-cursus supports a 3-node Raft-based cluster with Kafka-style routing.
+cursus supports a 3-node Raft-based cluster with coordinator and partition-leader routing.
 
 ### Cluster Topology
 
@@ -237,7 +237,7 @@ graph TB
 | Coordinator | Per-group (consistent hash) | `FIND_COORDINATOR` | `JOIN_GROUP`, `SYNC_GROUP`, `LEAVE_GROUP`, `HEARTBEAT`, `COMMIT_OFFSET`, `FETCH_OFFSET` |
 | Partition leader | Per-partition | `METADATA` | `CONSUME`, `STREAM`, `PUBLISH` |
 
-### Coordinator Pattern (Kafka Model)
+### Coordinator Pattern
 
 ```mermaid
 sequenceDiagram

--- a/docs/cluster-consumer.md
+++ b/docs/cluster-consumer.md
@@ -4,7 +4,7 @@ Consumer가 클러스터 환경에서 메시지를 소비하기 위한 FindCoord
 
 ## Overview
 
-Kafka와 동일한 패턴으로, Consumer Group 관련 커맨드는 Coordinator 브로커로, 데이터 커맨드는 파티션 리더로 라우팅합니다.
+Consumer Group 관련 커맨드는 Coordinator 브로커로, 데이터 커맨드는 파티션 리더로 라우팅합니다.
 
 ## Command Routing
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -127,7 +127,7 @@ Text command responses are machine-readable.
 
 **CREATE**
 ```
-CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [replication_factor=<N>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read>]
+CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [replication_factor=<N>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read|acl>] [read_acl=<principal[,principal]>] [write_acl=<principal[,principal]>]
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
@@ -137,10 +137,12 @@ CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [replication_fact
 | retention_hours | No | 0 | Per-topic retention hours override metadata; 0 means broker default |
 | retention_bytes | No | 0 | Per-topic retention bytes override metadata; 0 means broker default |
 | partitioner | No | hash_key | `hash_key` uses message key hash, `round_robin` ignores keys |
-| auth_policy | No | open | `open`, `deny_write`, or `deny_read` topic policy |
+| auth_policy | No | open | `open`, `deny_write`, `deny_read`, or `acl` topic policy |
+| read_acl | No | - | Comma-separated principals allowed to read when `auth_policy=acl`; `*` allows any authenticated principal |
+| write_acl | No | - | Comma-separated principals allowed to write when `auth_policy=acl`; `*` allows any authenticated principal |
 | replication_factor | No | 3 | Replica count (distributed mode) |
 
-Response: `OK topic=<name> partitions=<N> partitioner=<hash_key|round_robin> auth_policy=<open|deny_write|deny_read> retention_hours=<N> retention_bytes=<N>`
+Response: `OK topic=<name> partitions=<N> partitioner=<hash_key|round_robin> auth_policy=<open|deny_write|deny_read|acl> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>`
 
 **DELETE**
 ```
@@ -200,6 +202,8 @@ PUBLISH topic=<name> acks=<0|1|-1|all> producerId=<id> [partition=<N>] [seqNum=<
 | isIdempotent | No | false | Enable dedup for this message |
 
 Because `message=` captures the rest of the line, optional parameters such as `partition`, `seqNum`, `epoch`, and `isIdempotent` must appear before `message=` in text commands.
+
+Transaction metadata fields such as `transactional_id`, `transaction_state`, and `transaction_marker` are broker-internal on `PUBLISH`. Clients must use `INIT_PRODUCER_ID`, `BEGIN_TXN`, `TXN_PUBLISH`, and `END_TXN`; direct metadata injection is rejected with `ERROR: transaction_metadata_forbidden command=PUBLISH`.
 
 Response (JSON — `AckResponse`):
 ```json
@@ -344,7 +348,7 @@ used. If the command omits a usable explicit offset in a future protocol
 revision, `autoOffsetReset=earliest` starts at `0` and `autoOffsetReset=latest`
 starts at the partition high-water mark.
 
-`CONSUME` is a stateless partition-leader read, analogous to Kafka `FETCH`. The
+`CONSUME` is a stateless partition-leader read. The
 partition leader does not validate consumer group ownership, member liveness, or
 generation on the data path. Ownership and generation fencing are enforced by
 coordinator commands such as `HEARTBEAT`, `COMMIT_OFFSET`, and `BATCH_COMMIT`.
@@ -367,6 +371,30 @@ STREAM_CONTROL type=CLOSE reason=<stopped|removed|timeout|error|offset_out_of_ra
 `type=CLOSE` is a graceful stream terminator. `offset` is the broker's next stream offset at close time. `reason=offset_out_of_range` means the requested stream offset is older than the retained log. Clients SHOULD close the socket, keep or refresh their committed offset, and reconnect or rejoin according to the consumer group lifecycle. A broker crash, process kill, or network failure can still close the TCP connection without a terminator; clients MUST treat raw disconnect as retryable and resume from the broker committed offset.
 
 #### Offset Management
+
+
+**LIST_OFFSETS**
+
+```text
+LIST_OFFSETS topic=<name> [partition=<N>]
+```
+
+Success response:
+
+```text
+OK topic=<name> partitions=<N> offsets=P0:earliest=<N>:latest=<N>:leo=<N>:hwm=<N>,P1:earliest=<N>:latest=<N>:leo=<N>:hwm=<N>
+```
+
+`LIST_OFFSETS` returns the broker-side offset range for retained records. `earliest` is the first retained offset. `latest` is the next readable committed offset and is the value clients should use for `autoOffsetReset=latest`. `leo` is the partition log end offset, and `hwm` is the high-water mark before the broker caps reads to the flushed durable tail. A single `partition=` returns only that partition.
+
+Errors:
+
+```text
+ERROR: missing_topic command=LIST_OFFSETS
+ERROR: topic_not_found topic=<name>
+ERROR: invalid_partition command=LIST_OFFSETS
+ERROR: partition_not_found partition=<N>
+```
 
 **FETCH_OFFSET**
 ```
@@ -405,6 +433,67 @@ the batch. If any partition is not owned by that member in that generation, the
 entire batch is rejected with `ERROR: NOT_OWNER ...`. Stale generations return
 `ERROR: GEN_MISMATCH ...`, and unknown members return `ERROR: member_not_found ...`.
 
+
+#### Transaction Coordinator
+
+Cursus exposes a broker-managed transaction coordinator for consume-process-produce workflows. In distributed mode, transaction commands are routed by `transactional_id` using the coordinator key `txn:<transactional_id>`. Clients can discover the owner with `FIND_COORDINATOR transactional_id=<id>` and must retry on `ERROR: NOT_COORDINATOR host=<host> port=<port>`.
+
+Transaction state is replicated through the Raft FSM as `TXN_SYNC` and included in FSM snapshot version 4. Clients should first call `INIT_PRODUCER_ID` for a `transactional_id`; the broker returns the authoritative `(producerId, epoch)` session and bumps `epoch` on re-initialization to fence older producers. The coordinator fences stale producers by `(transactional_id, producerId, epoch)`: lower epochs are rejected, and staged operations must use the same producer and epoch that opened the transaction. Completed transactional ids are retained for `transactional_id_expiration_ms` so retry/fencing state survives normal restarts, while active `open` and `committing` transactions are not expired by the cleanup path.
+
+**INIT_PRODUCER_ID**
+
+```text
+INIT_PRODUCER_ID transactional_id=<id>
+```
+
+Success: `OK transactional_id=<id> producerId=<producer-id> epoch=<N>`. Re-initializing the same `transactional_id` returns the same broker-managed `producerId` with a higher `epoch`, aborts any open local staging for that id, and fences commands that still use the previous epoch. If the transaction is already `committing`, the broker rejects reinitialization so the prepared commit can be retried or recovered.
+
+**BEGIN_TXN**
+
+```text
+BEGIN_TXN transactional_id=<id> producerId=<producer-id> epoch=<N>
+```
+
+Success: `OK transactional_id=<id> state=open producerId=<producer-id> epoch=<N>`.
+
+**TXN_PUBLISH**
+
+```text
+TXN_PUBLISH transactional_id=<id> topic=<topic> [partition=<N>] producerId=<producer-id> seqNum=<N> epoch=<N> [key=<key>] message=<payload>
+```
+
+Success: `OK transactional_id=<id> staged_messages=1 topic=<topic> partition=<N>`.
+
+The record is staged in the transaction coordinator and is not published until `END_TXN ... result=commit`. `seqNum` is required and must be greater than zero; the broker uses `(producerId, epoch, seqNum)` to make commit recovery idempotent even when the target topic is not globally idempotent. On commit, the broker writes the record with `transactional_id` and `transaction_state=open`, then uses the normal publish path, including partition-leader routing in distributed mode. After records are written and staged offsets are committed, the broker appends a hidden Cursus transaction commit marker to each touched partition; `read_committed` visibility is controlled by a later marker for the same `(transactional_id, epoch)`, so transactional records are not visible if marker append fails before retry/recovery completes, even if they carry transaction metadata or an older epoch marker exists. Uncommitted staged records are not published by this staging path, and abort writes hidden abort markers for touched partitions that already contain transaction records from a retry/recovery path.
+
+**SEND_OFFSETS_TO_TXN**
+
+```text
+SEND_OFFSETS_TO_TXN transactional_id=<id> producerId=<producer-id> epoch=<N> topic=<topic> group=<group> member=<member> generation=<N> P<partition>:<nextOffset>,P<partition>:<nextOffset>
+```
+
+Success: `OK transactional_id=<id> staged_offsets=<N>`.
+
+The broker validates `member`, `generation`, and partition ownership before staging offsets, then validates them again before commit. Offsets keep the same monotonic rule as `COMMIT_OFFSET`; `END_TXN ... result=commit` fails before publishing records if any staged offset would regress.
+
+**END_TXN**
+
+```text
+END_TXN transactional_id=<id> producerId=<producer-id> epoch=<N> result=<commit|abort>
+```
+
+Success: `OK transactional_id=<id> state=<committed|aborted> messages=<N> offsets=<N>`. Retrying the same final result with the same `producerId` and `epoch` is idempotent; a lower epoch is rejected as fenced, and trying to abort a committed transaction or commit an aborted transaction returns an error.
+
+**TXN_STATUS**
+
+```text
+TXN_STATUS transactional_id=<id>
+```
+
+Success: `OK transactional_id=<id> state=<open|committing|committed|aborted> messages=<N> offsets=<N>`.
+
+Current guarantee: a successful transaction commit stages records and offsets behind a broker transaction coordinator, fences stale producer epochs, persists transaction state through the distributed metadata FSM, writes hidden Cursus transaction control markers with durable transaction control-record key/value bytes and Cursus control-batch metadata to touched partition logs, uses the normal partition-leader publish path, appends commit markers before applying staged offsets, commits offsets through the consumer-group coordinator, and makes `ReadCommitted`/`CONSUME` use transaction markers to expose committed transactions, skip aborted transactions, and stop at the first unresolved open transaction as a last-stable-offset boundary. Partitions maintain an in-memory transaction marker index rebuilt from durable logs on startup, so `read_committed` does not need to rediscover every later marker by scanning from the requested offset. `INIT_PRODUCER_ID` provides broker-owned producer epoch allocation for transactional ids. Retried `END_TXN` requests for an already committed or aborted transaction are idempotent for the same producer epoch. On broker start, restored `committing` transactions are recovered by replaying the prepared transaction and finalizing it as committed on the transaction coordinator; producer sequence state is rebuilt from partition logs so replay does not append duplicate transactional records after a lost producer-state checkpoint. The marker contract is stored in Cursus log records (`control_batch_type=transaction`, `control_batch_version=2`, `control_batch_coordinator_epoch=<epoch>`) plus transaction control-record key/value bytes (`key: int16 version, int16 markerType`; `value: int16 version, int32 coordinatorEpoch`). This makes the transaction marker payload schema Cursus-compatible while the surrounding Cursus log segment remains Cursus-owned, not a Cursus broker network-protocol byte stream. Cursus does not make external side effects exactly-once. Clients should continue to use idempotent processors for external systems.
+
 #### Event Sourcing Commands
 
 These commands are available only on topics created with `event_sourcing=true`.
@@ -427,7 +516,7 @@ APPEND_STREAM topic=<name> key=<aggregate_key> version=<N> event_type=<type> [sc
 
 Success response: `OK version=<N> offset=<N> partition=<N>`
 
-Internal broker catch-up commands: LIST_SNAPSHOTS topic=<name> partition=<N>, FETCH_SNAPSHOT topic=<name> partition=<N> key=<aggregate_key>, and CATCHUP_SNAPSHOTS topic=<name> partition=<N> [leader=<host:port>]. These commands are for broker-to-broker recovery only.
+Internal broker catch-up commands: `LIST_SNAPSHOTS topic=<name> partition=<N>`, `FETCH_SNAPSHOT topic=<name> partition=<N> key=<aggregate_key>`, and `CATCHUP_SNAPSHOTS topic=<name> partition=<N> [leader=<host:port>]`. These commands are for broker-to-broker recovery only. In distributed mode, internal broker commands require `internal_token=<shared-token>` and brokers must be configured with `internal_auth_token`; clients and SDKs must not send these commands directly. Operators can additionally set `internal_broker_port` to move broker-to-broker command forwarding off the public client listener. When `internal_use_tls=true`, that internal listener requires mutual TLS using `internal_tls_cert_path`, `internal_tls_key_path`, and `internal_tls_ca_path`; the router dials peer brokers on the internal port with the same CA trust. The shared internal token remains a command-level guard, but mTLS/internal listener separation is the stronger network boundary.
 
 Error responses:
 - `ERROR: version_conflict current=<N> expected=<N>` — optimistic concurrency failure
@@ -486,7 +575,7 @@ SAVE_SNAPSHOT topic=<name> key=<aggregate_key> version=<N> message=<payload>
 
 Success response: `OK version=<N> partition=<N>`
 
-In distributed mode, success means the leader stored the snapshot and replicated it to the configured in-sync replica quorum through the internal `REPLICATE_SNAPSHOT` broker-to-broker command. Clients should not send `REPLICATE_SNAPSHOT` directly.
+In distributed mode, success means the leader stored the snapshot and replicated it to the configured in-sync replica quorum through the internal `REPLICATE_SNAPSHOT internal_token=<shared-token> payload=<json>` broker-to-broker command. Clients should not send `REPLICATE_SNAPSHOT` directly. Brokers reject internal commands without the configured token with `ERROR: internal_command_unauthorized ...`, and reject distributed-mode internal commands when no token is configured with `ERROR: internal_auth_not_configured ...`.
 
 Error responses:
 - `ERROR: snapshot_version_exceeds_stream version=<N> current=<N>`
@@ -588,7 +677,7 @@ Client action:
 ```
 1. Saved offset from coordinator for (topic, group, partition)
 2. Explicit offset from request parameter
-3. autoOffsetReset = "latest" → partition HWM
+3. autoOffsetReset = "latest" → partition `LIST_OFFSETS latest` value
 4. autoOffsetReset = "earliest" → 0
 ```
 
@@ -622,9 +711,7 @@ Recommended client loop:
 
 This gives at-least-once delivery when the client commits after processing. If a
 client commits before processing and then crashes, it may skip unprocessed
-records, which is at-most-once behavior for that client. Cursus does not provide
-exactly-once processing semantics; applications that need exactly-once effects
-must make their processing idempotent or transactional outside the broker.
+records, which is at-most-once behavior for that client. Cursus provides broker-managed transaction commands for consume-process-produce workflows, including producer fencing, durable transaction state, idempotent finalization, hidden partition transaction markers with durable transaction control-record key/value bytes and Cursus control-batch metadata, startup recovery for prepared commits, and read-committed filtering with a last-stable-offset style boundary for unresolved open transactions. It is still not exactly-once for external effects, so applications that need exactly-once external effects must still make their processors idempotent or transactional outside the broker.
 
 Example for a game server such as wargame-IOCP:
 
@@ -689,7 +776,7 @@ Client should reconnect to the specified address and retry.
 
 ### Authorization
 
-The wire protocol now exposes a minimal per-topic `auth_policy` metadata contract: `open`, `deny_write`, and `deny_read`. `deny_write` rejects `PUBLISH`/batch publish with `ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=<T> operation=write`; `deny_read` rejects `CONSUME`/`STREAM` with `ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=<T> operation=read`. This is not SASL or identity-aware ACL yet; deployments should still use TLS plus network, service-mesh, or application-level controls for caller authentication.
+The wire protocol exposes per-topic `auth_policy` metadata: `open`, `deny_write`, `deny_read`, and `acl`. `AUTH principal=<principal> token=<token>` authenticates a client connection when `enable_sasl=true`, and individual commands may also provide `principal=<principal> auth_token=<token>` for inline authentication. `auth_policy=acl` checks `read_acl` for `CONSUME`/`STREAM` and `write_acl` for `PUBLISH`/`TXN_PUBLISH`; unauthorized operations return `ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=<T> operation=<read|write>`. This is a simple token contract, not a mechanism-specific SASL byte protocol. Deployments that expose brokers across trust boundaries should still use TLS/mTLS and network controls.
 
 ### Retention
 
@@ -714,16 +801,16 @@ Set `isIdempotent=true` on PUBLISH or in binary batch header.
 - A new `(producerId, epoch)` sequence starts at `seqNum=1`; starting above 1 is rejected as a gap
 - A higher `epoch` fences the previous producer session and may restart `seqNum` from 1
 - A lower `epoch` is rejected as stale producer state
-- `seqNum` = 0 disables dedup for that message
+- `seqNum` = 0 disables dedup for non-transactional publish messages; transactional `TXN_PUBLISH` requires `seqNum > 0`
 - Broker rejects duplicates silently (returns OK)
 
 ### Sequence Tracking
 
 - Broker tracks the last seen `(epoch, seqNum)` per `(producerId)` per partition
-- Disk-backed partitions persist producer sequence checkpoints and restore them on broker restart
+- Disk-backed partitions persist producer sequence checkpoints, rebuild producer state from partition logs on broker restart, and use that state to make transactional commit recovery idempotent
 - Distributed FSM snapshots also include producer sequence state for replicated message commands
 - FSM snapshots that encode producer epochs use snapshot version 3. Do not run mixed-version rolling upgrades across brokers that cannot decode producer-epoch snapshot state; upgrade the cluster together or drain snapshots before introducing older binaries.
-- Producer state expires from memory after 30 minutes of inactivity; durable checkpoints retain the last persisted sequence until the partition data is removed
+- Producer state expires from memory after `producer_state_ttl_ms` of inactivity (default 30 minutes); durable checkpoints retain the last persisted sequence until the partition data is removed
 
 ---
 
@@ -747,6 +834,7 @@ Set `isIdempotent=true` on PUBLISH or in binary batch header.
 - [ ] Exponential backoff on reconnect
 - [ ] Async offset commits (BATCH_COMMIT)
 - [ ] Idempotent producer with sequence numbers
+- [x] Transaction coordinator commands (BEGIN_TXN, TXN_PUBLISH, SEND_OFFSETS_TO_TXN, END_TXN)
 - [ ] Wildcard topic subscription
 - [ ] Stream mode (continuous push)
 - [ ] Read/write buffer tuning (2MB recommended)

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -30,7 +30,7 @@ Legacy natural-language responses such as `Topic '<name>' now has <N> partitions
 ### CREATE
 
 ```text
-CREATE topic=<name> [partitions=<N>] [idempotent=<bool>] [event_sourcing=<bool>] [replication_factor=<N>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read>]
+CREATE topic=<name> [partitions=<N>] [idempotent=<bool>] [event_sourcing=<bool>] [replication_factor=<N>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read|acl>] [read_acl=<principal[,principal]>] [write_acl=<principal[,principal]>]
 ```
 
 Creates a topic or increases its partition count when the topic already exists.
@@ -126,6 +126,8 @@ PUBLISH topic=<name> [partition=<N>] [key=<routing-key>] [producerId=<id>] [seqN
 
 Because `message=` captures the rest of the line, put optional parameters before `message=`.
 
+Transaction metadata fields are not accepted on client `PUBLISH`; use the transaction commands for transactional records. Direct `transactional_id`, `transaction_state`, or `transaction_marker` injection returns `ERROR: transaction_metadata_forbidden command=PUBLISH`.
+
 For `acks=1` or `acks=all`, success is a JSON ack response with `status:"OK"`. Text `PUBLISH` may include `partition=<N>` to target a partition explicitly; otherwise the topic partition policy selects the partition. Idempotent publish uses `(producerId, epoch, seqNum)` per partition: each new `(producerId, epoch)` sequence starts at `seqNum=1`, higher epochs fence older producer sessions, lower epochs are rejected as stale, and `seqNum=0` disables dedup for that message. Distributed FSM snapshots that include producer epochs use snapshot version 3; avoid mixed-version rolling upgrades with binaries that cannot decode that snapshot state. For `acks=0`, success is:
 
 ```text
@@ -147,7 +149,7 @@ ERROR: stale_producer_epoch reason="..."
 
 ### REPLICATE_MESSAGE
 
-Internal replication command used between brokers.
+Internal replication command used between brokers. In distributed mode this command requires `internal_token=<shared-token>` before `payload=`. External clients and SDKs must not call it directly.
 
 Success:
 
@@ -158,6 +160,8 @@ OK
 Common errors:
 
 ```text
+ERROR: internal_auth_not_configured command=REPLICATE_MESSAGE
+ERROR: internal_command_unauthorized command=REPLICATE_MESSAGE
 ERROR: missing_payload command=REPLICATE_MESSAGE
 ERROR: unmarshal_failed reason="..."
 ERROR: topic_not_found topic=<name>
@@ -280,6 +284,30 @@ Success:
 OK group=<group> member=<assigned-member-id> left=true
 ```
 
+
+### LIST_OFFSETS
+
+```text
+LIST_OFFSETS topic=<name> [partition=<N>]
+```
+
+Returns retained and readable offset bounds for all partitions or one partition.
+
+```text
+OK topic=<name> partitions=<N> offsets=P0:earliest=<N>:latest=<N>:leo=<N>:hwm=<N>,P1:earliest=<N>:latest=<N>:leo=<N>:hwm=<N>
+```
+
+`latest` is the next readable committed offset and is the value SDKs should use for `auto_offset_reset=latest`. `leo` is the log end offset, and `hwm` is the high-water mark before the broker caps reads to the flushed durable tail.
+
+Errors:
+
+```text
+ERROR: missing_topic command=LIST_OFFSETS
+ERROR: topic_not_found topic=<name>
+ERROR: invalid_partition command=LIST_OFFSETS
+ERROR: partition_not_found partition=<N>
+```
+
 ### FETCH_OFFSET
 
 ```text
@@ -394,7 +422,7 @@ ERROR: distribution_not_enabled
 
 ### RAFT_APPLY
 
-Internal replication command used by distributed brokers.
+Internal replication command used by distributed brokers. In distributed mode this command requires `internal_token=<shared-token>` before `type=`. External clients and SDKs must not call it directly.
 
 Success:
 
@@ -405,6 +433,8 @@ OK
 Common errors:
 
 ```text
+ERROR: internal_auth_not_configured command=RAFT_APPLY
+ERROR: internal_command_unauthorized command=RAFT_APPLY
 ERROR: missing_required_params command=RAFT_APPLY params=type,payload
 ERROR: empty_required_params command=RAFT_APPLY params=type,payload
 ERROR: distribution_required command=RAFT_APPLY
@@ -420,8 +450,57 @@ Event-sourcing commands are routed by aggregate `key`. In distributed mode, the 
 ERROR: NOT_LEADER LEADER_IS <host:port>
 ```
 
-Clients and SDKs should reconnect to that leader and retry. Followers index replicated event-sourcing records, apply quorum-replicated snapshots, and can pull missing snapshots from the partition leader with internal catch-up commands after restart. Partitions restore a synced high-watermark checkpoint with durable-tail clamping, so committed reads remain bounded by the last successful committed tail.
+Clients and SDKs should reconnect to that leader and retry. Followers index replicated event-sourcing records, apply quorum-replicated snapshots, and can pull missing snapshots from the partition leader with token-authenticated internal catch-up commands after restart. Partitions restore a synced high-watermark checkpoint with durable-tail clamping, so committed reads remain bounded by the last successful committed tail.
 
+
+
+### INIT_PRODUCER_ID
+
+```text
+INIT_PRODUCER_ID transactional_id=<id>
+```
+
+Initializes or reinitializes a broker-managed producer session for a transactional id. Success: `OK transactional_id=<id> producerId=<producer-id> epoch=<N>`. Reinitialization bumps `epoch` and fences older producers for that `transactional_id`. If the transaction is already `committing`, the broker rejects reinitialization so the prepared commit can be retried or recovered. Completed transactional ids expire after `transactional_id_expiration_ms`; active `open` and `committing` transactions are retained for recovery.
+
+### BEGIN_TXN
+
+```text
+BEGIN_TXN transactional_id=<id> producerId=<producer-id> epoch=<N>
+```
+
+Starts a broker-managed transaction using the `producerId` and `epoch` returned by `INIT_PRODUCER_ID`. In distributed mode, route transaction commands to `FIND_COORDINATOR transactional_id=<id>`; the coordinator key is `txn:<id>`. Success: `OK transactional_id=<id> state=open producerId=<producer-id> epoch=<N>`.
+
+### TXN_PUBLISH
+
+```text
+TXN_PUBLISH transactional_id=<id> topic=<topic> [partition=<N>] producerId=<producer-id> seqNum=<N> epoch=<N> [key=<key>] message=<payload>
+```
+
+Stages one record in the transaction. `seqNum` is required and must be greater than zero; Cursus uses `(producerId, epoch, seqNum)` to make commit recovery idempotent even on non-idempotent topics. The record is not published until `END_TXN ... result=commit` succeeds. Committed records are written with transaction metadata before they enter the normal publish path, but they remain `transaction_state=open` until a hidden Cursus commit marker on the touched partition makes them visible to `read_committed` consumers; a later marker for the same `(transactional_id, epoch)` is the visibility authority for transactional records. Commit/abort writes hidden Cursus transaction control markers to touched partition logs. The producer and epoch must match `BEGIN_TXN`; stale epochs are fenced.
+
+### SEND_OFFSETS_TO_TXN
+
+```text
+SEND_OFFSETS_TO_TXN transactional_id=<id> producerId=<producer-id> epoch=<N> topic=<topic> group=<group> member=<member> generation=<N> P<partition>:<nextOffset>,P<partition>:<nextOffset>
+```
+
+Stages consumer offsets in the transaction. The broker validates group member, generation, and partition ownership when offsets are staged, then revalidates ownership and monotonic offsets during commit before publishing records.
+
+### END_TXN
+
+```text
+END_TXN transactional_id=<id> producerId=<producer-id> epoch=<N> result=<commit|abort>
+```
+
+Commits or aborts staged records and offsets. Transaction state is replicated in the metadata FSM and included in snapshots, `INIT_PRODUCER_ID` provides broker-owned producer epoch allocation, committed records use the normal partition-leader publish path with forced idempotent sequence validation, finalization retries are idempotent for the same producer epoch, hidden Cursus transaction markers with durable transaction control-record key/value bytes and Cursus control-batch metadata are appended to touched partition logs before staged offsets are committed, startup recovery finalizes restored `committing` transactions, producer sequence state is rebuilt from partition logs, and committed reads use a partition transaction marker index to expose committed transactions, skip aborted transactions, and stop at the first unresolved open transaction as a last-stable-offset boundary. Cursus stores transaction control-record key/value bytes (`key: int16 version, int16 markerType`; `value: int16 version, int32 coordinatorEpoch`) alongside Cursus control-batch metadata (`control_batch_type=transaction`, `control_batch_version=2`, `control_batch_coordinator_epoch=<epoch>`). The transaction marker payload schema is Cursus-compatible, while the surrounding Cursus log segment is still Cursus-owned rather than Cursus broker network-protocol byte compatibility; external side effects are not made exactly-once by the broker.
+
+### TXN_STATUS
+
+```text
+TXN_STATUS transactional_id=<id>
+```
+
+Returns transaction state and staged operation counts.
 
 ### APPEND_STREAM
 
@@ -509,8 +588,8 @@ OK snapshot=null
 
 ## Topic Policy Notes
 
-- Minimal per-topic authorization policy is part of topic metadata: `auth_policy=open|deny_write|deny_read`. It rejects unauthorized topic reads/writes with `ERROR: NOT_AUTHORIZED_FOR_TOPIC ...`, but it is not caller identity-aware ACL/SASL yet. Use TLS and external network/application controls for authentication boundaries.
-- Topics expose `retention_hours` and `retention_bytes` policy metadata. `0` means broker default. Reads before the earliest retained offset fail with `ERROR: OFFSET_OUT_OF_RANGE requested=<N> earliest=<N> latest=<N>`. SDKs should apply `auto_offset_reset` (`earliest`, `latest`, or `error`) to decide whether to reset or fail.
+- Per-topic authorization policy is part of topic metadata: `auth_policy=open|deny_write|deny_read|acl`. `AUTH principal=<principal> token=<token>` authenticates a connection when `enable_sasl=true`; commands can also include `principal=<principal> auth_token=<token>` for inline authentication. `auth_policy=acl` checks `read_acl` for reads and `write_acl` for writes, returning `ERROR: NOT_AUTHORIZED_FOR_TOPIC ...` on denial. This is a simple token contract, not a mechanism-specific SASL byte protocol; use TLS/mTLS and network controls for broker exposure.
+- Topics expose `retention_hours` and `retention_bytes` policy metadata. `0` means broker default. Reads before the earliest retained offset fail with `ERROR: OFFSET_OUT_OF_RANGE requested=<N> earliest=<N> latest=<N>`. SDKs should apply `auto_offset_reset` (`earliest`, `latest`, or `error`) to decide whether to reset or fail; `latest` should use `LIST_OFFSETS latest`, the next readable committed offset.
 - `partitioner=hash_key` uses FNV-1a 64-bit hash modulo partition count for keyed messages and round-robin for missing keys. `partitioner=round_robin` ignores keys. Increasing partition count can remap future records for an existing key.
 
 ## Server-Level Errors

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -4,7 +4,7 @@ This document compares **cursus** with other popular messaging systems to help y
 
 ## High-Level Comparison Matrix
 
-| Feature | **cursus** | **Apache Kafka** | **NATS (JetStream)** | **RabbitMQ** | **Redis Streams** |
+| Feature | **cursus** | **Large log platforms** | **NATS (JetStream)** | **RabbitMQ** | **Redis Streams** |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Model** | Log-based (Pull/Stream) | Log-based (Pull) | Pub/Sub & Log | Queue-based (Push) | Log-based (Pull) |
 | **Storage** | Disk (mmap, Async) | Disk (Sequential) | Memory/Disk | Memory/Disk | In-memory (Optional Disk) |
@@ -16,20 +16,20 @@ This document compares **cursus** with other popular messaging systems to help y
 
 ---
 
-## cursus vs. Apache Kafka
+## cursus vs. large log platforms
 
-**cursus** is heavily inspired by Kafka's partitioned log architecture but aims for a much smaller operational footprint.
+**cursus** uses a partitioned log architecture while aiming for a much smaller operational footprint.
 
-*   **Simplicity:** Kafka is a massive ecosystem requiring JVM and complex configuration. Cursus is a single Go binary with minimal dependencies, ideal for edge computing or small-to-medium-scale environments.
-*   **Built-in Deduplication:** Cursus provides a native 30-minute deduplication window, whereas Kafka requires idempotent producers or external state management for exactly-once processing.
-*   **Performance:** While Kafka scales to petabytes, Cursus optimizes for single-node or small cluster performance using Linux-specific optimizations like `sendfile` and `fadvise`.
+*   **Simplicity:** Cursus is a single Go binary with minimal dependencies, ideal for edge computing or small-to-medium-scale environments.
+*   **Built-in Deduplication:** Cursus provides a native 30-minute deduplication window plus producer idempotency support for reliable processing.
+*   **Performance:** Cursus optimizes for single-node or small cluster performance using Linux-specific optimizations like `sendfile` and `fadvise`.
 
 ## cursus vs. NATS (JetStream & Core)
 
 NATS distinguishes between **Core NATS** (ephemeral, at-most-once) and **JetStream** (persistent, at-least-once). Cursus takes a unified approach that combines elements of both.
 
 *   **Unified Model:** Unlike NATS which requires choosing between Core and JetStream, Cursus is built from the ground up as a persistent log-based broker. However, it provides "Core-like" performance by using dual-path delivery: messages are dispatched to active consumers immediately (like Core) while simultaneously being batched for disk persistence (like JetStream).
-*   **Streaming Semantics:** Cursus follows the Kafka/JetStream "streaming" model where messages are stored in an ordered log. This allows for features like **Replay** (consuming from a specific offset) and **Retention policies**, which are not available in Core NATS.
+*   **Streaming Semantics:** Cursus follows a durable streaming model where messages are stored in an ordered log. This allows for features like **Replay** (consuming from a specific offset) and **Retention policies**, which are not available in Core NATS.
 *   **Push vs. Pull:** 
     *   **NATS Core** is predominantly push-based.
     *   **NATS JetStream** supports both push and pull.
@@ -69,12 +69,12 @@ Redis Streams provides a log-like data structure within an in-memory database.
 ## Summary: When to use cursus?
 
 **Choose cursus if you need:**
-1.  **Kafka-like semantics** (partitioning, log-based persistence) without the operational complexity of Kafka.
+1.  **Partitioned-log semantics** with a lightweight operational model.
 2.  **Lightweight footprint** for edge deployments or microservices where resource efficiency is critical.
 3.  **High-performance disk I/O** on Linux environments.
 4.  **Built-in idempotency** and deduplication for reliable message delivery.
 
 **Choose something else if you need:**
--   Massive, enterprise-wide event streaming (use Kafka).
+-   Massive, enterprise-wide event streaming where a heavyweight platform is already required.
 -   Complex routing patterns like header-based or topic-exchange routing (use RabbitMQ).
 -   Simple, transient in-memory messaging (use Core NATS or Redis).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -46,6 +46,16 @@ broker:
   use_tls: false
   tls_cert_path: "certs/server.crt"
   tls_key_path: "certs/server.key"
+  internal_broker_port: 19000
+  internal_use_tls: false
+  internal_tls_cert_path: "certs/broker.crt"
+  internal_tls_key_path: "certs/broker.key"
+  internal_tls_ca_path: "certs/ca.crt"
+  internal_tls_server_name: "broker.internal"
+  enable_sasl: false
+  sasl_users:
+    - principal: "game-server"
+      token: "change-me"
   
   # Compression
   enable_gzip: false
@@ -111,9 +121,17 @@ The configuration is represented by the Config struct in the codebase, which org
 | `use_tls`        | bool   | false   | Enable TLS for TCP connections               |
 | `tls_cert_path`  | string | ""      | Path to TLS certificate file                 |
 | `tls_key_path`  | string | ""      | Path to TLS private key file                 |
+| `internal_broker_port` | int | 0 | Optional dedicated broker-to-broker command port |
+| `internal_use_tls` | bool | false | Require mutual TLS on the internal broker listener |
+| `internal_tls_cert_path` | string | "" | Broker certificate for internal mTLS |
+| `internal_tls_key_path` | string | "" | Broker private key for internal mTLS |
+| `internal_tls_ca_path` | string | "" | CA used to verify peer broker certificates |
+| `internal_tls_server_name` | string | "" | Server name used by broker-to-broker mTLS clients |
+| `enable_sasl` | bool | false | Enable SASL-PLAIN-style token authentication for text commands |
+| `sasl_users` | list | [] | Principal/token pairs accepted by `AUTH` and inline `principal`/`auth_token` |
 | `enable_gzip`    | bool   | false   | Enable gzip compression for messages        |
 
-When `use_tls` is enabled and certificate paths are provided, the broker loads the certificate using `tls.LoadX509KeyPair()` during initialization 
+When `use_tls` is enabled and certificate paths are provided, the broker loads the certificate using `tls.LoadX509KeyPair()` during initialization. In distributed mode, `internal_broker_port` moves broker-to-broker text commands away from the public client listener. If `internal_use_tls` is enabled, the internal listener requires client certificates signed by `internal_tls_ca_path`, and peer routers dial the internal port with mTLS using `internal_tls_server_name` for certificate verification. If `enable_sasl` is enabled, clients authenticate with `AUTH principal=<principal> token=<token>` or inline `principal=<principal> auth_token=<token>` on protected commands; topic `auth_policy=acl` then checks `read_acl`/`write_acl`.
 
 # DiskHandler Performance Tuning
 
@@ -265,6 +283,15 @@ The Config struct uses both YAML and JSON tags to support both formats. Here's h
 | TLSCertPath               | `tls_cert_path`              | `tls.cert_path`               | --tls-cert               |
 | TLSKeyPath                | `tls_key_path`               | `tls.key_path`                | --tls-key                |
 | EnableGzip                | `enable_gzip`                | `gzip.enable`                 | --gzip                   |
+| InternalBrokerPort        | `internal_broker_port`       | `distribution.internal_broker_port` | --internal-broker-port |
+| InternalUseTLS            | `internal_use_tls`           | `internal_tls.enable`         | --internal-tls           |
+| InternalTLSCertPath        | `internal_tls_cert_path`     | `internal_tls.cert_path`      | --internal-tls-cert      |
+| InternalTLSKeyPath         | `internal_tls_key_path`      | `internal_tls.key_path`       | --internal-tls-key       |
+| InternalTLSCAPath          | `internal_tls_ca_path`       | `internal_tls.ca_path`        | --internal-tls-ca        |
+| InternalTLSServerName      | `internal_tls_server_name`   | `internal_tls.server_name`    | --internal-tls-server-name |
+| EnableSASL                 | `enable_sasl`                | `sasl.enable`                 | --enable-sasl            |
+| ProducerStateTTLMS        | `producer_state_ttl_ms`      | `producer.state.ttl.ms`       | --producer-state-ttl-ms  |
+| TransactionalIDExpirationMS | `transactional_id_expiration_ms` | `transactional.id.expiration.ms` | --transactional-id-expiration-ms |
 | DiskFlushBatchSize        | `disk_flush_batch_size`      | `disk.flush.batch.size`       | --disk-flush-batch       |
 | LingerMS                  | `linger_ms`                  | `linger.ms`                   | --linger-ms              |
 | ChannelBufferSize         | `channel_buffer_size`        | `channel.buffer.size`         | --channel-buffer         |

--- a/pkg/cluster/controller/controller.go
+++ b/pkg/cluster/controller/controller.go
@@ -70,6 +70,7 @@ type ClusterController struct {
 	Discovery   ServiceDiscovery
 	Election    *ControllerElection
 	Router      *ClusterRouter
+	Config      *config.Config
 	brokerID    string
 }
 
@@ -78,7 +79,8 @@ func NewClusterController(ctx context.Context, cfg *config.Config, rm RaftManage
 		RaftManager: rm,
 		Discovery:   sd,
 		Election:    NewControllerElection(rm),
-		Router:      NewClusterRouter(brokerID, localAddr, nil, rm, cfg.BrokerPort, cfg.AdvertisedClientHost),
+		Router:      NewClusterRouter(brokerID, localAddr, nil, rm, cfg.BrokerPort, cfg.AdvertisedClientHost, cfg),
+		Config:      cfg,
 		brokerID:    brokerID,
 	}
 
@@ -138,6 +140,13 @@ func (cc *ClusterController) IsAuthorized(topic string, partition int) bool {
 	}
 
 	return meta.Leader == cc.brokerID
+}
+
+func (cc *ClusterController) internalAuthPrefix() string {
+	if cc != nil && cc.Config != nil && cc.Config.InternalAuthToken != "" {
+		return "internal_token=" + cc.Config.InternalAuthToken + " "
+	}
+	return ""
 }
 
 func (cc *ClusterController) ForwardCommandToBroker(addr, command string) (string, error) {
@@ -242,7 +251,7 @@ func (cc *ClusterController) ReplicateToFollowers(topic string, partition int, m
 	if err != nil {
 		return err
 	}
-	replicateCmd := fmt.Sprintf("REPLICATE_MESSAGE payload=%s", string(data))
+	replicateCmd := fmt.Sprintf("REPLICATE_MESSAGE %spayload=%s", cc.internalAuthPrefix(), string(data))
 
 	var wg sync.WaitGroup
 	var successCount int32 = 1 // Count self (leader)

--- a/pkg/cluster/controller/controller_ext_test.go
+++ b/pkg/cluster/controller/controller_ext_test.go
@@ -93,7 +93,7 @@ func TestClusterController_Basic(t *testing.T) {
 func TestClusterRouter_Forwarding(t *testing.T) {
 	rm := &MockRaftManager{isLeader: false}
 	lp := &MockLocalProcessor{}
-	router := NewClusterRouter("node1", "localhost:9001", lp, rm, 9000, "")
+	router := NewClusterRouter("node1", "localhost:9001", lp, rm, 9000, "", nil)
 
 	t.Run("ForwardToLeader - Leader is self (error case)", func(t *testing.T) {
 		rm.isLeader = false

--- a/pkg/cluster/controller/router.go
+++ b/pkg/cluster/controller/router.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -29,6 +31,7 @@ type ClusterRouter struct {
 	clientHost     string
 	internalPort   int
 	internalTLS    *tls.Config
+	internalToken  string
 	timeout        time.Duration
 	localProcessor LocalProcessor
 
@@ -40,9 +43,11 @@ type ClusterRouter struct {
 func NewClusterRouter(brokerID, localAddr string, processor LocalProcessor, rm RaftManager, clientPort int, clientHost string, cfg *config.Config) *ClusterRouter {
 	internalPort := 0
 	var internalTLS *tls.Config
+	internalToken := ""
 	if cfg != nil {
 		internalPort = cfg.InternalBrokerPort
 		internalTLS = cfg.InternalClientTLSConfig()
+		internalToken = cfg.InternalAuthToken
 	}
 	return &ClusterRouter{
 		brokerID:       brokerID,
@@ -52,6 +57,7 @@ func NewClusterRouter(brokerID, localAddr string, processor LocalProcessor, rm R
 		clientHost:     clientHost,
 		internalPort:   internalPort,
 		internalTLS:    internalTLS,
+		internalToken:  internalToken,
 		timeout:        5 * time.Second,
 		localProcessor: processor,
 	}
@@ -234,7 +240,7 @@ func (r *ClusterRouter) forwardDataWithTimeout(addr string, data []byte) (string
 	}
 
 	clientAddr := r.brokerCommandAddr(host)
-	return r.sendDataRequest(clientAddr, data)
+	return r.sendDataRequest(clientAddr, r.wrapInternalBatch(data))
 }
 
 func (r *ClusterRouter) brokerCommandAddr(host string) string {
@@ -242,7 +248,7 @@ func (r *ClusterRouter) brokerCommandAddr(host string) string {
 	if r.internalPort > 0 {
 		port = r.internalPort
 	}
-	return fmt.Sprintf("%s:%d", host, port)
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func (r *ClusterRouter) processLocally(req string) string {
@@ -252,18 +258,54 @@ func (r *ClusterRouter) processLocally(req string) string {
 	return "ERROR: local_processor_not_configured"
 }
 
+func (r *ClusterRouter) withInternalToken(command string) string {
+	if r.internalToken == "" {
+		return command
+	}
+	if _, payload, err := util.DecodeMessage([]byte(command)); err == nil {
+		return string(util.EncodeMessage("", injectInternalToken(payload, r.internalToken)))
+	}
+	return injectInternalToken(command, r.internalToken)
+}
+
+func injectInternalToken(command, token string) string {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" || strings.Contains(trimmed, " internal_token=") || strings.HasPrefix(trimmed, "internal_token=") {
+		return command
+	}
+	parts := strings.Fields(trimmed)
+	if len(parts) == 0 {
+		return command
+	}
+	commandName := parts[0]
+	rest := strings.TrimSpace(trimmed[len(commandName):])
+	if rest == "" {
+		return commandName + " internal_token=" + token
+	}
+	return commandName + " internal_token=" + token + " " + rest
+}
+
+func (r *ClusterRouter) wrapInternalBatch(data []byte) []byte {
+	if r.internalToken == "" {
+		return data
+	}
+	payload := base64.StdEncoding.EncodeToString(data)
+	return []byte("INTERNAL_BATCH internal_token=" + r.internalToken + " payload=" + payload)
+}
 func (r *ClusterRouter) sendRequest(addr, command string) (string, error) {
-	return r.sendDataRequest(addr, []byte(command))
+	return r.sendDataRequest(addr, []byte(r.withInternalToken(command)))
 }
 
 func (r *ClusterRouter) sendDataRequest(addr string, data []byte) (string, error) {
-	dialer := &net.Dialer{Timeout: r.timeout}
 	var conn net.Conn
 	var err error
 	if r.internalTLS != nil {
-		conn, err = tls.DialWithDialer(dialer, "tcp", addr, r.internalTLS)
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		tlsDialer := &tls.Dialer{NetDialer: &net.Dialer{}, Config: r.internalTLS}
+		conn, err = tlsDialer.DialContext(ctx, "tcp", addr)
 	} else {
-		conn, err = dialer.Dial("tcp", addr)
+		conn, err = (&net.Dialer{Timeout: r.timeout}).Dial("tcp", addr)
 	}
 	if err != nil {
 		return "", err

--- a/pkg/cluster/controller/router.go
+++ b/pkg/cluster/controller/router.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"crypto/tls"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/util"
 )
 
@@ -25,6 +27,8 @@ type ClusterRouter struct {
 	rm             RaftManager
 	clientPort     int
 	clientHost     string
+	internalPort   int
+	internalTLS    *tls.Config
 	timeout        time.Duration
 	localProcessor LocalProcessor
 
@@ -33,13 +37,21 @@ type ClusterRouter struct {
 	coordBrokerHash string // hash of active broker IDs to detect changes
 }
 
-func NewClusterRouter(brokerID, localAddr string, processor LocalProcessor, rm RaftManager, clientPort int, clientHost string) *ClusterRouter {
+func NewClusterRouter(brokerID, localAddr string, processor LocalProcessor, rm RaftManager, clientPort int, clientHost string, cfg *config.Config) *ClusterRouter {
+	internalPort := 0
+	var internalTLS *tls.Config
+	if cfg != nil {
+		internalPort = cfg.InternalBrokerPort
+		internalTLS = cfg.InternalClientTLSConfig()
+	}
 	return &ClusterRouter{
 		brokerID:       brokerID,
 		LocalAddr:      localAddr,
 		rm:             rm,
 		clientPort:     clientPort,
 		clientHost:     clientHost,
+		internalPort:   internalPort,
+		internalTLS:    internalTLS,
 		timeout:        5 * time.Second,
 		localProcessor: processor,
 	}
@@ -170,7 +182,7 @@ func (r *ClusterRouter) forwardWithTimeout(addr, req string) (string, error) {
 		return "", fmt.Errorf("invalid address format %s: %w", addr, splitErr)
 	}
 
-	clientAddr := fmt.Sprintf("%s:%d", host, r.clientPort)
+	clientAddr := r.brokerCommandAddr(host)
 	resp, err := r.sendRequest(clientAddr, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to forward request to %s: %w", clientAddr, err)
@@ -221,8 +233,16 @@ func (r *ClusterRouter) forwardDataWithTimeout(addr string, data []byte) (string
 		return "", fmt.Errorf("invalid address format %s: %w", addr, splitErr)
 	}
 
-	clientAddr := fmt.Sprintf("%s:%d", host, r.clientPort)
+	clientAddr := r.brokerCommandAddr(host)
 	return r.sendDataRequest(clientAddr, data)
+}
+
+func (r *ClusterRouter) brokerCommandAddr(host string) string {
+	port := r.clientPort
+	if r.internalPort > 0 {
+		port = r.internalPort
+	}
+	return fmt.Sprintf("%s:%d", host, port)
 }
 
 func (r *ClusterRouter) processLocally(req string) string {
@@ -237,7 +257,14 @@ func (r *ClusterRouter) sendRequest(addr, command string) (string, error) {
 }
 
 func (r *ClusterRouter) sendDataRequest(addr string, data []byte) (string, error) {
-	conn, err := net.DialTimeout("tcp", addr, r.timeout)
+	dialer := &net.Dialer{Timeout: r.timeout}
+	var conn net.Conn
+	var err error
+	if r.internalTLS != nil {
+		conn, err = tls.DialWithDialer(dialer, "tcp", addr, r.internalTLS)
+	} else {
+		conn, err = dialer.Dial("tcp", addr)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cluster/controller/router_test.go
+++ b/pkg/cluster/controller/router_test.go
@@ -224,4 +224,12 @@ func TestClusterRouterBrokerCommandAddrPrefersInternalPort(t *testing.T) {
 	if got := fallback.brokerCommandAddr("broker-2"); got != "broker-2:7000" {
 		t.Fatalf("expected client port fallback, got %s", got)
 	}
+
+	if got := router.brokerCommandAddr("2001:db8::1"); got != "[2001:db8::1]:19000" {
+		t.Fatalf("expected bracketed IPv6 internal address, got %s", got)
+	}
+
+	if got := fallback.brokerCommandAddr("2001:db8::2"); got != "[2001:db8::2]:7000" {
+		t.Fatalf("expected bracketed IPv6 client address, got %s", got)
+	}
 }

--- a/pkg/cluster/controller/router_test.go
+++ b/pkg/cluster/controller/router_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cursus-io/cursus/pkg/cluster/replication"
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
+	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/hashicorp/raft"
 )
@@ -57,7 +58,7 @@ func TestClusterRouter_LocalProcess(t *testing.T) {
 	processor := &MockLocalProcessor{}
 
 	rm := &MockRaftManager{isLeader: true}
-	router := NewClusterRouter("node1", "localhost:7000", processor, rm, 9000, "")
+	router := NewClusterRouter("node1", "localhost:7000", processor, rm, 9000, "", nil)
 
 	if router.processLocally("CREATE topic=t1") != "OK" {
 		t.Fatal("Expected local processing to succeed")
@@ -75,7 +76,7 @@ func TestClusterRouter_FindCoordinator(t *testing.T) {
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"node3\",\"addr\":\"localhost:7003\",\"status\":\"active\"}")})
 
 	rm := &MockRaftManager{isLeader: true, mockFSM: mockFSM}
-	router := NewClusterRouter("node1", "localhost:7001", nil, rm, 7000, "")
+	router := NewClusterRouter("node1", "localhost:7001", nil, rm, 7000, "", nil)
 
 	group1 := "group-a"
 	id1, addr1, err := router.FindCoordinator(group1)
@@ -112,7 +113,7 @@ func TestClusterRouter_FindCoordinator_CacheRebuild(t *testing.T) {
 	mockFSM.Apply(&raft.Log{Data: []byte("REGISTER:{\"id\":\"n2\",\"addr\":\"localhost:7002\",\"status\":\"active\"}")})
 
 	rm := &MockRaftManager{isLeader: true, mockFSM: mockFSM}
-	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "")
+	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "", nil)
 
 	// First call builds ring
 	id1, _, err := router.FindCoordinator("group-x")
@@ -138,7 +139,7 @@ func TestClusterRouter_FindCoordinator_CacheRebuild(t *testing.T) {
 func TestClusterRouter_FindCoordinator_NoActiveBrokers(t *testing.T) {
 	mockFSM := fsm.NewBrokerFSM(nil, nil)
 	rm := &MockRaftManager{isLeader: true, mockFSM: mockFSM}
-	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "")
+	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "", nil)
 
 	_, _, err := router.FindCoordinator("group-x")
 	if err == nil {
@@ -148,7 +149,7 @@ func TestClusterRouter_FindCoordinator_NoActiveBrokers(t *testing.T) {
 
 func TestClusterRouter_FindCoordinator_NilFSM(t *testing.T) {
 	rm := &MockRaftManager{isLeader: true, mockFSM: nil}
-	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "")
+	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "", nil)
 
 	_, _, err := router.FindCoordinator("group-x")
 	if err == nil {
@@ -162,7 +163,7 @@ func TestClusterRouter_ForwardToCoordinator_Local(t *testing.T) {
 
 	processor := &MockLocalProcessor{}
 	rm := &MockRaftManager{isLeader: true, mockFSM: mockFSM}
-	router := NewClusterRouter("n1", "localhost:7001", processor, rm, 7000, "")
+	router := NewClusterRouter("n1", "localhost:7001", processor, rm, 7000, "", nil)
 
 	// With only one broker, all groups map to n1 -> local processing
 	resp, err := router.ForwardToCoordinator("any-group", "HEARTBEAT group=any-group member=m1")
@@ -187,7 +188,7 @@ func TestClusterRouter_ForwardToPartitionLeader_Local(t *testing.T) {
 
 	processor := &MockLocalProcessor{}
 	rm := &MockRaftManager{isLeader: true, mockFSM: mockFSM}
-	router := NewClusterRouter("n1", "localhost:7001", processor, rm, 7000, "")
+	router := NewClusterRouter("n1", "localhost:7001", processor, rm, 7000, "", nil)
 
 	resp, err := router.ForwardToPartitionLeader("t1", 0, "PUBLISH topic=t1 message=hello")
 	if err != nil {
@@ -201,7 +202,7 @@ func TestClusterRouter_ForwardToPartitionLeader_Local(t *testing.T) {
 func TestClusterRouter_ForwardToLeader_IsLeader(t *testing.T) {
 	processor := &MockLocalProcessor{}
 	rm := &MockRaftManager{isLeader: true}
-	router := NewClusterRouter("n1", "localhost:7001", processor, rm, 7000, "")
+	router := NewClusterRouter("n1", "localhost:7001", processor, rm, 7000, "", nil)
 
 	resp, err := router.ForwardToLeader("LIST")
 	if err != nil {
@@ -209,5 +210,18 @@ func TestClusterRouter_ForwardToLeader_IsLeader(t *testing.T) {
 	}
 	if resp != "OK" {
 		t.Fatalf("Expected OK, got %s", resp)
+	}
+}
+
+func TestClusterRouterBrokerCommandAddrPrefersInternalPort(t *testing.T) {
+	rm := &MockRaftManager{isLeader: true}
+	router := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "", &config.Config{InternalBrokerPort: 19000})
+	if got := router.brokerCommandAddr("broker-2"); got != "broker-2:19000" {
+		t.Fatalf("expected internal broker port, got %s", got)
+	}
+
+	fallback := NewClusterRouter("n1", "localhost:7001", nil, rm, 7000, "", nil)
+	if got := fallback.brokerCommandAddr("broker-2"); got != "broker-2:7000" {
+		t.Fatalf("expected client port fallback, got %s", got)
 	}
 }

--- a/pkg/cluster/replication/fsm/fsm.go
+++ b/pkg/cluster/replication/fsm/fsm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/transaction"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
 	"github.com/hashicorp/raft"
@@ -60,6 +61,7 @@ type BrokerFSMState struct {
 	PartitionMetadata map[string]*PartitionMetadata                  `json:"partitionMetadata"`
 	ProducerState     map[string]map[int]map[string]ProducerSequence `json:"producerState"`
 	GroupState        map[string]*coordinator.GroupStateSnapshot     `json:"groupState,omitempty"`
+	TransactionState  map[string]*transaction.Snapshot               `json:"transactionState,omitempty"`
 }
 
 type BrokerFSM struct {
@@ -72,8 +74,10 @@ type BrokerFSM struct {
 	producerState     map[string]map[int]map[string]ProducerSequence // Topic -> Partition -> ProducerID -> Last Epoch/Seq
 	applied           uint64
 
-	tm *topic.TopicManager
-	cd *coordinator.Coordinator
+	tm                       *topic.TopicManager
+	cd                       *coordinator.Coordinator
+	txn                      *transaction.Manager
+	restoredTransactionState map[string]*transaction.Snapshot
 }
 
 func NewBrokerFSM(tm *topic.TopicManager, cd *coordinator.Coordinator) *BrokerFSM {
@@ -114,6 +118,17 @@ func (f *BrokerFSM) SetCoordinator(cd *coordinator.Coordinator) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.cd = cd
+}
+
+func (f *BrokerFSM) SetTransactionManager(txn *transaction.Manager) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.txn = txn
+	if f.txn != nil && f.restoredTransactionState != nil {
+		f.txn.ImportState(f.restoredTransactionState)
+		util.Info("FSM: Imported %d deferred restored transactions", len(f.restoredTransactionState))
+		f.restoredTransactionState = nil
+	}
 }
 
 func (f *BrokerFSM) Apply(log *raft.Log) interface{} {
@@ -161,6 +176,8 @@ func (f *BrokerFSM) Apply(log *raft.Log) interface{} {
 		res = f.applyOffsetSyncCommand(strings.TrimPrefix(data, "OFFSET_SYNC:"))
 	case strings.HasPrefix(data, "BATCH_OFFSET:"):
 		res = f.applyBatchOffsetSyncCommand(strings.TrimPrefix(data, "BATCH_OFFSET:"))
+	case strings.HasPrefix(data, "TXN_SYNC:"):
+		res = f.applyTransactionSyncCommand(strings.TrimPrefix(data, "TXN_SYNC:"))
 	default:
 		res = f.handleUnknownCommand(data)
 	}
@@ -200,6 +217,8 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 		util.Info("FSM Restore: Validating snapshot Version 2 (with group state)")
 	case 3:
 		util.Info("FSM Restore: Validating snapshot Version 3 (with producer epochs)")
+	case 4:
+		util.Info("FSM Restore: Validating snapshot Version 4 (with transaction state)")
 	default:
 		return fmt.Errorf("unknown snapshot version: %d", state.Version)
 	}
@@ -220,6 +239,16 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 	if state.GroupState != nil && f.cd != nil {
 		f.cd.ImportState(state.GroupState)
 		util.Info("FSM Restore: Restored %d consumer groups from snapshot", len(state.GroupState))
+	}
+
+	if state.TransactionState != nil {
+		if f.txn != nil {
+			f.txn.ImportState(state.TransactionState)
+			util.Info("FSM Restore: Restored %d transactions from snapshot", len(state.TransactionState))
+		} else {
+			f.restoredTransactionState = state.TransactionState
+			util.Info("FSM Restore: Deferred %d transactions until transaction manager is attached", len(state.TransactionState))
+		}
 	}
 
 	util.Info("FSM restore completed: %d logs, %d brokers, %d partitions", len(state.Logs), len(state.Brokers), len(state.PartitionMetadata))
@@ -270,6 +299,10 @@ func (f *BrokerFSM) Snapshot() (raft.FSMSnapshot, error) {
 	if f.cd != nil {
 		groupState = f.cd.ExportState()
 	}
+	var transactionState map[string]*transaction.Snapshot
+	if f.txn != nil {
+		transactionState = f.txn.ExportState()
+	}
 
 	util.Debug("Creating FSM snapshot")
 	return &BrokerFSMSnapshot{
@@ -279,6 +312,7 @@ func (f *BrokerFSM) Snapshot() (raft.FSMSnapshot, error) {
 		partitionMetadata: metadataCopy,
 		producerState:     producerStateCopy,
 		groupState:        groupState,
+		transactionState:  transactionState,
 	}, nil
 }
 

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -76,7 +76,7 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 
 	replicationFactor := topicCmd.ReplicationFactor
 	if replicationFactor <= 0 {
-		replicationFactor = 3 // default, same as Kafka
+		replicationFactor = 3 // default small-cluster replication factor
 	}
 	if replicationFactor > len(brokers) {
 		util.Warn("FSM: Requested RF %d exceeds active brokers %d. Capping to %d", replicationFactor, len(brokers), len(brokers))

--- a/pkg/cluster/replication/fsm/fsm_snapshot.go
+++ b/pkg/cluster/replication/fsm/fsm_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/transaction"
 	"github.com/cursus-io/cursus/util"
 	"github.com/hashicorp/raft"
 )
@@ -15,17 +16,19 @@ type BrokerFSMSnapshot struct {
 	partitionMetadata map[string]*PartitionMetadata
 	producerState     map[string]map[int]map[string]ProducerSequence
 	groupState        map[string]*coordinator.GroupStateSnapshot
+	transactionState  map[string]*transaction.Snapshot
 }
 
 func (s *BrokerFSMSnapshot) Persist(sink raft.SnapshotSink) error {
 	state := BrokerFSMState{
-		Version:           3,
+		Version:           4,
 		Applied:           s.applied,
 		Logs:              s.logs,
 		Brokers:           s.brokers,
 		PartitionMetadata: s.partitionMetadata,
 		ProducerState:     s.producerState,
 		GroupState:        s.groupState,
+		TransactionState:  s.transactionState,
 	}
 
 	util.Debug("Persisting snapshot data")

--- a/pkg/cluster/replication/fsm/fsm_test.go
+++ b/pkg/cluster/replication/fsm/fsm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/transaction"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/hashicorp/raft"
 )
@@ -425,7 +426,7 @@ func TestBrokerFSM_TopicCreation_ReplicaSubset(t *testing.T) {
 func TestBrokerFSM_TopicCreation_DefaultRF_Capped(t *testing.T) {
 	fsm := newTestFSM()
 
-	// Register only 2 brokers — default RF=3 should be capped to 2.
+	// Register only 2 brokers - default RF=3 should be capped to 2.
 	for i := 1; i <= 2; i++ {
 		data, _ := json.Marshal(BrokerInfo{
 			ID:     fmt.Sprintf("broker-%d", i),
@@ -457,7 +458,7 @@ func TestBrokerFSM_TopicCreation_DefaultRF_Capped(t *testing.T) {
 func TestBrokerFSM_TopicCreation_DefaultRF_Satisfied(t *testing.T) {
 	fsm := newTestFSM()
 
-	// Register 5 brokers — enough to satisfy the default RF=3 without capping.
+	// Register 5 brokers - enough to satisfy the default RF=3 without capping.
 	// This proves that the default is actually 3 and not just "all available brokers".
 	for i := 1; i <= 5; i++ {
 		data, _ := json.Marshal(BrokerInfo{
@@ -894,5 +895,92 @@ func TestBrokerFSM_Snapshot_Restore_GroupState(t *testing.T) {
 	}
 	if group.Generation != cd.GetGeneration("test-group") {
 		t.Errorf("Generation mismatch: expected %d, got %d", cd.GetGeneration("test-group"), group.Generation)
+	}
+}
+
+func TestBrokerFSM_Snapshot_Restore_TransactionState(t *testing.T) {
+	cfg := &config.Config{LogDir: t.TempDir()}
+	tm := topic.NewTopicManager(cfg, &MockHandlerProvider{}, nil)
+	txnManager := transaction.NewManager()
+	f := NewBrokerFSM(tm, nil)
+	f.SetTransactionManager(txnManager)
+
+	producerID, epoch, initErr := txnManager.InitProducer("tx-restore")
+	if initErr != nil {
+		t.Fatalf("init producer failed: %v", initErr)
+	}
+	if err := txnManager.Begin("tx-restore", producerID, epoch); err != nil {
+		t.Fatalf("begin failed: %v", err)
+	}
+	if err := txnManager.AddOffsets("tx-restore", producerID, epoch, []transaction.OffsetOperation{{Topic: "orders", Group: "workers", Member: "member-1", Generation: 3, Partition: 0, Offset: 12}}); err != nil {
+		t.Fatalf("add offsets failed: %v", err)
+	}
+
+	snapshot, err := f.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	buf := new(bytes.Buffer)
+	sink := &MockSnapshotSink{Writer: buf}
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("Persist failed: %v", err)
+	}
+
+	restoredTxnManager := transaction.NewManager()
+	newFSM := NewBrokerFSM(tm, nil)
+	newFSM.SetTransactionManager(restoredTxnManager)
+	if err := newFSM.Restore(io.NopCloser(bytes.NewReader(buf.Bytes()))); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+
+	tx, err := restoredTxnManager.Status("tx-restore")
+	if err != nil {
+		t.Fatalf("restored transaction missing: %v", err)
+	}
+	if tx.Producer != producerID || tx.Epoch != epoch || len(tx.Offsets) != 1 || tx.Offsets[0].Offset != 12 {
+		t.Fatalf("unexpected restored transaction: %+v", tx)
+	}
+}
+func TestBrokerFSM_RestoreDefersTransactionStateUntilManagerAttached(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	hp := &MockHandlerProvider{}
+	tm := topic.NewTopicManager(cfg, hp, nil)
+	manager := transaction.NewManager()
+	f := NewBrokerFSM(tm, nil)
+	f.SetTransactionManager(manager)
+	producerID, epoch, initErr := manager.InitProducer("tx-deferred")
+	if initErr != nil {
+		t.Fatalf("init producer failed: %v", initErr)
+	}
+	if err := manager.Begin("tx-deferred", producerID, epoch); err != nil {
+		t.Fatalf("begin failed: %v", err)
+	}
+	if _, err := manager.PrepareCommit("tx-deferred", producerID, epoch); err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+
+	snapshot, err := f.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	buf := &bytes.Buffer{}
+	sink := &MockSnapshotSink{Writer: buf}
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("Persist failed: %v", err)
+	}
+
+	restored := NewBrokerFSM(tm, nil)
+	if err := restored.Restore(io.NopCloser(bytes.NewReader(buf.Bytes()))); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	restoredManager := transaction.NewManager()
+	restored.SetTransactionManager(restoredManager)
+	tx, err := restoredManager.Status("tx-deferred")
+	if err != nil {
+		t.Fatalf("restored transaction missing: %v", err)
+	}
+	if tx.State != transaction.StateCommitting || tx.Epoch != epoch {
+		t.Fatalf("unexpected restored transaction: %+v", tx)
 	}
 }

--- a/pkg/cluster/replication/fsm/fsm_transaction.go
+++ b/pkg/cluster/replication/fsm/fsm_transaction.go
@@ -1,0 +1,27 @@
+package fsm
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cursus-io/cursus/pkg/transaction"
+	"github.com/cursus-io/cursus/util"
+)
+
+func (f *BrokerFSM) applyTransactionSyncCommand(jsonData string) interface{} {
+	var cmd struct {
+		Transaction *transaction.Snapshot `json:"transaction"`
+	}
+	if err := json.Unmarshal([]byte(jsonData), &cmd); err != nil {
+		util.Error("FSM: Failed to unmarshal TXN_SYNC: %v", err)
+		return err
+	}
+	if cmd.Transaction == nil || cmd.Transaction.ID == "" {
+		return fmt.Errorf("invalid transaction sync payload")
+	}
+	if f.txn == nil {
+		return fmt.Errorf("transaction manager not available")
+	}
+	f.txn.ApplySnapshot(cmd.Transaction)
+	return nil
+}

--- a/pkg/cluster/replication/fsm/fsm_transaction.go
+++ b/pkg/cluster/replication/fsm/fsm_transaction.go
@@ -19,9 +19,12 @@ func (f *BrokerFSM) applyTransactionSyncCommand(jsonData string) interface{} {
 	if cmd.Transaction == nil || cmd.Transaction.ID == "" {
 		return fmt.Errorf("invalid transaction sync payload")
 	}
-	if f.txn == nil {
+	f.mu.RLock()
+	txn := f.txn
+	f.mu.RUnlock()
+	if txn == nil {
 		return fmt.Errorf("transaction manager not available")
 	}
-	f.txn.ApplySnapshot(cmd.Transaction)
+	txn.ApplySnapshot(cmd.Transaction)
 	return nil
 }

--- a/pkg/config/internal_tls_test.go
+++ b/pkg/config/internal_tls_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInternalBrokerMTLSConfigWithFixtureCertificates(t *testing.T) {
+	dir := t.TempDir()
+	caCertPEM, caKey, caCert := mustCreateTestCA(t)
+	brokerCertPEM, brokerKeyPEM := mustCreateBrokerCert(t, caCert, caKey)
+
+	caPath := filepath.Join(dir, "ca.pem")
+	certPath := filepath.Join(dir, "broker.pem")
+	keyPath := filepath.Join(dir, "broker-key.pem")
+	if err := os.WriteFile(caPath, caCertPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	if err := os.WriteFile(certPath, brokerCertPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, brokerKeyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.InternalUseTLS = true
+	cfg.InternalBrokerPort = 19000
+	cfg.InternalTLSCAPath = caPath
+	cfg.InternalTLSCertPath = certPath
+	cfg.InternalTLSKeyPath = keyPath
+	cfg.InternalTLSServerName = "localhost"
+	if err := cfg.loadInternalTLSConfig(); err != nil {
+		t.Fatalf("loadInternalTLSConfig failed: %v", err)
+	}
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", cfg.InternalServerTLSConfig())
+	if err != nil {
+		t.Fatalf("tls listen failed: %v", err)
+	}
+	defer listener.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+		_, err = conn.Write([]byte("ok"))
+		serverErr <- err
+	}()
+
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", listener.Addr().String(), cfg.InternalClientTLSConfig())
+	if err != nil {
+		t.Fatalf("tls dial failed: %v", err)
+	}
+	defer conn.Close()
+	buf := make([]byte, 2)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("tls read failed: %v", err)
+	}
+	if string(buf) != "ok" {
+		t.Fatalf("unexpected payload %q", string(buf))
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server write failed: %v", err)
+	}
+}
+
+func mustCreateTestCA(t *testing.T) ([]byte, *rsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "cursus-test-ca"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create ca cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, cert
+}
+
+func mustCreateBrokerCert(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey) ([]byte, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate broker key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		DNSNames:     []string{"localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create broker cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
+}

--- a/pkg/config/properties.go
+++ b/pkg/config/properties.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,6 +19,11 @@ var (
 	defaultConfig *Config
 	defaultOnce   sync.Once
 )
+
+type SASLUser struct {
+	Principal string `yaml:"principal" json:"principal"`
+	Token     string `yaml:"token" json:"token"`
+}
 
 type ConsumerGroupConfig struct {
 	Name            string         `yaml:"name" json:"name"`
@@ -62,20 +68,24 @@ type Config struct {
 
 	// distributed cluster
 	EnabledDistribution  bool     `yaml:"enabled_distribution" json:"distribution.enabled"`
+	InternalAuthToken    string   `yaml:"internal_auth_token" json:"distribution.internal_auth_token"`
+	InternalBrokerPort   int      `yaml:"internal_broker_port" json:"distribution.internal_broker_port"`
 	RaftPort             int      `yaml:"raft_port" json:"distribution.raft.port"`
 	DiscoveryPort        int      `yaml:"discovery_port" json:"distribution.discovery.port"`
 	RaftPeers            []string `yaml:"raft_peers" json:"distribution.raft.peers"`
 	StaticClusterMembers []string `yaml:"static_cluster_members" json:"distribution.static_cluster_members"`
 	BootstrapCluster     bool     `yaml:"bootstrap_cluster" json:"distribution.bootstrap"`
 
-	AdvertisedHost       string `yaml:"advertised_host" json:"distribution.advertised_host"`
-	AdvertisedBrokerPort int    `yaml:"advertised_broker_port" json:"distribution.advertised_broker_port"`
-	AdvertisedClientHost string `yaml:"advertised_client_host" json:"distribution.advertised_client_host"`
+	AdvertisedHost           string `yaml:"advertised_host" json:"distribution.advertised_host"`
+	AdvertisedBrokerPort     int    `yaml:"advertised_broker_port" json:"distribution.advertised_broker_port"`
+	AdvertisedClientHost     string `yaml:"advertised_client_host" json:"distribution.advertised_client_host"`
 	MinInSyncReplicas        int    `yaml:"min_insync_replicas" json:"min.insync.replicas"`
 	DefaultReplicationFactor int    `yaml:"default_replication_factor" json:"default.replication.factor"`
 
 	// idempotency
-	EnableIdempotence bool `yaml:"enable_idempotence" json:"enable.idempotence"`
+	EnableIdempotence           bool `yaml:"enable_idempotence" json:"enable.idempotence"`
+	ProducerStateTTLMS          int  `yaml:"producer_state_ttl_ms" json:"producer.state.ttl.ms"`
+	TransactionalIDExpirationMS int  `yaml:"transactional_id_expiration_ms" json:"transactional.id.expiration.ms"`
 
 	// consumer
 	ConsumerSessionTimeoutMS int                   `yaml:"consumer_session_timeout_ms" json:"consumer.session.timeout.ms"`
@@ -89,10 +99,20 @@ type Config struct {
 	StreamCommitInterval    time.Duration `yaml:"stream_commit_interval" json:"stream.commit.interval"`
 
 	// security
-	UseTLS      bool `yaml:"use_tls" json:"tls.enable"`
-	TLSCert     tls.Certificate
-	TLSCertPath string `yaml:"tls_cert_path" json:"tls.cert_path"`
-	TLSKeyPath  string `yaml:"tls_key_path" json:"tls.key_path"`
+	UseTLS                  bool `yaml:"use_tls" json:"tls.enable"`
+	TLSCert                 tls.Certificate
+	TLSCertPath             string `yaml:"tls_cert_path" json:"tls.cert_path"`
+	TLSKeyPath              string `yaml:"tls_key_path" json:"tls.key_path"`
+	InternalUseTLS          bool   `yaml:"internal_use_tls" json:"internal_tls.enable"`
+	InternalTLSCertPath     string `yaml:"internal_tls_cert_path" json:"internal_tls.cert_path"`
+	InternalTLSKeyPath      string `yaml:"internal_tls_key_path" json:"internal_tls.key_path"`
+	InternalTLSCAPath       string `yaml:"internal_tls_ca_path" json:"internal_tls.ca_path"`
+	InternalTLSServerName   string `yaml:"internal_tls_server_name" json:"internal_tls.server_name"`
+	InternalTLSCert         tls.Certificate
+	InternalTLSClientCAPool *x509.CertPool
+	InternalTLSRootCAPool   *x509.CertPool
+	EnableSASL              bool       `yaml:"enable_sasl" json:"sasl.enable"`
+	SASLUsers               []SASLUser `yaml:"sasl_users" json:"sasl.users"`
 }
 
 func DefaultConfig() *Config {
@@ -133,6 +153,8 @@ func DefaultConfig() *Config {
 
 			// distributed cluster
 			EnabledDistribution:      false,
+			InternalAuthToken:        "",
+			InternalBrokerPort:       0,
 			RaftPort:                 9001,
 			DiscoveryPort:            8000,
 			RaftPeers:                []string{},
@@ -144,7 +166,9 @@ func DefaultConfig() *Config {
 			DefaultReplicationFactor: 3,
 
 			// idempotency
-			EnableIdempotence: false,
+			EnableIdempotence:           false,
+			ProducerStateTTLMS:          30 * 60 * 1000,
+			TransactionalIDExpirationMS: 7 * 24 * 60 * 60 * 1000,
 
 			// consumer
 			ConsumerSessionTimeoutMS: 10000,
@@ -166,6 +190,10 @@ func DefaultConfig() *Config {
 	if defaultConfig.StaticClusterMembers != nil {
 		cfgCopy.StaticClusterMembers = make([]string, len(defaultConfig.StaticClusterMembers))
 		copy(cfgCopy.StaticClusterMembers, defaultConfig.StaticClusterMembers)
+	}
+	if defaultConfig.SASLUsers != nil {
+		cfgCopy.SASLUsers = make([]SASLUser, len(defaultConfig.SASLUsers))
+		copy(cfgCopy.SASLUsers, defaultConfig.SASLUsers)
 	}
 	if defaultConfig.StaticConsumerGroups != nil {
 		cfgCopy.StaticConsumerGroups = make([]ConsumerGroupConfig, len(defaultConfig.StaticConsumerGroups))
@@ -215,6 +243,8 @@ func LoadConfig() (*Config, error) {
 
 	// distributed cluster
 	flag.BoolVar(&cfg.EnabledDistribution, "enable-distribution", cfg.EnabledDistribution, "Enable distributed clustering")
+	flag.StringVar(&cfg.InternalAuthToken, "internal-auth-token", cfg.InternalAuthToken, "Shared token for broker-to-broker internal text commands")
+	flag.IntVar(&cfg.InternalBrokerPort, "internal-broker-port", cfg.InternalBrokerPort, "Dedicated broker-to-broker internal command port")
 	flag.IntVar(&cfg.RaftPort, "raft-port", cfg.RaftPort, "Raft port for replication")
 	flag.IntVar(&cfg.DiscoveryPort, "discovery-port", cfg.DiscoveryPort, "Discovery service port")
 	raftPeersFlag := flag.String("raft-peers", "", "Raft peer addresses (comma-separated)")
@@ -225,6 +255,8 @@ func LoadConfig() (*Config, error) {
 
 	// idempotency
 	flag.BoolVar(&cfg.EnableIdempotence, "enable-idempotence", cfg.EnableIdempotence, "Enable producer idempotency")
+	flag.IntVar(&cfg.ProducerStateTTLMS, "producer-state-ttl-ms", cfg.ProducerStateTTLMS, "Producer idempotency state TTL in milliseconds")
+	flag.IntVar(&cfg.TransactionalIDExpirationMS, "transactional-id-expiration-ms", cfg.TransactionalIDExpirationMS, "Completed transactional.id expiration in milliseconds")
 
 	// consumer
 	flag.IntVar(&cfg.ConsumerSessionTimeoutMS, "consumer-session-timeout", cfg.ConsumerSessionTimeoutMS, "Session timeout")
@@ -240,6 +272,12 @@ func LoadConfig() (*Config, error) {
 	flag.BoolVar(&cfg.UseTLS, "tls", cfg.UseTLS, "Enable TLS")
 	flag.StringVar(&cfg.TLSCertPath, "tls-cert", cfg.TLSCertPath, "TLS cert")
 	flag.StringVar(&cfg.TLSKeyPath, "tls-key", cfg.TLSKeyPath, "TLS key")
+	flag.BoolVar(&cfg.InternalUseTLS, "internal-tls", cfg.InternalUseTLS, "Enable mutual TLS on the internal broker listener")
+	flag.StringVar(&cfg.InternalTLSCertPath, "internal-tls-cert", cfg.InternalTLSCertPath, "Internal listener TLS certificate")
+	flag.StringVar(&cfg.InternalTLSKeyPath, "internal-tls-key", cfg.InternalTLSKeyPath, "Internal listener TLS private key")
+	flag.StringVar(&cfg.InternalTLSCAPath, "internal-tls-ca", cfg.InternalTLSCAPath, "CA used to verify internal broker certificates")
+	flag.StringVar(&cfg.InternalTLSServerName, "internal-tls-server-name", cfg.InternalTLSServerName, "Server name used by broker-to-broker mTLS clients")
+	flag.BoolVar(&cfg.EnableSASL, "enable-sasl", cfg.EnableSASL, "Enable SASL-style token authentication for client commands")
 
 	flag.Parse()
 
@@ -325,6 +363,8 @@ func LoadConfig() (*Config, error) {
 	overrideEnvInt(&cfg.BroadcastChannelBufferSize, "BROADCAST_CH_BUFFER")
 
 	overrideEnvBool(&cfg.EnabledDistribution, "ENABLE_DISTRIBUTION")
+	overrideEnvString(&cfg.InternalAuthToken, "INTERNAL_AUTH_TOKEN")
+	overrideEnvInt(&cfg.InternalBrokerPort, "INTERNAL_BROKER_PORT")
 	overrideEnvString(&cfg.AdvertisedHost, "ADVERTISED_HOST")
 	overrideEnvInt(&cfg.AdvertisedBrokerPort, "ADVERTISED_BROKER_PORT")
 	overrideEnvString(&cfg.AdvertisedClientHost, "ADVERTISED_CLIENT_HOST")
@@ -337,12 +377,33 @@ func LoadConfig() (*Config, error) {
 	overrideEnvInt(&cfg.DefaultReplicationFactor, "DEFAULT_REPLICATION_FACTOR")
 
 	overrideEnvBool(&cfg.EnableIdempotence, "ENABLE_IDEMPOTENCE")
+	overrideEnvInt(&cfg.ProducerStateTTLMS, "PRODUCER_STATE_TTL_MS")
+	overrideEnvInt(&cfg.TransactionalIDExpirationMS, "TRANSACTIONAL_ID_EXPIRATION_MS")
 
 	overrideEnvInt(&cfg.ConsumerSessionTimeoutMS, "CONSUMER_SESSION_TIMEOUT")
 	overrideEnvInt(&cfg.ConsumerHeartbeatCheckMS, "CONSUMER_HEARTBEAT_CHECK")
+	overrideEnvBool(&cfg.InternalUseTLS, "INTERNAL_USE_TLS")
+	overrideEnvString(&cfg.InternalTLSCertPath, "INTERNAL_TLS_CERT_PATH")
+	overrideEnvString(&cfg.InternalTLSKeyPath, "INTERNAL_TLS_KEY_PATH")
+	overrideEnvString(&cfg.InternalTLSCAPath, "INTERNAL_TLS_CA_PATH")
+	overrideEnvString(&cfg.InternalTLSServerName, "INTERNAL_TLS_SERVER_NAME")
+	overrideEnvBool(&cfg.EnableSASL, "ENABLE_SASL")
+	overrideEnvSASLUsers(&cfg.SASLUsers, "SASL_USERS")
 
 	cfg.Normalize()
 	util.SetLevel(cfg.LogLevel)
+
+	if cfg.EnabledDistribution {
+		if strings.TrimSpace(cfg.InternalAuthToken) == "" {
+			return nil, fmt.Errorf("internal_auth_token is required when enabled_distribution=true")
+		}
+		if strings.ContainsAny(cfg.InternalAuthToken, " \t\r\n") {
+			return nil, fmt.Errorf("internal_auth_token must not contain whitespace")
+		}
+	}
+	if err := cfg.loadInternalTLSConfig(); err != nil {
+		return nil, err
+	}
 
 	if cfg.UseTLS {
 		if cfg.TLSCertPath == "" || cfg.TLSKeyPath == "" {
@@ -356,4 +417,61 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func (cfg *Config) loadInternalTLSConfig() error {
+	if !cfg.InternalUseTLS {
+		return nil
+	}
+	if cfg.InternalBrokerPort <= 0 {
+		return fmt.Errorf("internal_use_tls requires internal_broker_port")
+	}
+	if cfg.InternalTLSCertPath == "" || cfg.InternalTLSKeyPath == "" || cfg.InternalTLSCAPath == "" {
+		return fmt.Errorf("internal TLS enabled but missing cert/key/ca path")
+	}
+	cert, err := tls.LoadX509KeyPair(cfg.InternalTLSCertPath, cfg.InternalTLSKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load internal TLS cert: %w", err)
+	}
+	// #nosec G304 -- internal CA path is broker operator supplied configuration.
+	caPEM, err := os.ReadFile(cfg.InternalTLSCAPath)
+	if err != nil {
+		return fmt.Errorf("failed to read internal TLS CA: %w", err)
+	}
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(caPEM) {
+		return fmt.Errorf("failed to parse internal TLS CA")
+	}
+	rootCAPool := x509.NewCertPool()
+	if !rootCAPool.AppendCertsFromPEM(caPEM) {
+		return fmt.Errorf("failed to parse internal TLS root CA")
+	}
+	cfg.InternalTLSCert = cert
+	cfg.InternalTLSClientCAPool = clientCAPool
+	cfg.InternalTLSRootCAPool = rootCAPool
+	return nil
+}
+
+func (cfg *Config) InternalServerTLSConfig() *tls.Config {
+	if cfg == nil || !cfg.InternalUseTLS {
+		return nil
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cfg.InternalTLSCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    cfg.InternalTLSClientCAPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+func (cfg *Config) InternalClientTLSConfig() *tls.Config {
+	if cfg == nil || !cfg.InternalUseTLS {
+		return nil
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cfg.InternalTLSCert},
+		RootCAs:      cfg.InternalTLSRootCAPool,
+		ServerName:   cfg.InternalTLSServerName,
+		MinVersion:   tls.VersionTLS12,
+	}
 }

--- a/pkg/config/properties_helper.go
+++ b/pkg/config/properties_helper.go
@@ -230,10 +230,16 @@ func overrideEnvSASLUsers(target *[]SASLUser, key string) {
 		users := make([]SASLUser, 0, len(entries))
 		for _, entry := range entries {
 			parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
-			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			principal := strings.TrimSpace(parts[0])
+			token := ""
+			if len(parts) == 2 {
+				token = strings.TrimSpace(parts[1])
+			}
+			if len(parts) != 2 || principal == "" || token == "" {
+				util.Warn("Skipping invalid %s entry %q (expected principal:token)", key, entry)
 				continue
 			}
-			users = append(users, SASLUser{Principal: parts[0], Token: parts[1]})
+			users = append(users, SASLUser{Principal: principal, Token: token})
 		}
 		*target = users
 	}

--- a/pkg/config/properties_helper.go
+++ b/pkg/config/properties_helper.go
@@ -101,6 +101,9 @@ func (cfg *Config) Normalize() {
 	}
 
 	// distributed cluster
+	if cfg.InternalBrokerPort < 0 {
+		cfg.InternalBrokerPort = 0
+	}
 	if cfg.RaftPort <= 0 {
 		cfg.RaftPort = 9001
 	}
@@ -112,6 +115,13 @@ func (cfg *Config) Normalize() {
 	}
 	if cfg.MinInSyncReplicas <= 0 {
 		cfg.MinInSyncReplicas = 2
+	}
+
+	if cfg.ProducerStateTTLMS <= 0 {
+		cfg.ProducerStateTTLMS = 30 * 60 * 1000
+	}
+	if cfg.TransactionalIDExpirationMS <= 0 {
+		cfg.TransactionalIDExpirationMS = 7 * 24 * 60 * 60 * 1000
 	}
 
 	// consumer
@@ -211,5 +221,20 @@ func overrideEnvStringSlice(target *[]string, key string) {
 			}
 		}
 		*target = result
+	}
+}
+
+func overrideEnvSASLUsers(target *[]SASLUser, key string) {
+	if v := os.Getenv(key); v != "" {
+		entries := strings.Split(v, ",")
+		users := make([]SASLUser, 0, len(entries))
+		for _, entry := range entries {
+			parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				continue
+			}
+			users = append(users, SASLUser{Principal: parts[0], Token: parts[1]})
+		}
+		*target = users
 	}
 }

--- a/pkg/controller/auth.go
+++ b/pkg/controller/auth.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+func (ch *CommandHandler) handleAuth(cmd string, ctx *ClientContext) string {
+	args := parseKeyValueArgs(cmd[len("AUTH "):])
+	principal := strings.TrimSpace(args["principal"])
+	token := args["token"]
+	if principal == "" || token == "" {
+		return "ERROR: invalid_auth command=AUTH"
+	}
+	if !ch.validateSASLToken(principal, token) {
+		return "ERROR: authentication_failed mechanism=PLAIN"
+	}
+	if ctx != nil {
+		ctx.Principal = principal
+		ctx.Authenticated = true
+	}
+	return fmt.Sprintf("OK principal=%s authenticated=true", principal)
+}
+
+func (ch *CommandHandler) authenticateInline(args map[string]string, ctx *ClientContext) string {
+	principal := strings.TrimSpace(args["principal"])
+	token := args["auth_token"]
+	if principal == "" && token == "" {
+		return ""
+	}
+	if principal == "" || token == "" {
+		return "ERROR: invalid_auth reason=principal_and_auth_token_required"
+	}
+	if !ch.validateSASLToken(principal, token) {
+		return "ERROR: authentication_failed mechanism=PLAIN"
+	}
+	if ctx != nil {
+		ctx.Principal = principal
+		ctx.Authenticated = true
+	}
+	return ""
+}
+
+func (ch *CommandHandler) validateSASLToken(principal, token string) bool {
+	if ch == nil || ch.Config == nil || !ch.Config.EnableSASL {
+		return false
+	}
+	for _, user := range ch.Config.SASLUsers {
+		if user.Principal == principal && user.Token == token {
+			return true
+		}
+	}
+	return false
+}
+
+func principalFromContext(ctx *ClientContext) string {
+	if ctx == nil || !ctx.Authenticated {
+		return ""
+	}
+	return ctx.Principal
+}
+
+func (ch *CommandHandler) authorizeTopicRead(policy topic.Policy, ctx *ClientContext) string {
+	if policy.CanReadPrincipal(principalFromContext(ctx)) {
+		return ""
+	}
+	return "ERROR: NOT_AUTHORIZED_FOR_TOPIC operation=read"
+}
+
+func (ch *CommandHandler) authorizeTopicWrite(policy topic.Policy, ctx *ClientContext) string {
+	if policy.CanWritePrincipal(principalFromContext(ctx)) {
+		return ""
+	}
+	return "ERROR: NOT_AUTHORIZED_FOR_TOPIC operation=write"
+}

--- a/pkg/controller/auth.go
+++ b/pkg/controller/auth.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"strings"
 
@@ -48,13 +49,16 @@ func (ch *CommandHandler) validateSASLToken(principal, token string) bool {
 		return false
 	}
 	for _, user := range ch.Config.SASLUsers {
-		if user.Principal == principal && user.Token == token {
+		if user.Principal == principal && constantTimeStringEqual(user.Token, token) {
 			return true
 		}
 	}
 	return false
 }
 
+func constantTimeStringEqual(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
 func principalFromContext(ctx *ClientContext) string {
 	if ctx == nil || !ctx.Authenticated {
 		return ""

--- a/pkg/controller/auth_test.go
+++ b/pkg/controller/auth_test.go
@@ -81,6 +81,72 @@ func TestSASLACLGuardsPublishAndConsume(t *testing.T) {
 	}
 }
 
+func TestListOffsetsRequiresReadACL(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnableSASL = true
+	cfg.SASLUsers = []config.SASLUser{{Principal: "alice", Token: "secret"}}
+
+	storage := &authTestStorage{}
+	tm := topic.NewTopicManager(cfg, &authStorageProvider{storage: storage}, nil)
+	if err := tm.CreateTopicWithPolicy("offset-acl-topic", 1, false, false, topic.Policy{
+		AuthPolicy: topic.AuthPolicyACL,
+		ReadACL:    []string{"alice"},
+		WriteACL:   []string{"alice"},
+	}); err != nil {
+		t.Fatalf("CreateTopicWithPolicy failed: %v", err)
+	}
+
+	ch := NewCommandHandler(tm, cfg, nil, nil, nil)
+	unauth := ch.HandleCommand("LIST_OFFSETS topic=offset-acl-topic", NewClientContext("", 0))
+	if !strings.Contains(unauth, "NOT_AUTHORIZED_FOR_TOPIC") {
+		t.Fatalf("expected unauthenticated LIST_OFFSETS to be denied, got %q", unauth)
+	}
+
+	auth := ch.HandleCommand("LIST_OFFSETS topic=offset-acl-topic principal=alice auth_token=secret", NewClientContext("", 0))
+	if !strings.HasPrefix(auth, "OK") {
+		t.Fatalf("expected authenticated LIST_OFFSETS success, got %q", auth)
+	}
+}
+
+func TestPublicPublishCannotUseInternalTxnFlag(t *testing.T) {
+	cfg := config.DefaultConfig()
+	storage := &authTestStorage{}
+	tm := topic.NewTopicManager(cfg, &authStorageProvider{storage: storage}, nil)
+	if err := tm.CreateTopicWithPolicy("txn-internal-topic", 1, false, false, topic.DefaultPolicy()); err != nil {
+		t.Fatalf("CreateTopicWithPolicy failed: %v", err)
+	}
+
+	ch := NewCommandHandler(tm, cfg, nil, nil, nil)
+	resp := ch.HandleCommand("PUBLISH topic=txn-internal-topic producerId=p1 internal_txn_publish=true message=blocked", NewClientContext("", 0))
+	if !strings.Contains(resp, "internal_txn_publish_forbidden") {
+		t.Fatalf("expected public internal transaction publish to be rejected, got %q", resp)
+	}
+}
+func TestCommitOffsetOwnershipOnlyRequiresMemberGeneration(t *testing.T) {
+	cfg := config.DefaultConfig()
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &dummyPublisher{})
+	ch := NewCommandHandler(nil, cfg, coord, nil, nil)
+
+	resp := ch.HandleCommand("COMMIT_OFFSET topic=t1 group=g1 partition=0 offset=1 validate_only=true ownership_only=true", NewClientContext("", 0))
+	if !strings.Contains(resp, "missing_ownership_params") {
+		t.Fatalf("expected missing ownership params, got %q", resp)
+	}
+}
+
+func TestPublishRejectsMalformedControlBatchMetadata(t *testing.T) {
+	cfg := config.DefaultConfig()
+	storage := &authTestStorage{}
+	tm := topic.NewTopicManager(cfg, &authStorageProvider{storage: storage}, nil)
+	if err := tm.CreateTopicWithPolicy("txn-control-topic", 1, false, false, topic.DefaultPolicy()); err != nil {
+		t.Fatalf("CreateTopicWithPolicy failed: %v", err)
+	}
+
+	ch := NewCommandHandler(tm, cfg, nil, nil, nil)
+	resp := ch.HandleCommand("PUBLISH topic=txn-control-topic producerId=p1 partition=0 seqNum=1 epoch=0 internal_txn_publish=true control_batch_version=oops message=blocked", NewInternalClientContext("", 0))
+	if !strings.Contains(resp, "invalid_control_batch_version") {
+		t.Fatalf("expected invalid control batch version, got %q", resp)
+	}
+}
 func TestTransactionMarkerRequiresControlBatchMetadata(t *testing.T) {
 	tx := &transaction.Transaction{
 		ID:       "txn-1",

--- a/pkg/controller/auth_test.go
+++ b/pkg/controller/auth_test.go
@@ -1,0 +1,187 @@
+package controller
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/transaction"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
+)
+
+func TestSASLACLGuardsPublishAndConsume(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnableSASL = true
+	cfg.SASLUsers = []config.SASLUser{{Principal: "alice", Token: "secret"}}
+
+	storage := &authTestStorage{messages: []types.Message{{Offset: 0, Payload: "ready"}}}
+	tm := topic.NewTopicManager(cfg, &authStorageProvider{storage: storage}, nil)
+	err := tm.CreateTopicWithPolicy("acl-topic", 1, false, false, topic.Policy{
+		AuthPolicy: topic.AuthPolicyACL,
+		ReadACL:    []string{"alice"},
+		WriteACL:   []string{"alice"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopicWithPolicy failed: %v", err)
+	}
+
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &dummyPublisher{})
+	if err := coord.RegisterGroup("acl-topic", "acl-group", 1); err != nil {
+		t.Fatalf("RegisterGroup failed: %v", err)
+	}
+	ch := NewCommandHandler(tm, cfg, coord, nil, nil)
+	ctx := NewClientContext("acl-group", 0)
+
+	unauth := ch.HandleCommand("PUBLISH topic=acl-topic producerId=p1 message=nope", NewClientContext("", 0))
+	if !strings.Contains(unauth, "NOT_AUTHORIZED_FOR_TOPIC") {
+		t.Fatalf("expected unauthenticated publish to be denied, got %q", unauth)
+	}
+
+	auth := ch.HandleCommand("AUTH principal=alice token=secret", ctx)
+	if !strings.HasPrefix(auth, "OK") {
+		t.Fatalf("expected AUTH success, got %q", auth)
+	}
+
+	published := ch.HandleCommand("PUBLISH topic=acl-topic producerId=p1 message=ok", ctx)
+	if !strings.HasPrefix(published, "OK") && !strings.HasPrefix(published, "{") {
+		t.Fatalf("expected authenticated publish success, got %q", published)
+	}
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := ch.HandleConsumeCommand(server, "CONSUME topic=acl-topic partition=0 offset=0 group=acl-group member=alice batch=1", ctx)
+		errCh <- err
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	data, err := util.ReadWithLength(client)
+	if err != nil {
+		t.Fatalf("ReadWithLength failed: %v", err)
+	}
+	batch, err := util.DecodeBatchMessages(data)
+	if err != nil {
+		t.Fatalf("DecodeBatchMessages failed: %v", err)
+	}
+	if len(batch.Messages) != 1 || batch.Messages[0].Payload != "ready" {
+		t.Fatalf("unexpected consume batch: %+v", batch.Messages)
+	}
+	_ = client.Close()
+	if err := <-errCh; err != nil && !strings.Contains(err.Error(), "closed pipe") && !strings.Contains(err.Error(), "EOF") {
+		t.Fatalf("consume failed: %v", err)
+	}
+}
+
+func TestTransactionMarkerRequiresControlBatchMetadata(t *testing.T) {
+	tx := &transaction.Transaction{
+		ID:       "txn-1",
+		Producer: "producer-1",
+		Epoch:    4,
+		State:    transaction.StateCommitting,
+		Messages: []transaction.MessageOperation{{
+			Topic:     "txn-topic",
+			Partition: 0,
+			Message: types.Message{
+				ProducerID:      "producer-1",
+				SeqNum:          1,
+				Epoch:           4,
+				TransactionalID: "txn-1",
+				Payload:         "value",
+			},
+		}},
+	}
+	ch := NewCommandHandler(nil, config.DefaultConfig(), nil, nil, nil)
+	msg := types.Message{
+		ProducerID:        transactionMarkerProducerID(tx, types.TransactionMarkerCommit),
+		SeqNum:            1,
+		Epoch:             tx.Epoch,
+		TransactionalID:   tx.ID,
+		TransactionState:  types.TransactionStateCommitted,
+		TransactionMarker: types.TransactionMarkerCommit,
+	}
+
+	errResp := ch.validateTransactionMarkerPublish(tx, "txn-topic", 0, &msg)
+	if !strings.Contains(errResp, "invalid_transaction_control_batch") {
+		t.Fatalf("expected invalid control batch, got %q", errResp)
+	}
+
+	msg.ControlBatchType = types.ControlBatchTransaction
+	msg.ControlBatchVersion = types.ControlBatchVersionCursusV2
+	msg.ControlBatchCoordinatorEpoch = tx.Epoch
+	key, value, err := transactionMarkerControlBytes(types.TransactionMarkerCommit, tx.Epoch)
+	if err != nil {
+		t.Fatalf("transactionMarkerControlBytes failed: %v", err)
+	}
+	msg.ControlBatchKey = key
+	msg.ControlBatchValue = value
+	if resp := ch.validateTransactionMarkerPublish(tx, "txn-topic", 0, &msg); resp != "" {
+		t.Fatalf("expected valid transaction marker, got %q", resp)
+	}
+}
+
+type authStorageProvider struct {
+	storage types.StorageHandler
+}
+
+func (p *authStorageProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	return p.storage, nil
+}
+
+type authTestStorage struct {
+	messages []types.Message
+}
+
+func (s *authTestStorage) ReadMessages(offset uint64, max int) ([]types.Message, error) {
+	var out []types.Message
+	for _, msg := range s.messages {
+		if msg.Offset >= offset {
+			out = append(out, msg)
+			if len(out) == max {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *authTestStorage) GetFirstOffset() uint64 {
+	if len(s.messages) == 0 {
+		return 0
+	}
+	return s.messages[0].Offset
+}
+
+func (s *authTestStorage) tailOffset() uint64 {
+	if len(s.messages) == 0 {
+		return 0
+	}
+	return s.messages[len(s.messages)-1].Offset + 1
+}
+
+func (s *authTestStorage) GetAbsoluteOffset() uint64 { return s.tailOffset() }
+func (s *authTestStorage) GetFlushedOffset() uint64  { return s.tailOffset() }
+func (s *authTestStorage) GetLatestOffset() uint64   { return s.tailOffset() }
+func (s *authTestStorage) GetSegmentPath(uint64) string {
+	return ""
+}
+func (s *authTestStorage) AppendMessage(string, int, *types.Message) (uint64, error) {
+	return 0, nil
+}
+func (s *authTestStorage) AppendMessageSync(string, int, *types.Message) (uint64, error) {
+	return 0, nil
+}
+func (s *authTestStorage) AppendMessageWithOffset(string, int, *types.Message) error {
+	return nil
+}
+func (s *authTestStorage) WriteBatch([]types.DiskMessage) error { return nil }
+func (s *authTestStorage) Flush()                               {}
+func (s *authTestStorage) Close() error                         { return nil }

--- a/pkg/controller/cluster_handler.go
+++ b/pkg/controller/cluster_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -116,10 +117,18 @@ const coordCacheTTL = 30 * time.Second
 // checkCoordinator checks if this broker is the coordinator for the given group.
 // Returns (addr, false) if another broker is coordinator, or (_, true) if we are.
 func (ch *CommandHandler) checkCoordinator(groupName string) (AdvertisedAddr, bool) {
+	return ch.checkCoordinatorKey(groupName, fmt.Sprintf("FIND_COORDINATOR group=%s", groupName))
+}
+
+func (ch *CommandHandler) checkTransactionCoordinator(txnID string) (AdvertisedAddr, bool) {
+	return ch.checkCoordinatorKey(transactionCoordinatorKey(txnID), fmt.Sprintf("FIND_COORDINATOR transactional_id=%s", txnID))
+}
+
+func (ch *CommandHandler) checkCoordinatorKey(coordKey string, findCmd string) (AdvertisedAddr, bool) {
 	if !ch.hasRouter() {
 		return AdvertisedAddr{}, true
 	}
-	id, _, err := ch.Cluster.Router.FindCoordinator(groupName)
+	id, raftAddr, err := ch.Cluster.Router.FindCoordinator(coordKey)
 	if err != nil {
 		return AdvertisedAddr{}, true
 	}
@@ -127,7 +136,6 @@ func (ch *CommandHandler) checkCoordinator(groupName string) (AdvertisedAddr, bo
 		return AdvertisedAddr{}, true
 	}
 
-	// Check cache
 	ch.coordCacheMu.RLock()
 	if cached, ok := ch.coordCache[id]; ok && time.Since(cached.updated) < coordCacheTTL {
 		ch.coordCacheMu.RUnlock()
@@ -135,10 +143,22 @@ func (ch *CommandHandler) checkCoordinator(groupName string) (AdvertisedAddr, bo
 	}
 	ch.coordCacheMu.RUnlock()
 
-	// Get coordinator's advertised address by forwarding FIND_COORDINATOR to it
-	findCmd := fmt.Sprintf("FIND_COORDINATOR group=%s", groupName)
+	if fsm := ch.Cluster.RaftManager.GetFSM(); fsm != nil {
+		if broker := fsm.GetBroker(id); broker != nil && broker.ClientAddr != "" {
+			if host, portStr, splitErr := net.SplitHostPort(broker.ClientAddr); splitErr == nil {
+				if port, scanErr := strconv.Atoi(portStr); scanErr == nil && host != "" && port > 0 {
+					addr := AdvertisedAddr{Host: host, Port: port}
+					ch.coordCacheMu.Lock()
+					ch.coordCache[id] = coordCacheEntry{addr: addr, updated: time.Now()}
+					ch.coordCacheMu.Unlock()
+					return addr, false
+				}
+			}
+		}
+	}
+
 	encodedCmd := util.EncodeMessage("", findCmd)
-	resp, fwdErr := ch.Cluster.Router.ForwardToCoordinator(groupName, string(encodedCmd))
+	resp, fwdErr := ch.Cluster.Router.ForwardToCoordinator(coordKey, string(encodedCmd))
 	if fwdErr == nil && strings.HasPrefix(resp, "OK") {
 		host, port := "", 0
 		for _, part := range strings.Fields(resp) {
@@ -157,8 +177,10 @@ func (ch *CommandHandler) checkCoordinator(groupName string) (AdvertisedAddr, bo
 		}
 	}
 
-	// Fallback
 	host := ch.Config.AdvertisedClientHost
+	if host == "" {
+		host, _, _ = net.SplitHostPort(raftAddr)
+	}
 	if host == "" {
 		host = "localhost"
 	}
@@ -294,7 +316,7 @@ func (ch *CommandHandler) applyViaLeader(cmdType string, payload map[string]inte
 		return nil, fmt.Errorf("marshal payload: %w", jsonErr)
 	}
 
-	forwardCmd := fmt.Sprintf("RAFT_APPLY type=%s payload=%s", cmdType, string(data))
+	forwardCmd := fmt.Sprintf("RAFT_APPLY %stype=%s payload=%s", ch.internalAuthPrefix(), cmdType, string(data))
 	encodedCmd := util.EncodeMessage("", forwardCmd)
 	resp, fwdErr := ch.Cluster.Router.ForwardToLeader(string(encodedCmd))
 	if fwdErr != nil {

--- a/pkg/controller/cluster_handler.go
+++ b/pkg/controller/cluster_handler.go
@@ -40,7 +40,7 @@ func (ch *CommandHandler) hasRouter() bool {
 }
 
 func (ch *CommandHandler) ProcessCommand(cmd string) string {
-	ctx := NewClientContext("default-group", 0)
+	ctx := NewInternalClientContext("default-group", 0)
 
 	// Forwarded commands arrive wrapped in a binary envelope
 	// (2-byte topic length + topic + payload). Decode it first.

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,7 +28,7 @@ var (
 func (ch *CommandHandler) handleHelp() string {
 	commands := []string{
 		"CREATE", "DELETE", "LIST", "PUBLISH", "CONSUME", "STREAM", "JOIN_GROUP", "SYNC_GROUP",
-		"LEAVE_GROUP", "HEARTBEAT", "COMMIT_OFFSET", "BATCH_COMMIT", "FETCH_OFFSET", "REGISTER_GROUP",
+		"LEAVE_GROUP", "HEARTBEAT", "COMMIT_OFFSET", "BATCH_COMMIT", "FETCH_OFFSET", "LIST_OFFSETS", "INIT_PRODUCER_ID", "BEGIN_TXN", "TXN_PUBLISH", "SEND_OFFSETS_TO_TXN", "END_TXN", "TXN_STATUS", "REGISTER_GROUP",
 		"GROUP_STATUS", "DESCRIBE", "APPEND_STREAM", "READ_STREAM", "SAVE_SNAPSHOT",
 		"READ_SNAPSHOT", "STREAM_VERSION", "METADATA", "FIND_COORDINATOR", "HELP", "EXIT",
 	}
@@ -110,7 +111,7 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 			util.Warn("Failed to register default group with coordinator: %v", err)
 		}
 	}
-	return fmt.Sprintf("OK topic=%s partitions=%d partitioner=%s auth_policy=%s retention_hours=%d retention_bytes=%d", topicName, len(t.Partitions), t.Policy.Partitioner, t.Policy.AuthPolicy, t.Policy.RetentionHours, t.Policy.RetentionBytes)
+	return fmt.Sprintf("OK topic=%s partitions=%d partitioner=%s auth_policy=%s read_acl=%s write_acl=%s retention_hours=%d retention_bytes=%d", topicName, len(t.Partitions), t.Policy.Partitioner, t.Policy.AuthPolicy, strings.Join(t.Policy.ReadACL, ","), strings.Join(t.Policy.WriteACL, ","), t.Policy.RetentionHours, t.Policy.RetentionBytes)
 }
 
 func parseTopicPolicy(args map[string]string) (topic.Policy, string) {
@@ -135,11 +136,28 @@ func parseTopicPolicy(args map[string]string) (topic.Policy, string) {
 	if v := args["auth_policy"]; v != "" {
 		policy.AuthPolicy = v
 	}
+	policy.ReadACL = parseACLArg(args["read_acl"])
+	policy.WriteACL = parseACLArg(args["write_acl"])
 	policy, err := policy.Normalize()
 	if err != nil {
 		return policy, fmt.Sprintf("ERROR: invalid_topic_policy reason=%q", err.Error())
 	}
 	return policy, ""
+}
+
+func parseACLArg(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	acl := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			acl = append(acl, part)
+		}
+	}
+	return acl
 }
 
 // handleDelete processes DELETE command
@@ -402,6 +420,48 @@ func (ch *CommandHandler) handleLeaveGroup(cmd string) string {
 	return fmt.Sprintf("OK group=%s member=%s left=true", groupName, consumerID)
 }
 
+// handleListOffsets processes LIST_OFFSETS topic=<name> [partition=<N>].
+func (ch *CommandHandler) handleListOffsets(cmd string) string {
+	argsText := ""
+	if len(cmd) > len("LIST_OFFSETS") {
+		argsText = strings.TrimSpace(cmd[len("LIST_OFFSETS"):])
+	}
+	args := parseKeyValueArgs(argsText)
+	topicName, ok := args["topic"]
+	if !ok || topicName == "" {
+		return "ERROR: missing_topic command=LIST_OFFSETS"
+	}
+
+	t := ch.TopicManager.GetTopic(topicName)
+	if t == nil {
+		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
+	}
+
+	format := func(p *topic.Partition) string {
+		r := p.OffsetRange()
+		return fmt.Sprintf("P%d:earliest=%d:latest=%d:leo=%d:hwm=%d", p.ID(), r.Earliest, r.Latest, r.LEO, r.HWM)
+	}
+
+	entries := make([]string, 0, len(t.Partitions))
+	if partitionStr := args["partition"]; partitionStr != "" {
+		partition, err := strconv.Atoi(partitionStr)
+		if err != nil {
+			return "ERROR: invalid_partition command=LIST_OFFSETS"
+		}
+		p, err := t.GetPartition(partition)
+		if err != nil {
+			return fmt.Sprintf("ERROR: partition_not_found partition=%d", partition)
+		}
+		entries = append(entries, format(p))
+	} else {
+		for _, p := range t.Partitions {
+			entries = append(entries, format(p))
+		}
+	}
+
+	return fmt.Sprintf("OK topic=%s partitions=%d offsets=%s", topicName, len(entries), strings.Join(entries, ","))
+}
+
 // handleFetchOffset processes FETCH_OFFSET command
 func (ch *CommandHandler) handleFetchOffset(cmd string) string {
 	args := parseKeyValueArgs(cmd[13:])
@@ -533,6 +593,8 @@ func (ch *CommandHandler) handleHeartbeat(cmd string) string {
 // handleCommitOffset processes COMMIT_OFFSET command
 func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 	args := parseKeyValueArgs(cmd[14:])
+	validateOnly := strings.EqualFold(args["validate_only"], "true")
+	ownershipOnly := strings.EqualFold(args["ownership_only"], "true")
 
 	topicName, ok := args["topic"]
 	if !ok || topicName == "" {
@@ -579,6 +641,15 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 		if errResp := ch.Coordinator.ValidateOwnershipFailure(groupID, memberID, generation, partition); errResp != "" {
 			return errResp
 		}
+	}
+	if validateOnly && ownershipOnly {
+		return "OK validated=true"
+	}
+	if current, ok := ch.Coordinator.GetOffset(groupID, offsetTopic, partition); ok && offset < current {
+		return formatCoordinatorError(fmt.Errorf("offset regression group=%s topic=%s partition=%d current=%d got=%d", groupID, offsetTopic, partition, current, offset))
+	}
+	if validateOnly {
+		return "OK validated=true"
 	}
 
 	if ch.isDistributed() {
@@ -783,7 +854,7 @@ func (ch *CommandHandler) resolveOffset(p *topic.Partition, topicName string, cA
 	}
 
 	if cArgs.AutoOffsetReset == "latest" {
-		latest := p.GetLatestOffset()
+		latest := p.OffsetRange().Latest
 		util.Debug("Reset policy 'latest': starting at %d", latest)
 		return latest, nil
 	}
@@ -955,22 +1026,28 @@ func (ch *CommandHandler) handleMetadata(cmd string) string {
 		}
 	}
 
-	return fmt.Sprintf("OK topic=%s partitions=%d leaders=%s epochs=%s partitioner=%s auth_policy=%s retention_hours=%d retention_bytes=%d",
-		topicName, partitionCount, strings.Join(leaders, ","), strings.Join(epochs, ","), t.Policy.Partitioner, t.Policy.AuthPolicy, t.Policy.RetentionHours, t.Policy.RetentionBytes)
+	return fmt.Sprintf("OK topic=%s partitions=%d leaders=%s epochs=%s partitioner=%s auth_policy=%s read_acl=%s write_acl=%s retention_hours=%d retention_bytes=%d",
+		topicName, partitionCount, strings.Join(leaders, ","), strings.Join(epochs, ","), t.Policy.Partitioner, t.Policy.AuthPolicy, strings.Join(t.Policy.ReadACL, ","), strings.Join(t.Policy.WriteACL, ","), t.Policy.RetentionHours, t.Policy.RetentionBytes)
 }
 
 func (ch *CommandHandler) handleFindCoordinator(cmd string) string {
 	args := parseKeyValueArgs(cmd[17:]) // len("FIND_COORDINATOR ") = 17
-	groupName, ok := args["group"]
-	if !ok || groupName == "" {
-		return "ERROR: missing_group command=FIND_COORDINATOR"
+	coordKey := args["group"]
+	coordType := "group"
+	if coordKey == "" {
+		txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+		if txnID == "" {
+			return "ERROR: missing_coordinator_key command=FIND_COORDINATOR"
+		}
+		coordKey = transactionCoordinatorKey(txnID)
+		coordType = "transaction"
 	}
 
 	host := "localhost"
 	port := ch.Config.BrokerPort
 
 	if ch.isDistributed() {
-		coordID, _, err := ch.Cluster.Router.FindCoordinator(groupName)
+		coordID, _, err := ch.Cluster.Router.FindCoordinator(coordKey)
 		if err != nil {
 			return fmt.Sprintf("ERROR: find_coordinator_failed reason=%q", err.Error())
 		}
@@ -982,12 +1059,22 @@ func (ch *CommandHandler) handleFindCoordinator(cmd string) string {
 			if ch.Config.AdvertisedBrokerPort > 0 {
 				port = ch.Config.AdvertisedBrokerPort
 			}
-			return fmt.Sprintf("OK coordinator_id=%s host=%s port=%d", coordID, host, port)
+			return fmt.Sprintf("OK coordinator_id=%s coordinator_type=%s host=%s port=%d", coordID, coordType, host, port)
 		}
 
-		// Forward to coordinator to get its own advertised address
+		if fsm := ch.Cluster.RaftManager.GetFSM(); fsm != nil {
+			if broker := fsm.GetBroker(coordID); broker != nil && broker.ClientAddr != "" {
+				if brokerHost, brokerPort, err := net.SplitHostPort(broker.ClientAddr); err == nil {
+					parsedPort, _ := strconv.Atoi(brokerPort)
+					if brokerHost != "" && parsedPort > 0 {
+						return fmt.Sprintf("OK coordinator_id=%s coordinator_type=%s host=%s port=%d", coordID, coordType, brokerHost, parsedPort)
+					}
+				}
+			}
+		}
+
 		encodedCmd := util.EncodeMessage("", cmd)
-		resp, fwdErr := ch.Cluster.Router.ForwardToCoordinator(groupName, string(encodedCmd))
+		resp, fwdErr := ch.Cluster.Router.ForwardToCoordinator(coordKey, string(encodedCmd))
 		if fwdErr != nil {
 			return fmt.Sprintf("ERROR: forward_to_coordinator_failed reason=%q", fwdErr.Error())
 		}
@@ -1000,5 +1087,5 @@ func (ch *CommandHandler) handleFindCoordinator(cmd string) string {
 	if ch.Config.AdvertisedBrokerPort > 0 {
 		port = ch.Config.AdvertisedBrokerPort
 	}
-	return fmt.Sprintf("OK coordinator_id=standalone host=%s port=%d", host, port)
+	return fmt.Sprintf("OK coordinator_id=standalone coordinator_type=%s host=%s port=%d", coordType, host, port)
 }

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -421,12 +421,15 @@ func (ch *CommandHandler) handleLeaveGroup(cmd string) string {
 }
 
 // handleListOffsets processes LIST_OFFSETS topic=<name> [partition=<N>].
-func (ch *CommandHandler) handleListOffsets(cmd string) string {
+func (ch *CommandHandler) handleListOffsets(cmd string, ctx *ClientContext) string {
 	argsText := ""
 	if len(cmd) > len("LIST_OFFSETS") {
 		argsText = strings.TrimSpace(cmd[len("LIST_OFFSETS"):])
 	}
 	args := parseKeyValueArgs(argsText)
+	if authResp := ch.authenticateInline(args, ctx); authResp != "" {
+		return authResp
+	}
 	topicName, ok := args["topic"]
 	if !ok || topicName == "" {
 		return "ERROR: missing_topic command=LIST_OFFSETS"
@@ -435,6 +438,9 @@ func (ch *CommandHandler) handleListOffsets(cmd string) string {
 	t := ch.TopicManager.GetTopic(topicName)
 	if t == nil {
 		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
+	}
+	if authResp := ch.authorizeTopicRead(t.Policy, ctx); authResp != "" {
+		return fmt.Sprintf("%s topic=%s", authResp, topicName)
 	}
 
 	format := func(p *topic.Partition) string {
@@ -633,6 +639,7 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 	if ch.Coordinator == nil {
 		return "ERROR: offset_manager_not_available"
 	}
+	ownershipChecked := false
 	if memberID := args["member"]; memberID != "" || args["generation"] != "" {
 		generation, genErr := strconv.Atoi(args["generation"])
 		if genErr != nil {
@@ -641,8 +648,12 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 		if errResp := ch.Coordinator.ValidateOwnershipFailure(groupID, memberID, generation, partition); errResp != "" {
 			return errResp
 		}
+		ownershipChecked = true
 	}
 	if validateOnly && ownershipOnly {
+		if !ownershipChecked {
+			return "ERROR: missing_ownership_params command=COMMIT_OFFSET"
+		}
 		return "OK validated=true"
 	}
 	if current, ok := ch.Coordinator.GetOffset(groupID, offsetTopic, partition); ok && offset < current {

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -22,6 +22,9 @@ var ErrStreamRejected = errors.New("stream rejected")
 func (ch *CommandHandler) HandleConsumeCommand(conn net.Conn, rawCmd string, ctx *ClientContext) (int, error) {
 	// CONSUME topic=<name> partition=<N> offset=<N> group=<name> [autoOffsetReset=<earliest|latest>]
 	argsMap := parseKeyValueArgs(rawCmd[8:])
+	if authResp := ch.authenticateInline(argsMap, ctx); authResp != "" {
+		return 0, fmt.Errorf("%s", authResp)
+	}
 	if err := ch.validateConsumeArgs(argsMap); err != nil {
 		return 0, err
 	}
@@ -121,8 +124,8 @@ func (ch *CommandHandler) readFromTopic(topicName string, cArgs CommonArgs, ctx 
 	if err != nil {
 		return nil, err
 	}
-	if !t.Policy.CanRead() {
-		return nil, fmt.Errorf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=read", topicName)
+	if authResp := ch.authorizeTopicRead(t.Policy, ctx); authResp != "" {
+		return nil, fmt.Errorf("%s topic=%s", authResp, topicName)
 	}
 
 	cacheKey := fmt.Sprintf("%s-%d", topicName, cArgs.PartitionID)
@@ -194,6 +197,9 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 	}
 
 	argsMap := parseKeyValueArgs(rawCmd[7:])
+	if authResp := ch.authenticateInline(argsMap, ctx); authResp != "" {
+		return fmt.Errorf("%s", authResp)
+	}
 	if err := ch.validateStreamArgs(argsMap); err != nil {
 		return err
 	}
@@ -217,8 +223,8 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 	if err != nil {
 		return err
 	}
-	if !t.Policy.CanRead() {
-		return fmt.Errorf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=read", cArgs.TopicName)
+	if authResp := ch.authorizeTopicRead(t.Policy, ctx); authResp != "" {
+		return fmt.Errorf("%s topic=%s", authResp, cArgs.TopicName)
 	}
 
 	actualOffset, err := ch.resolveOffset(p, cArgs.TopicName, cArgs)

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -7,6 +7,8 @@ type ClientContext struct {
 	MemberID      string
 	Generation    int
 	OffsetCache   map[string]uint64
+	Principal     string
+	Authenticated bool
 }
 
 func NewClientContext(group string, idx int) *ClientContext {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -9,6 +9,7 @@ type ClientContext struct {
 	OffsetCache   map[string]uint64
 	Principal     string
 	Authenticated bool
+	Internal      bool
 }
 
 func NewClientContext(group string, idx int) *ClientContext {
@@ -20,6 +21,12 @@ func NewClientContext(group string, idx int) *ClientContext {
 		Generation:    0,
 		OffsetCache:   make(map[string]uint64),
 	}
+}
+
+func NewInternalClientContext(group string, idx int) *ClientContext {
+	ctx := NewClientContext(group, idx)
+	ctx.Internal = true
+	return ctx
 }
 
 func (ctx *ClientContext) SetConsumerGroup(groupName string) {

--- a/pkg/controller/eventsource_handler.go
+++ b/pkg/controller/eventsource_handler.go
@@ -57,7 +57,7 @@ func (ch *CommandHandler) handleSaveSnapshot(cmd string) string {
 			if err != nil {
 				return err
 			}
-			replicateCmd := fmt.Sprintf("REPLICATE_SNAPSHOT payload=%s", string(payload))
+			replicateCmd := fmt.Sprintf("REPLICATE_SNAPSHOT %spayload=%s", ch.internalAuthPrefix(), string(payload))
 			return ch.Cluster.ReplicateCommandToFollowers(result.Topic, result.Partition, replicateCmd, ch.Config.MinInSyncReplicas)
 		})
 		if errResp != "" {
@@ -137,7 +137,7 @@ func (ch *CommandHandler) handleCatchupSnapshots(cmd string) string {
 	if ch.Cluster == nil {
 		return "ERROR: cluster_not_available"
 	}
-	resp, err := ch.Cluster.ForwardCommandToBroker(leaderAddr, fmt.Sprintf("LIST_SNAPSHOTS topic=%s partition=%d", topicName, partition))
+	resp, err := ch.Cluster.ForwardCommandToBroker(leaderAddr, fmt.Sprintf("LIST_SNAPSHOTS %stopic=%s partition=%d", ch.internalAuthPrefix(), topicName, partition))
 	if err != nil {
 		return fmt.Sprintf("ERROR: snapshot_catchup_failed reason=%q", err.Error())
 	}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	clusterController "github.com/cursus-io/cursus/pkg/cluster/controller"
 	"github.com/cursus-io/cursus/pkg/config"
@@ -11,6 +12,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/eventsource"
 	"github.com/cursus-io/cursus/pkg/stream"
 	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/transaction"
 	"github.com/cursus-io/cursus/util"
 )
 
@@ -24,10 +26,19 @@ type CommandHandler struct {
 	StreamManager *stream.StreamManager
 	Cluster       *clusterController.ClusterController
 	ESHandler     *eventsource.Handler
+	TxnManager    *transaction.Manager
 	commands      []commandEntry
 
 	coordCache   map[string]coordCacheEntry
 	coordCacheMu sync.RWMutex
+	txnApplyMu   sync.Mutex
+}
+
+func transactionalIDExpiration(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.TransactionalIDExpirationMS <= 0 {
+		return 7 * 24 * time.Hour
+	}
+	return time.Duration(cfg.TransactionalIDExpirationMS) * time.Millisecond
 }
 
 // commandEntry defines a single command routing rule.
@@ -58,24 +69,39 @@ func NewCommandHandler(
 		coordCache:    make(map[string]coordCacheEntry),
 		Cluster:       cc,
 		ESHandler:     eventsource.NewHandler(tm),
+		TxnManager:    transaction.NewManagerWithExpiration(transactionalIDExpiration(cfg)),
+	}
+	if cc != nil && cc.RaftManager != nil {
+		if fsm := cc.RaftManager.GetFSM(); fsm != nil {
+			fsm.SetTransactionManager(ch.TxnManager)
+		}
 	}
 	ch.commands = []commandEntry{
+		{prefix: "AUTH ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleAuth(cmd, ctx) }},
 		{prefix: "HELP", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleHelp() }},
 		{prefix: "LIST_CLUSTER", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListCluster() }},
 		{prefix: "LIST", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleList() }},
 		{prefix: "CREATE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCreate(cmd) }},
 		{prefix: "DELETE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDelete(cmd) }},
-		{prefix: "PUBLISH ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handlePublish(cmd) }},
+		{prefix: "PUBLISH ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handlePublish(cmd, ctx) }},
 		{prefix: "REGISTER_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleRegisterGroup(cmd) }},
 		{prefix: "JOIN_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleJoinGroup(cmd, ctx) }},
 		{prefix: "SYNC_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleSyncGroup(cmd) }},
 		{prefix: "LEAVE_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleLeaveGroup(cmd) }},
 		{prefix: "FETCH_OFFSET ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleFetchOffset(cmd) }},
+		{prefix: "LIST_OFFSETS", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd) }},
+		{prefix: "LIST_OFFSETS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd) }},
 		{prefix: "GROUP_STATUS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleGroupStatus(cmd) }},
 		{prefix: "DESCRIBE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDescribeTopic(cmd) }},
 		{prefix: "HEARTBEAT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleHeartbeat(cmd) }},
 		{prefix: "COMMIT_OFFSET ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCommitOffset(cmd) }},
 		{prefix: "BATCH_COMMIT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleBatchCommit(cmd) }},
+		{prefix: "INIT_PRODUCER_ID ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleInitProducerID(cmd) }},
+		{prefix: "BEGIN_TXN ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleBeginTxn(cmd) }},
+		{prefix: "TXN_PUBLISH ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleTxnPublish(cmd, ctx) }},
+		{prefix: "SEND_OFFSETS_TO_TXN ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleSendOffsetsToTxn(cmd) }},
+		{prefix: "END_TXN ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleEndTxn(cmd) }},
+		{prefix: "TXN_STATUS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleTxnStatus(cmd) }},
 		{prefix: "APPEND_STREAM ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleAppendStream(cmd) }},
 		{prefix: "STREAM_VERSION ", exact: false, handler: func(cmd string, ctx *ClientContext) string {
 			return ch.handleEventSourceRoutedCommand(cmd, "STREAM_VERSION ", ch.ESHandler.HandleStreamVersion)
@@ -97,13 +123,54 @@ func NewCommandHandler(
 	return ch
 }
 
+var internalCommandPrefixes = []string{
+	"REPLICATE_MESSAGE ",
+	"REPLICATE_SNAPSHOT ",
+	"LIST_SNAPSHOTS ",
+	"FETCH_SNAPSHOT ",
+	"CATCHUP_SNAPSHOTS ",
+	"RAFT_APPLY ",
+}
+
 func (ch *CommandHandler) logCommandResult(cmd, response string) {
 	status := "SUCCESS"
 	if strings.HasPrefix(response, "ERROR:") {
 		status = "FAILURE"
 	}
-	cleanResponse := strings.ReplaceAll(response, "\n", " ")
-	util.Debug("status: '%s', command: '%s' to Response '%s'", status, cmd, cleanResponse)
+	cleanCmd := redactCommandSecrets(cmd)
+	cleanResponse := redactCommandSecrets(strings.ReplaceAll(response, "\n", " "))
+	util.Debug("status: '%s', command: '%s' to Response '%s'", status, cleanCmd, cleanResponse)
+}
+
+func redactCommandSecrets(s string) string {
+	keys := []string{"internal_token=", "auth_token=", "token="}
+	for _, key := range keys {
+		s = redactOneCommandSecret(s, key)
+	}
+	return s
+}
+
+func redactOneCommandSecret(s, key string) string {
+	idx := strings.Index(s, key)
+	if idx == -1 {
+		return s
+	}
+
+	var b strings.Builder
+	for idx != -1 {
+		b.WriteString(s[:idx])
+		b.WriteString(key)
+		b.WriteString("<redacted>")
+		rest := s[idx+len(key):]
+		end := 0
+		for end < len(rest) && rest[end] > ' ' {
+			end++
+		}
+		s = rest[end:]
+		idx = strings.Index(s, key)
+	}
+	b.WriteString(s)
+	return b.String()
 }
 
 // HandleCommand processes non-streaming commands and returns a signal for streaming commands.
@@ -120,6 +187,11 @@ func (ch *CommandHandler) HandleCommand(rawCmd string, ctx *ClientContext) strin
 	}
 	if strings.HasPrefix(upper, "CONSUME ") {
 		return ch.validateConsumeSyntax(cmd, rawCmd)
+	}
+	if name, ok := internalCommandName(upper); ok {
+		if resp := ch.authorizeInternalCommand(name, cmd); resp != "" {
+			return ch.fail(rawCmd, resp)
+		}
 	}
 
 	resp := ch.handleCommandByType(cmd, upper, ctx)
@@ -141,6 +213,37 @@ func (ch *CommandHandler) handleCommandByType(cmd, upper string, ctx *ClientCont
 		}
 	}
 	return fmt.Sprintf("ERROR: unknown_command command=%s", cmd)
+}
+
+func internalCommandName(upper string) (string, bool) {
+	for _, prefix := range internalCommandPrefixes {
+		if strings.HasPrefix(upper, prefix) {
+			return strings.TrimSpace(prefix), true
+		}
+	}
+	return "", false
+}
+
+func (ch *CommandHandler) authorizeInternalCommand(name, cmd string) string {
+	if ch == nil || ch.Config == nil || !ch.Config.EnabledDistribution {
+		return ""
+	}
+	token := ch.Config.InternalAuthToken
+	if token == "" {
+		return fmt.Sprintf("ERROR: internal_auth_not_configured command=%s", name)
+	}
+	args := parseKeyValueArgs(strings.TrimPrefix(cmd, name+" "))
+	if args["internal_token"] != token {
+		return fmt.Sprintf("ERROR: internal_command_unauthorized command=%s", name)
+	}
+	return ""
+}
+
+func (ch *CommandHandler) internalAuthPrefix() string {
+	if ch != nil && ch.Config != nil && ch.Config.InternalAuthToken != "" {
+		return "internal_token=" + ch.Config.InternalAuthToken + " "
+	}
+	return ""
 }
 
 func (ch *CommandHandler) fail(raw, msg string) string {

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -89,8 +89,8 @@ func NewCommandHandler(
 		{prefix: "SYNC_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleSyncGroup(cmd) }},
 		{prefix: "LEAVE_GROUP ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleLeaveGroup(cmd) }},
 		{prefix: "FETCH_OFFSET ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleFetchOffset(cmd) }},
-		{prefix: "LIST_OFFSETS", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd) }},
-		{prefix: "LIST_OFFSETS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd) }},
+		{prefix: "LIST_OFFSETS", exact: true, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd, ctx) }},
+		{prefix: "LIST_OFFSETS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd, ctx) }},
 		{prefix: "GROUP_STATUS ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleGroupStatus(cmd) }},
 		{prefix: "DESCRIBE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDescribeTopic(cmd) }},
 		{prefix: "HEARTBEAT ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleHeartbeat(cmd) }},
@@ -233,7 +233,7 @@ func (ch *CommandHandler) authorizeInternalCommand(name, cmd string) string {
 		return fmt.Sprintf("ERROR: internal_auth_not_configured command=%s", name)
 	}
 	args := parseKeyValueArgs(strings.TrimPrefix(cmd, name+" "))
-	if args["internal_token"] != token {
+	if !constantTimeStringEqual(args["internal_token"], token) {
 		return fmt.Sprintf("ERROR: internal_command_unauthorized command=%s", name)
 	}
 	return ""

--- a/pkg/controller/handler_coverage_test.go
+++ b/pkg/controller/handler_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/transaction"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -621,6 +623,14 @@ func TestHandlePublish_InvalidEpoch(t *testing.T) {
 	assert.Contains(t, resp, "invalid_epoch")
 }
 
+func TestHandlePublishRejectsExternalTransactionMetadata(t *testing.T) {
+	ch, tm := newTestHandler(t)
+	require.NoError(t, tm.CreateTopic("txn-spoof-topic", 1, false, false))
+	ctx := NewClientContext("", 0)
+
+	resp := ch.HandleCommand("PUBLISH topic=txn-spoof-topic partition=0 acks=1 producerId=p1 seqNum=1 epoch=0 transactional_id=tx-spoof transaction_state=open transaction_marker=commit message=spoof", ctx)
+	assert.Contains(t, resp, "transaction_metadata_forbidden")
+}
 func TestHandlePublish_IdempotentTrue(t *testing.T) {
 	ch, tm := newTestHandler(t)
 	_ = tm.CreateTopic("idem-pub-topic", 1, true, false)
@@ -661,6 +671,15 @@ func TestHandleReplicateMessage_InvalidJSON(t *testing.T) {
 	assert.Contains(t, resp, "unmarshal_failed")
 }
 
+func TestHandleReplicateMessageRejectsUnownedTransactionMetadata(t *testing.T) {
+	ch, tm := newTestHandler(t)
+	require.NoError(t, tm.CreateTopic("rep-spoof-topic", 1, false, false))
+	ctx := NewClientContext("", 0)
+
+	payload := `{"topic":"rep-spoof-topic","partition":0,"messages":[{"Payload":"spoof","ProducerID":"p1","SeqNum":1,"Epoch":0,"TransactionalID":"tx-spoof","TransactionState":"open"}]}`
+	resp := ch.HandleCommand("REPLICATE_MESSAGE payload="+payload, ctx)
+	assert.Contains(t, resp, "transaction_not_found")
+}
 func TestHandleReplicateMessage_TopicNotFound(t *testing.T) {
 	ch, _ := newTestHandler(t)
 	ctx := NewClientContext("", 0)
@@ -950,6 +969,33 @@ func TestHandleCommitOffset_ValidatesMemberGenerationAndOwnership(t *testing.T) 
 	notOwner := fmt.Sprintf("COMMIT_OFFSET topic=commit-validated-topic partition=%d group=commit-validated-g1 offset=11 member=commit-m1 generation=%d", notOwned, gen)
 	resp = ch.HandleCommand(notOwner, ctx)
 	assert.Contains(t, resp, "NOT_OWNER")
+}
+func TestHandleCommitOffsetValidateOnlyDoesNotMutateOffset(t *testing.T) {
+	ch, tm, coord := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("commit-validate-only-topic", 2, false, false))
+	require.NoError(t, coord.RegisterGroup("commit-validate-only-topic", "commit-validate-only-g1", 2))
+	_, err := coord.AddConsumer("commit-validate-only-g1", "commit-validate-only-m1")
+	require.NoError(t, err)
+	coord.Rebalance("commit-validate-only-g1")
+	gen := coord.GetGeneration("commit-validate-only-g1")
+	owned := coord.GetMemberAssignments("commit-validate-only-g1", "commit-validate-only-m1")
+	require.NotEmpty(t, owned)
+	ctx := NewClientContext("", 0)
+
+	validate := fmt.Sprintf("COMMIT_OFFSET topic=commit-validate-only-topic partition=%d group=commit-validate-only-g1 offset=10 member=commit-validate-only-m1 generation=%d validate_only=true", owned[0], gen)
+	resp := ch.HandleCommand(validate, ctx)
+	assert.Equal(t, "OK validated=true", resp)
+
+	resp = ch.HandleCommand(fmt.Sprintf("FETCH_OFFSET topic=commit-validate-only-topic partition=%d group=commit-validate-only-g1", owned[0]), ctx)
+	assert.Equal(t, "OK offset=0", resp)
+
+	commit := fmt.Sprintf("COMMIT_OFFSET topic=commit-validate-only-topic partition=%d group=commit-validate-only-g1 offset=10 member=commit-validate-only-m1 generation=%d", owned[0], gen)
+	resp = ch.HandleCommand(commit, ctx)
+	assert.Equal(t, "OK", resp)
+
+	regression := fmt.Sprintf("COMMIT_OFFSET topic=commit-validate-only-topic partition=%d group=commit-validate-only-g1 offset=9 member=commit-validate-only-m1 generation=%d validate_only=true", owned[0], gen)
+	resp = ch.HandleCommand(regression, ctx)
+	assert.Contains(t, resp, "offset_regression")
 }
 func TestHandleLeaveGroup_WithCoordinator(t *testing.T) {
 	ch, tm, coord := newTestHandlerWithCoordinator(t)
@@ -1337,4 +1383,303 @@ func TestHandlePublish_InvalidExplicitPartition(t *testing.T) {
 
 	resp := ch.HandleCommand("PUBLISH topic=invalid-publish-partition partition=99 acks=1 producerId=p1 message=bad", ctx)
 	assert.Contains(t, resp, "partition_not_found")
+}
+
+func TestHandleListOffsets(t *testing.T) {
+	ch, tm := newTestHandler(t)
+	require.NoError(t, tm.CreateTopic("offsets-topic", 2, false, false))
+	tObj := tm.GetTopic("offsets-topic")
+	p0, err := tObj.GetPartition(0)
+	require.NoError(t, err)
+	p0.SetHWM(7)
+	p1, err := tObj.GetPartition(1)
+	require.NoError(t, err)
+	p1.SetHWM(3)
+	ctx := NewClientContext("", 0)
+
+	resp := ch.HandleCommand("LIST_OFFSETS topic=offsets-topic", ctx)
+	assert.Contains(t, resp, "OK topic=offsets-topic partitions=2 offsets=")
+	assert.Contains(t, resp, "P0:earliest=0:latest=0:leo=1:hwm=7")
+	assert.Contains(t, resp, "P1:earliest=0:latest=0:leo=1:hwm=3")
+
+	resp = ch.HandleCommand("LIST_OFFSETS topic=offsets-topic partition=1", ctx)
+	assert.Equal(t, "OK topic=offsets-topic partitions=1 offsets=P1:earliest=0:latest=0:leo=1:hwm=3", resp)
+}
+
+func TestHandleListOffsetsErrors(t *testing.T) {
+	ch, tm := newTestHandler(t)
+	require.NoError(t, tm.CreateTopic("offsets-error-topic", 1, false, false))
+	ctx := NewClientContext("", 0)
+
+	assert.Contains(t, ch.HandleCommand("LIST_OFFSETS", ctx), "missing_topic")
+	assert.Contains(t, ch.HandleCommand("LIST_OFFSETS topic=missing", ctx), "topic_not_found")
+	assert.Contains(t, ch.HandleCommand("LIST_OFFSETS topic=offsets-error-topic partition=abc", ctx), "invalid_partition")
+	assert.Contains(t, ch.HandleCommand("LIST_OFFSETS topic=offsets-error-topic partition=9", ctx), "partition_not_found")
+}
+
+func TestInitProducerIDFencesPreviousEpoch(t *testing.T) {
+	ch, _, _ := newTestHandlerWithCoordinator(t)
+	ctx := NewClientContext("", 0)
+
+	resp := ch.HandleCommand("INIT_PRODUCER_ID transactional_id=tx-init", ctx)
+	assert.Contains(t, resp, "producerId=")
+	assert.Contains(t, resp, "epoch=0")
+	producerID := valueFromOKResponse(resp, "producerId")
+	require.NotEmpty(t, producerID)
+
+	resp = ch.HandleCommand("BEGIN_TXN transactional_id=tx-init producerId="+producerID+" epoch=0", ctx)
+	assert.Contains(t, resp, "state=open")
+	resp = ch.HandleCommand("INIT_PRODUCER_ID transactional_id=tx-init", ctx)
+	assert.Contains(t, resp, "epoch=1")
+	resp = ch.HandleCommand("TXN_STATUS transactional_id=tx-init", ctx)
+	assert.Contains(t, resp, "state=aborted")
+	resp = ch.HandleCommand("BEGIN_TXN transactional_id=tx-init producerId="+producerID+" epoch=0", ctx)
+	assert.Contains(t, resp, "transaction_begin_failed")
+	resp = ch.HandleCommand("BEGIN_TXN transactional_id=tx-init producerId="+producerID+" epoch=1", ctx)
+	assert.Contains(t, resp, "state=open")
+}
+
+func valueFromOKResponse(resp string, key string) string {
+	for _, field := range strings.Fields(resp) {
+		prefix := key + "="
+		if strings.HasPrefix(field, prefix) {
+			return strings.TrimPrefix(field, prefix)
+		}
+	}
+	return ""
+}
+func initTransactionSession(t *testing.T, ch *CommandHandler, ctx *ClientContext, txnID string) (string, string) {
+	t.Helper()
+	resp := ch.HandleCommand("INIT_PRODUCER_ID transactional_id="+txnID, ctx)
+	require.Contains(t, resp, "producerId=")
+	producerID := valueFromOKResponse(resp, "producerId")
+	epoch := valueFromOKResponse(resp, "epoch")
+	require.NotEmpty(t, producerID)
+	require.NotEmpty(t, epoch)
+	return producerID, epoch
+}
+func TestTransactionPublishRequiresSeqNum(t *testing.T) {
+	ch, tm, _ := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("txn-seq-topic", 1, false, false))
+	ctx := NewClientContext("", 0)
+
+	producerID, epoch := initTransactionSession(t, ch, ctx, "tx-seq")
+	resp := ch.HandleCommand("BEGIN_TXN transactional_id=tx-seq producerId="+producerID+" epoch="+epoch, ctx)
+	assert.Contains(t, resp, "state=open")
+	resp = ch.HandleCommand("TXN_PUBLISH transactional_id=tx-seq topic=txn-seq-topic partition=0 producerId="+producerID+" epoch="+epoch+" message=missing-seq", ctx)
+	assert.Contains(t, resp, "invalid_seq_num")
+}
+func TestTransactionCommitStagesMessagesAndOffsets(t *testing.T) {
+	ch, tm, coord := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("txn-topic", 1, false, false))
+	require.NoError(t, coord.RegisterGroup("txn-topic", "txn-group", 1))
+	_, err := coord.AddConsumer("txn-group", "txn-member")
+	require.NoError(t, err)
+	generation := coord.GetGeneration("txn-group")
+	ctx := NewClientContext("", 0)
+
+	producerID, epoch := initTransactionSession(t, ch, ctx, "tx-1")
+	resp := ch.HandleCommand("BEGIN_TXN transactional_id=tx-1 producerId="+producerID+" epoch="+epoch, ctx)
+	assert.Contains(t, resp, "state=open")
+
+	resp = ch.HandleCommand("TXN_PUBLISH transactional_id=tx-1 topic=txn-topic partition=0 producerId="+producerID+" seqNum=1 epoch="+epoch+" message=created", ctx)
+	assert.Contains(t, resp, "staged_messages=1")
+
+	resp = ch.HandleCommand("SEND_OFFSETS_TO_TXN transactional_id=tx-1 producerId="+producerID+" epoch="+epoch+" topic=txn-topic group=txn-group member=txn-member generation="+strconv.Itoa(generation)+" P0:4", ctx)
+	assert.Contains(t, resp, "staged_offsets=1")
+
+	resp = ch.HandleCommand("FETCH_OFFSET topic=txn-topic partition=0 group=txn-group", ctx)
+	assert.Equal(t, "OK offset=0", resp)
+
+	resp = ch.HandleCommand("END_TXN transactional_id=tx-1 producerId="+producerID+" epoch="+epoch+" result=commit", ctx)
+	assert.Contains(t, resp, "state=committed")
+
+	resp = ch.HandleCommand("FETCH_OFFSET topic=txn-topic partition=0 group=txn-group", ctx)
+	assert.Equal(t, "OK offset=4", resp)
+
+	p, err := tm.GetTopic("txn-topic").GetPartition(0)
+	require.NoError(t, err)
+	nextOffsetAfterCommit := p.NextOffset()
+	resp = ch.HandleCommand("END_TXN transactional_id=tx-1 producerId="+producerID+" epoch="+epoch+" result=commit", ctx)
+	assert.Contains(t, resp, "state=committed")
+	resp = ch.HandleCommand("FETCH_OFFSET topic=txn-topic partition=0 group=txn-group", ctx)
+	assert.Equal(t, "OK offset=4", resp)
+	assert.Equal(t, nextOffsetAfterCommit, p.NextOffset())
+
+}
+
+func TestTransactionAbortDiscardsOffsets(t *testing.T) {
+	ch, tm, coord := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("txn-abort-topic", 1, false, false))
+	require.NoError(t, coord.RegisterGroup("txn-abort-topic", "txn-abort-group", 1))
+	_, err := coord.AddConsumer("txn-abort-group", "txn-abort-member")
+	require.NoError(t, err)
+	generation := coord.GetGeneration("txn-abort-group")
+	ctx := NewClientContext("", 0)
+
+	producerID, epoch := initTransactionSession(t, ch, ctx, "tx-abort")
+	resp := ch.HandleCommand("BEGIN_TXN transactional_id=tx-abort producerId="+producerID+" epoch="+epoch, ctx)
+	assert.Contains(t, resp, "state=open")
+	resp = ch.HandleCommand("TXN_PUBLISH transactional_id=tx-abort topic=txn-abort-topic partition=0 producerId="+producerID+" seqNum=1 epoch="+epoch+" message=discarded", ctx)
+	assert.Contains(t, resp, "staged_messages=1")
+	resp = ch.HandleCommand("SEND_OFFSETS_TO_TXN transactional_id=tx-abort producerId="+producerID+" epoch="+epoch+" topic=txn-abort-topic group=txn-abort-group member=txn-abort-member generation="+strconv.Itoa(generation)+" P0:9", ctx)
+	assert.Contains(t, resp, "staged_offsets=1")
+	resp = ch.HandleCommand("END_TXN transactional_id=tx-abort producerId="+producerID+" epoch="+epoch+" result=abort", ctx)
+	assert.Contains(t, resp, "state=aborted")
+
+	resp = ch.HandleCommand("FETCH_OFFSET topic=txn-abort-topic partition=0 group=txn-abort-group", ctx)
+	assert.Equal(t, "OK offset=0", resp)
+
+	p, err := tm.GetTopic("txn-abort-topic").GetPartition(0)
+	require.NoError(t, err)
+	nextOffsetAfterAbort := p.NextOffset()
+	resp = ch.HandleCommand("END_TXN transactional_id=tx-abort producerId="+producerID+" epoch="+epoch+" result=abort", ctx)
+	assert.Contains(t, resp, "state=aborted")
+	assert.Equal(t, nextOffsetAfterAbort, p.NextOffset())
+}
+
+func TestTransactionRejectsOffsetRegressionBeforePublishing(t *testing.T) {
+	ch, tm, coord := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("txn-regression-topic", 1, false, false))
+	require.NoError(t, coord.RegisterGroup("txn-regression-topic", "txn-regression-group", 1))
+	_, err := coord.AddConsumer("txn-regression-group", "txn-regression-member")
+	require.NoError(t, err)
+	generation := coord.GetGeneration("txn-regression-group")
+	require.NoError(t, coord.CommitOffset("txn-regression-group", "txn-regression-topic", 0, 10))
+	ctx := NewClientContext("", 0)
+
+	producerID, epoch := initTransactionSession(t, ch, ctx, "tx-regression")
+	resp := ch.HandleCommand("BEGIN_TXN transactional_id=tx-regression producerId="+producerID+" epoch="+epoch, ctx)
+	assert.Contains(t, resp, "state=open")
+	resp = ch.HandleCommand("TXN_PUBLISH transactional_id=tx-regression topic=txn-regression-topic partition=0 producerId="+producerID+" seqNum=1 epoch="+epoch+" message=should-not-commit", ctx)
+	assert.Contains(t, resp, "staged_messages=1")
+	resp = ch.HandleCommand("SEND_OFFSETS_TO_TXN transactional_id=tx-regression producerId="+producerID+" epoch="+epoch+" topic=txn-regression-topic group=txn-regression-group member=txn-regression-member generation="+strconv.Itoa(generation)+" P0:5", ctx)
+	assert.Contains(t, resp, "staged_offsets=1")
+
+	resp = ch.HandleCommand("END_TXN transactional_id=tx-regression producerId="+producerID+" epoch="+epoch+" result=commit", ctx)
+	assert.Contains(t, resp, "transaction_commit_failed")
+	assert.Contains(t, resp, "offset regression")
+
+	resp = ch.HandleCommand("FETCH_OFFSET topic=txn-regression-topic partition=0 group=txn-regression-group", ctx)
+	assert.Equal(t, "OK offset=10", resp)
+	resp = ch.HandleCommand("TXN_STATUS transactional_id=tx-regression", ctx)
+	assert.Contains(t, resp, "state=committing")
+	resp = ch.HandleCommand("INIT_PRODUCER_ID transactional_id=tx-regression", ctx)
+	assert.Contains(t, resp, "init_producer_failed")
+}
+func TestTransactionCommitRejectsStaleGroupGenerationBeforePublishing(t *testing.T) {
+	ch, tm, coord := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("txn-stale-generation-topic", 1, false, false))
+	require.NoError(t, coord.RegisterGroup("txn-stale-generation-topic", "txn-stale-generation-group", 1))
+	_, err := coord.AddConsumer("txn-stale-generation-group", "txn-stale-generation-member")
+	require.NoError(t, err)
+	generation := coord.GetGeneration("txn-stale-generation-group")
+	ctx := NewClientContext("", 0)
+
+	producerID, epoch := initTransactionSession(t, ch, ctx, "tx-stale-generation")
+	resp := ch.HandleCommand("BEGIN_TXN transactional_id=tx-stale-generation producerId="+producerID+" epoch="+epoch, ctx)
+	assert.Contains(t, resp, "state=open")
+	resp = ch.HandleCommand("TXN_PUBLISH transactional_id=tx-stale-generation topic=txn-stale-generation-topic partition=0 producerId="+producerID+" seqNum=1 epoch="+epoch+" message=must-not-publish", ctx)
+	assert.Contains(t, resp, "staged_messages=1")
+	resp = ch.HandleCommand("SEND_OFFSETS_TO_TXN transactional_id=tx-stale-generation producerId="+producerID+" epoch="+epoch+" topic=txn-stale-generation-topic group=txn-stale-generation-group member=txn-stale-generation-member generation="+strconv.Itoa(generation)+" P0:3", ctx)
+	assert.Contains(t, resp, "staged_offsets=1")
+
+	p, err := tm.GetTopic("txn-stale-generation-topic").GetPartition(0)
+	require.NoError(t, err)
+	nextOffsetBeforeCommit := p.NextOffset()
+	require.NoError(t, coord.RemoveConsumer("txn-stale-generation-group", "txn-stale-generation-member"))
+
+	resp = ch.HandleCommand("END_TXN transactional_id=tx-stale-generation producerId="+producerID+" epoch="+epoch+" result=commit", ctx)
+	assert.Contains(t, resp, "transaction_commit_failed")
+	assert.Contains(t, resp, "member_not_found")
+	assert.Equal(t, nextOffsetBeforeCommit, p.NextOffset())
+
+	resp = ch.HandleCommand("FETCH_OFFSET topic=txn-stale-generation-topic partition=0 group=txn-stale-generation-group", ctx)
+	assert.Equal(t, "OK offset=0", resp)
+	resp = ch.HandleCommand("TXN_STATUS transactional_id=tx-stale-generation", ctx)
+	assert.Contains(t, resp, "state=committing")
+}
+func TestRecoverPreparedTransactionsCommitsCommittingState(t *testing.T) {
+	ch, tm, coord := newTestHandlerWithCoordinator(t)
+	require.NoError(t, tm.CreateTopic("txn-recover-topic", 1, false, false))
+	require.NoError(t, coord.RegisterGroup("txn-recover-topic", "txn-recover-group", 1))
+	_, err := coord.AddConsumer("txn-recover-group", "txn-recover-member")
+	require.NoError(t, err)
+	generation := coord.GetGeneration("txn-recover-group")
+
+	producerID, epoch, initErr := ch.TxnManager.InitProducer("tx-recover")
+	require.NoError(t, initErr)
+	require.NoError(t, ch.TxnManager.Begin("tx-recover", producerID, epoch))
+	require.NoError(t, ch.TxnManager.AddMessage("tx-recover", producerID, epoch, transaction.MessageOperation{
+		Topic:     "txn-recover-topic",
+		Partition: 0,
+		Message: types.Message{
+			Payload:          "recover-me",
+			ProducerID:       producerID,
+			SeqNum:           1,
+			Epoch:            epoch,
+			TransactionalID:  "tx-recover",
+			TransactionState: types.TransactionStateOpen,
+		},
+	}))
+	require.NoError(t, ch.TxnManager.AddOffsets("tx-recover", producerID, epoch, []transaction.OffsetOperation{{Topic: "txn-recover-topic", Group: "txn-recover-group", Member: "txn-recover-member", Generation: generation, Partition: 0, Offset: 6}}))
+	_, err = ch.TxnManager.PrepareCommit("tx-recover", producerID, epoch)
+	require.NoError(t, err)
+
+	require.NoError(t, ch.RecoverPreparedTransactions())
+	tx, err := ch.TxnManager.Status("tx-recover")
+	require.NoError(t, err)
+	assert.Equal(t, transaction.StateCommitted, tx.State)
+	offset, ok := coord.GetOffset("txn-recover-group", "txn-recover-topic", 0)
+	require.True(t, ok)
+	assert.Equal(t, uint64(6), offset)
+}
+
+func TestInternalCommandsRequireTokenInDistributedMode(t *testing.T) {
+	ch, _ := newTestHandler(t)
+	ch.Config.EnabledDistribution = true
+	ch.Config.InternalAuthToken = "secret-token"
+	ctx := NewClientContext("", 0)
+
+	for _, cmd := range []string{
+		"REPLICATE_MESSAGE payload={}",
+		"REPLICATE_SNAPSHOT payload={}",
+		"LIST_SNAPSHOTS topic=t partition=0",
+		"FETCH_SNAPSHOT topic=t partition=0 key=k",
+		"CATCHUP_SNAPSHOTS topic=t partition=0",
+		"RAFT_APPLY type=REGISTER payload={}",
+	} {
+		resp := ch.HandleCommand(cmd, ctx)
+		assert.Contains(t, resp, "internal_command_unauthorized", cmd)
+	}
+}
+
+func TestInternalCommandsRejectMissingTokenConfigInDistributedMode(t *testing.T) {
+	ch, _ := newTestHandler(t)
+	ch.Config.EnabledDistribution = true
+	ctx := NewClientContext("", 0)
+
+	resp := ch.HandleCommand("REPLICATE_MESSAGE payload={}", ctx)
+	assert.Contains(t, resp, "internal_auth_not_configured")
+}
+
+func TestInternalCommandTokenAllowsHandlerDispatch(t *testing.T) {
+	ch, tm := newTestHandler(t)
+	ch.Config.EnabledDistribution = true
+	ch.Config.InternalAuthToken = "secret-token"
+	require.NoError(t, tm.CreateTopic("secure-rep-topic", 1, false, false))
+	ctx := NewClientContext("", 0)
+
+	payload := `{"topic":"secure-rep-topic","partition":0,"messages":[{"payload":"hello","producer_id":"p1"}]}`
+	resp := ch.HandleCommand("REPLICATE_MESSAGE internal_token=secret-token payload="+payload, ctx)
+	assert.Equal(t, "OK", resp)
+}
+
+func TestRedactCommandSecrets(t *testing.T) {
+	input := "REPLICATE_MESSAGE internal_token=super-secret payload={\"internal_token\":\"payload-value\"}"
+	redacted := redactCommandSecrets(input)
+
+	assert.NotContains(t, redacted, "super-secret")
+	assert.Contains(t, redacted, "internal_token=<redacted>")
+	assert.Contains(t, redacted, "payload-value")
 }

--- a/pkg/controller/produce_handler.go
+++ b/pkg/controller/produce_handler.go
@@ -96,11 +96,31 @@ func (ch *CommandHandler) handlePublish(cmd string, ctx ...*ClientContext) strin
 		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
 	}
 	if strings.EqualFold(args["internal_txn_publish"], "true") {
+		if clientCtx == nil || !clientCtx.Internal {
+			return "ERROR: internal_txn_publish_forbidden command=PUBLISH"
+		}
 		if !t.Policy.CanWrite() {
 			return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", topicName)
 		}
 	} else if authResp := ch.authorizeTopicWrite(t.Policy, clientCtx); authResp != "" {
 		return fmt.Sprintf("%s topic=%s", authResp, topicName)
+	}
+
+	controlBatchVersion, errResp := parseControlBatchVersion(args["control_batch_version"])
+	if errResp != "" {
+		return errResp
+	}
+	controlBatchCoordinatorEpoch, errResp := parseControlBatchCoordinatorEpoch(args["control_batch_coordinator_epoch"])
+	if errResp != "" {
+		return errResp
+	}
+	controlBatchKey, errResp := parseControlBatchBytes(args["control_batch_key"], "key")
+	if errResp != "" {
+		return errResp
+	}
+	controlBatchValue, errResp := parseControlBatchBytes(args["control_batch_value"], "value")
+	if errResp != "" {
+		return errResp
 	}
 
 	msg := &types.Message{
@@ -113,10 +133,10 @@ func (ch *CommandHandler) handlePublish(cmd string, ctx ...*ClientContext) strin
 		TransactionState:             args["transaction_state"],
 		TransactionMarker:            args["transaction_marker"],
 		ControlBatchType:             args["control_batch_type"],
-		ControlBatchVersion:          parseInt16Default(args["control_batch_version"], 0),
-		ControlBatchCoordinatorEpoch: parseInt64Default(args["control_batch_coordinator_epoch"], 0),
-		ControlBatchKey:              parseBase64Default(args["control_batch_key"]),
-		ControlBatchValue:            parseBase64Default(args["control_batch_value"]),
+		ControlBatchVersion:          controlBatchVersion,
+		ControlBatchCoordinatorEpoch: controlBatchCoordinatorEpoch,
+		ControlBatchKey:              controlBatchKey,
+		ControlBatchValue:            controlBatchValue,
 	}
 
 	if partition < 0 {
@@ -318,7 +338,11 @@ func (ch *CommandHandler) handleReplicateMessage(cmd string) string {
 }
 
 // HandleBatchMessage processes PUBLISH of multiple messages.
-func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string, error) {
+func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn, ctx ...*ClientContext) (string, error) {
+	var clientCtx *ClientContext
+	if len(ctx) > 0 {
+		clientCtx = ctx[0]
+	}
 	batch, err := util.DecodeBatchMessages(data)
 	if err != nil {
 		util.Error("Batch message decoding failed: %v", err)
@@ -369,8 +393,8 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 			util.Error("Batch process failed: topic '%s' not found", batch.Topic)
 			return fmt.Sprintf("ERROR: topic_not_found topic=%s", batch.Topic), nil
 		}
-		if !t.Policy.CanWritePrincipal("") {
-			return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", batch.Topic), nil
+		if authResp := ch.authorizeTopicWrite(t.Policy, clientCtx); authResp != "" {
+			return fmt.Sprintf("%s topic=%s", authResp, batch.Topic), nil
 		}
 
 		p, err := t.GetPartition(batch.Partition)
@@ -439,8 +463,8 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 		if t == nil {
 			return fmt.Sprintf("ERROR: topic_not_found topic=%s", batch.Topic), nil
 		}
-		if !t.Policy.CanWritePrincipal("") {
-			return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", batch.Topic), nil
+		if authResp := ch.authorizeTopicWrite(t.Policy, clientCtx); authResp != "" {
+			return fmt.Sprintf("%s topic=%s", authResp, batch.Topic), nil
 		}
 		p, err := t.GetPartition(batch.Partition)
 		if err != nil {
@@ -497,35 +521,35 @@ Respond:
 	return responseStr, nil
 }
 
-func parseInt16Default(value string, fallback int16) int16 {
+func parseControlBatchVersion(value string) (int16, string) {
 	if value == "" {
-		return fallback
+		return 0, ""
 	}
 	parsed, err := strconv.ParseInt(value, 10, 16)
 	if err != nil {
-		return fallback
+		return 0, fmt.Sprintf("ERROR: invalid_control_batch_version reason=%q", err.Error())
 	}
-	return int16(parsed)
+	return int16(parsed), ""
 }
 
-func parseInt64Default(value string, fallback int64) int64 {
+func parseControlBatchCoordinatorEpoch(value string) (int64, string) {
 	if value == "" {
-		return fallback
+		return 0, ""
 	}
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return fallback
+		return 0, fmt.Sprintf("ERROR: invalid_control_batch_coordinator_epoch reason=%q", err.Error())
 	}
-	return parsed
+	return parsed, ""
 }
 
-func parseBase64Default(value string) []byte {
+func parseControlBatchBytes(value, field string) ([]byte, string) {
 	if value == "" {
-		return nil
+		return nil, ""
 	}
 	decoded, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
-		return nil
+		return nil, fmt.Sprintf("ERROR: invalid_control_batch_%s reason=%q", field, err.Error())
 	}
-	return decoded
+	return decoded, ""
 }

--- a/pkg/controller/produce_handler.go
+++ b/pkg/controller/produce_handler.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -14,8 +15,15 @@ import (
 )
 
 // handlePublish processes PUBLISH command
-func (ch *CommandHandler) handlePublish(cmd string) string {
+func (ch *CommandHandler) handlePublish(cmd string, ctx ...*ClientContext) string {
+	var clientCtx *ClientContext
+	if len(ctx) > 0 {
+		clientCtx = ctx[0]
+	}
 	args := parseKeyValueArgs(cmd[8:])
+	if authResp := ch.authenticateInline(args, clientCtx); authResp != "" {
+		return authResp
+	}
 	var err error
 
 	topicName, ok := args["topic"]
@@ -87,15 +95,28 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 		util.Warn("ch publish: topic '%s' does not exist after retries", topicName)
 		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
 	}
-	if !t.Policy.CanWrite() {
-		return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", topicName)
+	if strings.EqualFold(args["internal_txn_publish"], "true") {
+		if !t.Policy.CanWrite() {
+			return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", topicName)
+		}
+	} else if authResp := ch.authorizeTopicWrite(t.Policy, clientCtx); authResp != "" {
+		return fmt.Sprintf("%s topic=%s", authResp, topicName)
 	}
 
 	msg := &types.Message{
-		Payload:    message,
-		ProducerID: producerID,
-		SeqNum:     seqNum,
-		Epoch:      epoch,
+		Payload:                      message,
+		Key:                          args["key"],
+		ProducerID:                   producerID,
+		SeqNum:                       seqNum,
+		Epoch:                        epoch,
+		TransactionalID:              args["transactional_id"],
+		TransactionState:             args["transaction_state"],
+		TransactionMarker:            args["transaction_marker"],
+		ControlBatchType:             args["control_batch_type"],
+		ControlBatchVersion:          parseInt16Default(args["control_batch_version"], 0),
+		ControlBatchCoordinatorEpoch: parseInt64Default(args["control_batch_coordinator_epoch"], 0),
+		ControlBatchKey:              parseBase64Default(args["control_batch_key"]),
+		ControlBatchValue:            parseBase64Default(args["control_batch_value"]),
 	}
 
 	if partition < 0 {
@@ -104,6 +125,9 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 	if _, err := t.GetPartition(partition); err != nil {
 		return fmt.Sprintf("ERROR: partition_not_found partition=%d", partition)
 	}
+	if errResp := ch.validateTransactionPublishMetadata(args, topicName, partition, msg); errResp != "" {
+		return errResp
+	}
 
 	if ch.Config.EnabledDistribution && ch.Cluster != nil {
 		forwardCmd := cmd
@@ -111,6 +135,27 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 			forwardCmd = fmt.Sprintf("PUBLISH topic=%s acks=%s producerId=%s partition=%d seqNum=%d epoch=%d", topicName, acks, producerID, partition, seqNum, epoch)
 			if _, explicitIdempotent := args["isIdempotent"]; explicitIdempotent {
 				forwardCmd += fmt.Sprintf(" isIdempotent=%t", isIdempotent)
+			}
+			if msg.TransactionalID != "" {
+				forwardCmd += fmt.Sprintf(" transactional_id=%s", msg.TransactionalID)
+			}
+			if msg.TransactionState != "" {
+				forwardCmd += fmt.Sprintf(" transaction_state=%s", msg.TransactionState)
+			}
+			if msg.TransactionMarker != "" {
+				forwardCmd += fmt.Sprintf(" transaction_marker=%s", msg.TransactionMarker)
+			}
+			if msg.ControlBatchType != "" {
+				forwardCmd += fmt.Sprintf(" control_batch_type=%s control_batch_version=%d control_batch_coordinator_epoch=%d", msg.ControlBatchType, msg.ControlBatchVersion, msg.ControlBatchCoordinatorEpoch)
+				if len(msg.ControlBatchKey) > 0 {
+					forwardCmd += fmt.Sprintf(" control_batch_key=%s", base64.StdEncoding.EncodeToString(msg.ControlBatchKey))
+				}
+				if len(msg.ControlBatchValue) > 0 {
+					forwardCmd += fmt.Sprintf(" control_batch_value=%s", base64.StdEncoding.EncodeToString(msg.ControlBatchValue))
+				}
+			}
+			if strings.EqualFold(args["internal_txn_publish"], "true") {
+				forwardCmd += " internal_txn_publish=true"
 			}
 			forwardCmd += " message=" + message
 		}
@@ -132,15 +177,8 @@ func (ch *CommandHandler) handlePublish(cmd string) string {
 			Partition:     partition,
 			IsIdempotent:  effectiveIdempotent,
 			SequenceScope: scope,
-			Messages: []types.Message{
-				{
-					Payload:    message,
-					ProducerID: producerID,
-					SeqNum:     seqNum,
-					Epoch:      epoch,
-				},
-			},
-			Acks: acks,
+			Messages:      []types.Message{*msg},
+			Acks:          acks,
 		}
 
 		// 1. Append locally (LEO advances, HWM stays until replication succeeds)
@@ -237,7 +275,7 @@ func (ch *CommandHandler) waitForTopic(topicName string) *topic.Topic {
 }
 
 func (ch *CommandHandler) handleReplicateMessage(cmd string) string {
-	// Format: REPLICATE_MESSAGE payload=<json_MessageCommand>
+	// Format: REPLICATE_MESSAGE [internal_token=<token>] payload=<json_MessageCommand>
 	idx := strings.Index(cmd, "payload=")
 	if idx == -1 {
 		return "ERROR: missing_payload command=REPLICATE_MESSAGE"
@@ -262,6 +300,11 @@ func (ch *CommandHandler) handleReplicateMessage(cmd string) string {
 	// Guard against empty messages to prevent index-out-of-range panic
 	if len(msgCmd.Messages) == 0 {
 		return "ERROR: empty_messages command=REPLICATE_MESSAGE"
+	}
+	for i := range msgCmd.Messages {
+		if errResp := ch.validateReplicatedTransactionMessage(msgCmd.Topic, msgCmd.Partition, &msgCmd.Messages[i]); errResp != "" {
+			return errResp
+		}
 	}
 
 	if err := p.ReplicaAppend(msgCmd.Messages); err != nil {
@@ -326,7 +369,7 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 			util.Error("Batch process failed: topic '%s' not found", batch.Topic)
 			return fmt.Sprintf("ERROR: topic_not_found topic=%s", batch.Topic), nil
 		}
-		if !t.Policy.CanWrite() {
+		if !t.Policy.CanWritePrincipal("") {
 			return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", batch.Topic), nil
 		}
 
@@ -396,7 +439,7 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn) (string
 		if t == nil {
 			return fmt.Sprintf("ERROR: topic_not_found topic=%s", batch.Topic), nil
 		}
-		if !t.Policy.CanWrite() {
+		if !t.Policy.CanWritePrincipal("") {
 			return fmt.Sprintf("ERROR: NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", batch.Topic), nil
 		}
 		p, err := t.GetPartition(batch.Partition)
@@ -452,4 +495,37 @@ Respond:
 	responseStr := string(ackBytes)
 	util.Debug("Broker Sending Batch Ack (Topic: %s): %s", batch.Topic, responseStr)
 	return responseStr, nil
+}
+
+func parseInt16Default(value string, fallback int16) int16 {
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseInt(value, 10, 16)
+	if err != nil {
+		return fallback
+	}
+	return int16(parsed)
+}
+
+func parseInt64Default(value string, fallback int64) int64 {
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func parseBase64Default(value string) []byte {
+	if value == "" {
+		return nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil
+	}
+	return decoded
 }

--- a/pkg/controller/response_contract_test.go
+++ b/pkg/controller/response_contract_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,16 @@ func TestTextCommandResponseContract(t *testing.T) {
 	assertContractSuccess(t, ch.HandleCommand("HEARTBEAT topic=contract-topic group=contract-group member="+ctx.MemberID, ctx), "HEARTBEAT")
 	assertContractSuccess(t, ch.HandleCommand("COMMIT_OFFSET topic=contract-topic partition=0 group=contract-group offset=2", ctx), "COMMIT_OFFSET")
 	assertContractSuccess(t, ch.HandleCommand("FETCH_OFFSET topic=contract-topic partition=0 group=contract-group", ctx), "FETCH_OFFSET")
+	initResp := ch.HandleCommand("INIT_PRODUCER_ID transactional_id=contract-tx", ctx)
+	assertContractSuccess(t, initResp, "INIT_PRODUCER_ID")
+	contractProducer := valueFromOKResponse(initResp, "producerId")
+	contractEpoch := valueFromOKResponse(initResp, "epoch")
+	assertContractSuccess(t, ch.HandleCommand("BEGIN_TXN transactional_id=contract-tx producerId="+contractProducer+" epoch="+contractEpoch, ctx), "BEGIN_TXN")
+	assertContractSuccess(t, ch.HandleCommand("TXN_PUBLISH transactional_id=contract-tx topic=contract-topic partition=0 producerId="+contractProducer+" seqNum=1 epoch="+contractEpoch+" message=tx", ctx), "TXN_PUBLISH")
+	assertContractSuccess(t, ch.HandleCommand("SEND_OFFSETS_TO_TXN transactional_id=contract-tx producerId="+contractProducer+" epoch="+contractEpoch+" topic=contract-topic group=contract-group member="+ctx.MemberID+" generation="+strconv.Itoa(ctx.Generation)+" P0:2", ctx), "SEND_OFFSETS_TO_TXN")
+	assertContractSuccess(t, ch.HandleCommand("TXN_STATUS transactional_id=contract-tx", ctx), "TXN_STATUS")
+	assertContractSuccess(t, ch.HandleCommand("END_TXN transactional_id=contract-tx producerId="+contractProducer+" epoch="+contractEpoch+" result=abort", ctx), "END_TXN")
+	assertContractSuccess(t, ch.HandleCommand("LIST_OFFSETS topic=contract-topic", ctx), "LIST_OFFSETS")
 
 	batchCmd := fmt.Sprintf("BATCH_COMMIT topic=contract-topic group=contract-group generation=%d member=%s P0:3", ctx.Generation, ctx.MemberID)
 	assertContractSuccess(t, ch.HandleCommand(batchCmd, ctx), "BATCH_COMMIT")
@@ -39,7 +50,14 @@ func TestTextCommandErrorContract(t *testing.T) {
 		"REGISTER_GROUP topic=missing-topic group=g1",
 		"JOIN_GROUP topic=missing-topic group=g1 member=m1",
 		"FETCH_OFFSET topic=t1 partition=0 group=g1",
+		"LIST_OFFSETS topic=missing-topic",
 		"COMMIT_OFFSET topic=t1 partition=0 group=g1 offset=1",
+		"INIT_PRODUCER_ID",
+		"BEGIN_TXN producerId=p1",
+		"BEGIN_TXN transactional_id=uninitialized producerId=p1 epoch=0",
+		"TXN_PUBLISH transactional_id=missing topic=t1 producerId=p1 message=x",
+		"SEND_OFFSETS_TO_TXN transactional_id=missing topic=t1 group=g1 P0:1",
+		"END_TXN transactional_id=missing result=commit",
 		"DESCRIBE topic=missing-topic",
 	}
 

--- a/pkg/controller/transaction_handler.go
+++ b/pkg/controller/transaction_handler.go
@@ -59,10 +59,12 @@ func (ch *CommandHandler) handleBeginTxn(cmd string) string {
 	if err != nil {
 		return fmt.Sprintf("ERROR: invalid_epoch reason=%q", err.Error())
 	}
+	previousSnap, hadPrevious := ch.snapshotTransaction(txnID)
 	if err := ch.TxnManager.Begin(txnID, producerID, epoch); err != nil {
 		return fmt.Sprintf("ERROR: transaction_begin_failed reason=%q", err.Error())
 	}
 	if err := ch.syncTransactionState(txnID); err != nil {
+		ch.restoreTransaction(txnID, previousSnap, hadPrevious)
 		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
 	}
 	return fmt.Sprintf("OK transactional_id=%s state=open producerId=%s epoch=%d", txnID, producerID, epoch)
@@ -123,10 +125,12 @@ func (ch *CommandHandler) handleTxnPublish(cmd string, ctx ...*ClientContext) st
 	if _, err := t.GetPartition(partition); err != nil {
 		return fmt.Sprintf("ERROR: partition_not_found partition=%d", partition)
 	}
+	previousSnap, hadPrevious := ch.snapshotTransaction(txnID)
 	if err := ch.TxnManager.AddMessage(txnID, producerID, epoch, transaction.MessageOperation{Topic: topicName, Partition: partition, Message: msg}); err != nil {
 		return fmt.Sprintf("ERROR: transaction_publish_failed reason=%q", err.Error())
 	}
 	if err := ch.syncTransactionState(txnID); err != nil {
+		ch.restoreTransaction(txnID, previousSnap, hadPrevious)
 		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
 	}
 	return fmt.Sprintf("OK transactional_id=%s staged_messages=1 topic=%s partition=%d", txnID, topicName, partition)
@@ -180,10 +184,12 @@ func (ch *CommandHandler) handleSendOffsetsToTxn(cmd string) string {
 		}
 		ops = append(ops, op)
 	}
+	previousSnap, hadPrevious := ch.snapshotTransaction(txnID)
 	if err := ch.TxnManager.AddOffsets(txnID, producerID, epoch, ops); err != nil {
 		return fmt.Sprintf("ERROR: transaction_offsets_failed reason=%q", err.Error())
 	}
 	if err := ch.syncTransactionState(txnID); err != nil {
+		ch.restoreTransaction(txnID, previousSnap, hadPrevious)
 		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
 	}
 	return fmt.Sprintf("OK transactional_id=%s staged_offsets=%d", txnID, len(ops))
@@ -494,7 +500,7 @@ func touchedTransactionPartitions(tx *transaction.Transaction) []transactionPart
 func (ch *CommandHandler) publishTransactionMarker(topicName string, partition int, msg types.Message) error {
 	if ch.isDistributed() {
 		cmd := fmt.Sprintf("PUBLISH topic=%s acks=1 producerId=%s partition=%d seqNum=%d epoch=%d isIdempotent=true transactional_id=%s transaction_state=%s transaction_marker=%s control_batch_type=%s control_batch_version=%d control_batch_coordinator_epoch=%d control_batch_key=%s control_batch_value=%s internal_txn_publish=true message=%s", topicName, msg.ProducerID, partition, msg.SeqNum, msg.Epoch, msg.TransactionalID, msg.TransactionState, msg.TransactionMarker, msg.ControlBatchType, msg.ControlBatchVersion, msg.ControlBatchCoordinatorEpoch, base64.StdEncoding.EncodeToString(msg.ControlBatchKey), base64.StdEncoding.EncodeToString(msg.ControlBatchValue), msg.Payload)
-		resp := ch.handlePublish(cmd)
+		resp := ch.handlePublish(cmd, NewInternalClientContext("default-group", 0))
 		if !strings.HasPrefix(resp, "OK") && !strings.HasPrefix(resp, "{") {
 			return fmt.Errorf("%s", resp)
 		}
@@ -515,7 +521,7 @@ func (ch *CommandHandler) publishCommittedTransactionMessage(op transaction.Mess
 			cmd += fmt.Sprintf(" transactional_id=%s transaction_state=%s", msg.TransactionalID, msg.TransactionState)
 		}
 		cmd += " message=" + msg.Payload
-		resp := ch.handlePublish(cmd)
+		resp := ch.handlePublish(cmd, NewInternalClientContext("default-group", 0))
 		if !strings.HasPrefix(resp, "OK") && !strings.HasPrefix(resp, "{") {
 			return fmt.Errorf("%s", resp)
 		}
@@ -665,6 +671,19 @@ func (ch *CommandHandler) ensureTransactionCoordinator(txnID string) string {
 	return ""
 }
 
+func (ch *CommandHandler) snapshotTransaction(txnID string) (*transaction.Snapshot, bool) {
+	state := ch.TxnManager.ExportState()
+	snap, ok := state[txnID]
+	return snap, ok
+}
+
+func (ch *CommandHandler) restoreTransaction(txnID string, snap *transaction.Snapshot, hadPrevious bool) {
+	if hadPrevious {
+		ch.TxnManager.ApplySnapshot(snap)
+		return
+	}
+	ch.TxnManager.Delete(txnID)
+}
 func (ch *CommandHandler) syncTransactionState(txnID string) error {
 	if !ch.isDistributed() {
 		return nil

--- a/pkg/controller/transaction_handler.go
+++ b/pkg/controller/transaction_handler.go
@@ -1,0 +1,784 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cursus-io/cursus/pkg/transaction"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
+)
+
+const transactionControlMarkerPayload = "__cursus_txn_control_marker__"
+
+func (ch *CommandHandler) handleInitProducerID(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("INIT_PRODUCER_ID "):])
+	txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+	if txnID == "" {
+		return "ERROR: missing_transactional_id command=INIT_PRODUCER_ID"
+	}
+	if resp := ch.ensureTransactionCoordinator(txnID); resp != "" {
+		return resp
+	}
+	previousState := ch.TxnManager.ExportState()
+	previousSnap, hadPrevious := previousState[txnID]
+	producerID, epoch, err := ch.TxnManager.InitProducer(txnID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: init_producer_failed reason=%q", err.Error())
+	}
+	if err := ch.syncTransactionState(txnID); err != nil {
+		if hadPrevious {
+			ch.TxnManager.ApplySnapshot(previousSnap)
+		} else {
+			ch.TxnManager.Delete(txnID)
+		}
+		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+	}
+	return fmt.Sprintf("OK transactional_id=%s producerId=%s epoch=%d", txnID, producerID, epoch)
+}
+
+func (ch *CommandHandler) handleBeginTxn(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("BEGIN_TXN "):])
+	txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+	if txnID == "" {
+		return "ERROR: missing_transactional_id command=BEGIN_TXN"
+	}
+	if resp := ch.ensureTransactionCoordinator(txnID); resp != "" {
+		return resp
+	}
+	producerID := firstNonEmpty(args["producerId"], args["producer_id"])
+	if producerID == "" {
+		return "ERROR: missing_producer_id command=BEGIN_TXN"
+	}
+	epoch, err := parseOptionalInt64(args["epoch"])
+	if err != nil {
+		return fmt.Sprintf("ERROR: invalid_epoch reason=%q", err.Error())
+	}
+	if err := ch.TxnManager.Begin(txnID, producerID, epoch); err != nil {
+		return fmt.Sprintf("ERROR: transaction_begin_failed reason=%q", err.Error())
+	}
+	if err := ch.syncTransactionState(txnID); err != nil {
+		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+	}
+	return fmt.Sprintf("OK transactional_id=%s state=open producerId=%s epoch=%d", txnID, producerID, epoch)
+}
+
+func (ch *CommandHandler) handleTxnPublish(cmd string, ctx ...*ClientContext) string {
+	var clientCtx *ClientContext
+	if len(ctx) > 0 {
+		clientCtx = ctx[0]
+	}
+	args := parseKeyValueArgs(cmd[len("TXN_PUBLISH "):])
+	if authResp := ch.authenticateInline(args, clientCtx); authResp != "" {
+		return authResp
+	}
+	txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+	if txnID == "" {
+		return "ERROR: missing_transactional_id command=TXN_PUBLISH"
+	}
+	if resp := ch.ensureTransactionCoordinator(txnID); resp != "" {
+		return resp
+	}
+	topicName := args["topic"]
+	if topicName == "" {
+		return "ERROR: missing_topic command=TXN_PUBLISH"
+	}
+	message := args["message"]
+	if message == "" {
+		return "ERROR: missing_message command=TXN_PUBLISH"
+	}
+	producerID, epoch, errResp := parseTxnProducerEpoch(args, "TXN_PUBLISH")
+	if errResp != "" {
+		return errResp
+	}
+	partition := -1
+	if partitionStr := args["partition"]; partitionStr != "" {
+		parsed, err := strconv.Atoi(partitionStr)
+		if err != nil {
+			return fmt.Sprintf("ERROR: invalid_partition reason=%q", err.Error())
+		}
+		partition = parsed
+	}
+	seqNum, err := parseRequiredPositiveUint64(args["seqNum"])
+	if err != nil {
+		return fmt.Sprintf("ERROR: invalid_seq_num command=TXN_PUBLISH reason=%q", err.Error())
+	}
+
+	t := ch.TopicManager.GetTopic(topicName)
+	if t == nil {
+		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
+	}
+	if authResp := ch.authorizeTopicWrite(t.Policy, clientCtx); authResp != "" {
+		return fmt.Sprintf("%s topic=%s", authResp, topicName)
+	}
+	msg := types.Message{Payload: message, ProducerID: producerID, SeqNum: seqNum, Epoch: epoch, Key: args["key"], TransactionalID: txnID, TransactionState: types.TransactionStateOpen}
+	if partition < 0 {
+		partition = t.GetPartitionForMessage(msg)
+	}
+	if _, err := t.GetPartition(partition); err != nil {
+		return fmt.Sprintf("ERROR: partition_not_found partition=%d", partition)
+	}
+	if err := ch.TxnManager.AddMessage(txnID, producerID, epoch, transaction.MessageOperation{Topic: topicName, Partition: partition, Message: msg}); err != nil {
+		return fmt.Sprintf("ERROR: transaction_publish_failed reason=%q", err.Error())
+	}
+	if err := ch.syncTransactionState(txnID); err != nil {
+		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+	}
+	return fmt.Sprintf("OK transactional_id=%s staged_messages=1 topic=%s partition=%d", txnID, topicName, partition)
+}
+
+func (ch *CommandHandler) handleSendOffsetsToTxn(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("SEND_OFFSETS_TO_TXN "):])
+	txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+	if txnID == "" {
+		return "ERROR: missing_transactional_id command=SEND_OFFSETS_TO_TXN"
+	}
+	if resp := ch.ensureTransactionCoordinator(txnID); resp != "" {
+		return resp
+	}
+	topicName := args["topic"]
+	if topicName == "" {
+		return "ERROR: missing_topic command=SEND_OFFSETS_TO_TXN"
+	}
+	groupID := args["group"]
+	if groupID == "" {
+		return "ERROR: missing_group command=SEND_OFFSETS_TO_TXN"
+	}
+	producerID, epoch, errResp := parseTxnProducerEpoch(args, "SEND_OFFSETS_TO_TXN")
+	if errResp != "" {
+		return errResp
+	}
+	memberID := args["member"]
+	if memberID == "" {
+		return "ERROR: missing_member command=SEND_OFFSETS_TO_TXN"
+	}
+	generation, genErr := strconv.Atoi(args["generation"])
+	if genErr != nil {
+		return "ERROR: invalid_generation command=SEND_OFFSETS_TO_TXN"
+	}
+	if ch.Coordinator == nil {
+		return "ERROR: offset_manager_not_available"
+	}
+	offsetTopic, offsetTopicErr := ch.resolveGroupOffsetTopic(groupID, topicName)
+	if offsetTopicErr != "" {
+		return offsetTopicErr
+	}
+	offsets, err := parseTxnOffsetPairs(cmd)
+	if err != nil {
+		return fmt.Sprintf("ERROR: invalid_txn_offsets reason=%q", err.Error())
+	}
+	ops := make([]transaction.OffsetOperation, 0, len(offsets))
+	for partition, offset := range offsets {
+		op := transaction.OffsetOperation{Topic: offsetTopic, Group: groupID, Member: memberID, Generation: generation, Partition: partition, Offset: offset}
+		if err := ch.validateTransactionOffset(op, false); err != nil {
+			return err.Error()
+		}
+		ops = append(ops, op)
+	}
+	if err := ch.TxnManager.AddOffsets(txnID, producerID, epoch, ops); err != nil {
+		return fmt.Sprintf("ERROR: transaction_offsets_failed reason=%q", err.Error())
+	}
+	if err := ch.syncTransactionState(txnID); err != nil {
+		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+	}
+	return fmt.Sprintf("OK transactional_id=%s staged_offsets=%d", txnID, len(ops))
+}
+
+func (ch *CommandHandler) handleEndTxn(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("END_TXN "):])
+	txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+	if txnID == "" {
+		return "ERROR: missing_transactional_id command=END_TXN"
+	}
+	if resp := ch.ensureTransactionCoordinator(txnID); resp != "" {
+		return resp
+	}
+	producerID, epoch, errResp := parseTxnProducerEpoch(args, "END_TXN")
+	if errResp != "" {
+		return errResp
+	}
+	result := strings.ToLower(firstNonEmpty(args["result"], args["action"], args["state"]))
+	if result == "" {
+		result = "commit"
+	}
+	current, statusErr := ch.TxnManager.ValidateOwner(txnID, producerID, epoch)
+	if statusErr != nil {
+		return fmt.Sprintf("ERROR: transaction_not_found reason=%q", statusErr.Error())
+	}
+	if result == "abort" {
+		if current.State == transaction.StateCommitted {
+			return fmt.Sprintf("ERROR: transaction_already_committed transactional_id=%s", txnID)
+		}
+		if current.State == transaction.StateAborted {
+			return fmt.Sprintf("OK transactional_id=%s state=aborted", txnID)
+		}
+		if err := ch.appendTransactionMarkers(current, types.TransactionMarkerAbort); err != nil {
+			return fmt.Sprintf("ERROR: transaction_abort_marker_failed reason=%q", err.Error())
+		}
+		if err := ch.TxnManager.Abort(txnID, producerID, epoch); err != nil {
+			return fmt.Sprintf("ERROR: transaction_abort_failed reason=%q", err.Error())
+		}
+		if err := ch.syncTransactionState(txnID); err != nil {
+			return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+		}
+		return fmt.Sprintf("OK transactional_id=%s state=aborted", txnID)
+	}
+	if result != "commit" {
+		return fmt.Sprintf("ERROR: invalid_transaction_result value=%s", result)
+	}
+
+	if current.State == transaction.StateCommitted {
+		return fmt.Sprintf("OK transactional_id=%s state=committed messages=%d offsets=%d", txnID, len(current.Messages), len(current.Offsets))
+	}
+	if current.State == transaction.StateAborted {
+		return fmt.Sprintf("ERROR: transaction_aborted transactional_id=%s", txnID)
+	}
+
+	tx, err := ch.TxnManager.PrepareCommit(txnID, producerID, epoch)
+	if err != nil {
+		return fmt.Sprintf("ERROR: transaction_prepare_failed reason=%q", err.Error())
+	}
+	if err := ch.syncTransactionState(txnID); err != nil {
+		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+	}
+	if err := ch.applyTransaction(tx); err != nil {
+		if syncErr := ch.syncTransactionState(txnID); syncErr != nil {
+			return fmt.Sprintf("ERROR: transaction_commit_failed reason=%q sync_reason=%q", err.Error(), syncErr.Error())
+		}
+		return fmt.Sprintf("ERROR: transaction_commit_failed state=committing reason=%q", err.Error())
+	}
+	if err := ch.TxnManager.Commit(txnID); err != nil {
+		return fmt.Sprintf("ERROR: transaction_commit_failed reason=%q", err.Error())
+	}
+	if err := ch.syncTransactionState(txnID); err != nil {
+		return fmt.Sprintf("ERROR: transaction_sync_failed reason=%q", err.Error())
+	}
+	return fmt.Sprintf("OK transactional_id=%s state=committed messages=%d offsets=%d", txnID, len(tx.Messages), len(tx.Offsets))
+}
+
+func (ch *CommandHandler) RecoverPreparedTransactions() error {
+	if ch.TxnManager == nil {
+		return nil
+	}
+	pending := ch.TxnManager.TransactionsByState(transaction.StateCommitting)
+	if len(pending) == 0 {
+		return nil
+	}
+	for _, tx := range pending {
+		if tx == nil {
+			continue
+		}
+		if resp := ch.ensureTransactionCoordinator(tx.ID); resp != "" {
+			util.Debug("Skipping transaction recovery for %s on non-coordinator: %s", tx.ID, resp)
+			continue
+		}
+		if err := ch.applyTransaction(tx); err != nil {
+			return fmt.Errorf("recover transaction %s: %w", tx.ID, err)
+		}
+		if err := ch.TxnManager.Commit(tx.ID); err != nil {
+			return fmt.Errorf("mark recovered transaction %s committed: %w", tx.ID, err)
+		}
+		if err := ch.syncTransactionState(tx.ID); err != nil {
+			return fmt.Errorf("sync recovered transaction %s: %w", tx.ID, err)
+		}
+		util.Info("Recovered prepared transaction %s", tx.ID)
+	}
+	return nil
+}
+func (ch *CommandHandler) handleTxnStatus(cmd string) string {
+	args := parseKeyValueArgs(cmd[len("TXN_STATUS "):])
+	txnID := firstNonEmpty(args["transactional_id"], args["txn"], args["transaction"])
+	if txnID == "" {
+		return "ERROR: missing_transactional_id command=TXN_STATUS"
+	}
+	if resp := ch.ensureTransactionCoordinator(txnID); resp != "" {
+		return resp
+	}
+	tx, err := ch.TxnManager.Status(txnID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: transaction_not_found reason=%q", err.Error())
+	}
+	return fmt.Sprintf("OK transactional_id=%s state=%s messages=%d offsets=%d", tx.ID, tx.State, len(tx.Messages), len(tx.Offsets))
+}
+
+func (ch *CommandHandler) applyTransaction(tx *transaction.Transaction) error {
+	ch.txnApplyMu.Lock()
+	defer ch.txnApplyMu.Unlock()
+
+	for _, op := range tx.Messages {
+		t := ch.TopicManager.GetTopic(op.Topic)
+		if t == nil {
+			return fmt.Errorf("topic %s not found", op.Topic)
+		}
+		if !t.Policy.CanWrite() {
+			return fmt.Errorf("NOT_AUTHORIZED_FOR_TOPIC topic=%s operation=write", op.Topic)
+		}
+		if _, err := t.GetPartition(op.Partition); err != nil {
+			return err
+		}
+	}
+	for _, op := range tx.Offsets {
+		if err := ch.validateTransactionOffset(op, true); err != nil {
+			return err
+		}
+	}
+	apply := func() error {
+		for _, op := range tx.Messages {
+			if err := ch.publishCommittedTransactionMessage(op); err != nil {
+				return err
+			}
+		}
+		if err := ch.appendTransactionMarkers(tx, types.TransactionMarkerCommit); err != nil {
+			return err
+		}
+		for _, op := range tx.Offsets {
+			if err := ch.commitTransactionOffset(op); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return ch.withTransactionOffsetFences(tx.Offsets, apply)
+}
+
+type transactionOffsetFence struct {
+	Group      string
+	Member     string
+	Generation int
+	Partitions []int
+}
+
+func (ch *CommandHandler) withTransactionOffsetFences(ops []transaction.OffsetOperation, apply func() error) error {
+	if ch.Coordinator == nil || len(ops) == 0 || ch.isDistributed() {
+		return apply()
+	}
+	fences := buildTransactionOffsetFences(ops)
+	var run func(int) error
+	run = func(idx int) error {
+		if idx >= len(fences) {
+			return apply()
+		}
+		fence := fences[idx]
+		return ch.Coordinator.WithOwnershipFence(fence.Group, fence.Member, fence.Generation, fence.Partitions, func() error {
+			return run(idx + 1)
+		})
+	}
+	return run(0)
+}
+
+func (ch *CommandHandler) validateTransactionOffset(op transaction.OffsetOperation, checkRegression bool) error {
+	if ch.Coordinator == nil {
+		return fmt.Errorf("ERROR: offset_manager_not_available")
+	}
+	if ch.isDistributed() && ch.Cluster != nil && ch.Cluster.Router != nil {
+		cmd := fmt.Sprintf("COMMIT_OFFSET topic=%s partition=%d group=%s offset=%d member=%s generation=%d validate_only=true", op.Topic, op.Partition, op.Group, op.Offset, op.Member, op.Generation)
+		if !checkRegression {
+			cmd += " ownership_only=true"
+		}
+		encodedCmd := util.EncodeMessage("", cmd)
+		resp, err := ch.Cluster.Router.ForwardToCoordinator(op.Group, string(encodedCmd))
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(resp, "OK") {
+			return fmt.Errorf("%s", resp)
+		}
+		return nil
+	}
+	if errResp := ch.Coordinator.ValidateOwnershipFailure(op.Group, op.Member, op.Generation, op.Partition); errResp != "" {
+		return fmt.Errorf("%s", errResp)
+	}
+	if checkRegression {
+		if current, ok := ch.Coordinator.GetOffset(op.Group, op.Topic, op.Partition); ok && op.Offset < current {
+			return fmt.Errorf("offset regression group=%s topic=%s partition=%d current=%d got=%d", op.Group, op.Topic, op.Partition, current, op.Offset)
+		}
+	}
+	return nil
+}
+func buildTransactionOffsetFences(ops []transaction.OffsetOperation) []transactionOffsetFence {
+	type key struct {
+		group      string
+		member     string
+		generation int
+	}
+	index := make(map[key]int)
+	partitionSeen := make(map[key]map[int]struct{})
+	fences := make([]transactionOffsetFence, 0)
+	for _, op := range ops {
+		k := key{group: op.Group, member: op.Member, generation: op.Generation}
+		idx, ok := index[k]
+		if !ok {
+			idx = len(fences)
+			index[k] = idx
+			partitionSeen[k] = make(map[int]struct{})
+			fences = append(fences, transactionOffsetFence{Group: op.Group, Member: op.Member, Generation: op.Generation})
+		}
+		if _, ok := partitionSeen[k][op.Partition]; ok {
+			continue
+		}
+		partitionSeen[k][op.Partition] = struct{}{}
+		fences[idx].Partitions = append(fences[idx].Partitions, op.Partition)
+	}
+	return fences
+}
+func (ch *CommandHandler) appendTransactionMarkers(tx *transaction.Transaction, marker string) error {
+	if tx == nil || len(tx.Messages) == 0 {
+		return nil
+	}
+	state := types.TransactionStateCommitted
+	if marker == types.TransactionMarkerAbort {
+		state = types.TransactionStateAborted
+	}
+
+	partitions := touchedTransactionPartitions(tx)
+	for _, partition := range partitions {
+		controlKey, controlValue, err := transactionMarkerControlBytes(marker, tx.Epoch)
+		if err != nil {
+			return err
+		}
+		msg := types.Message{
+			Payload:                      transactionControlMarkerPayload,
+			ProducerID:                   transactionMarkerProducerID(tx, marker),
+			SeqNum:                       1,
+			Epoch:                        tx.Epoch,
+			TransactionalID:              tx.ID,
+			TransactionState:             state,
+			TransactionMarker:            marker,
+			ControlBatchType:             types.ControlBatchTransaction,
+			ControlBatchVersion:          types.ControlBatchVersionCursusV2,
+			ControlBatchCoordinatorEpoch: tx.Epoch,
+			ControlBatchKey:              controlKey,
+			ControlBatchValue:            controlValue,
+		}
+		if err := ch.publishTransactionMarker(partition.Topic, partition.Partition, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type transactionPartition struct {
+	Topic     string
+	Partition int
+}
+
+func transactionMarkerProducerID(tx *transaction.Transaction, marker string) string {
+	if tx == nil {
+		return "txn-marker:unknown"
+	}
+	return fmt.Sprintf("txn-marker:%s:%s", tx.ID, marker)
+}
+func touchedTransactionPartitions(tx *transaction.Transaction) []transactionPartition {
+	seen := make(map[transactionPartition]struct{})
+	for _, op := range tx.Messages {
+		seen[transactionPartition{Topic: op.Topic, Partition: op.Partition}] = struct{}{}
+	}
+	out := make([]transactionPartition, 0, len(seen))
+	for partition := range seen {
+		out = append(out, partition)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Topic == out[j].Topic {
+			return out[i].Partition < out[j].Partition
+		}
+		return out[i].Topic < out[j].Topic
+	})
+	return out
+}
+
+func (ch *CommandHandler) publishTransactionMarker(topicName string, partition int, msg types.Message) error {
+	if ch.isDistributed() {
+		cmd := fmt.Sprintf("PUBLISH topic=%s acks=1 producerId=%s partition=%d seqNum=%d epoch=%d isIdempotent=true transactional_id=%s transaction_state=%s transaction_marker=%s control_batch_type=%s control_batch_version=%d control_batch_coordinator_epoch=%d control_batch_key=%s control_batch_value=%s internal_txn_publish=true message=%s", topicName, msg.ProducerID, partition, msg.SeqNum, msg.Epoch, msg.TransactionalID, msg.TransactionState, msg.TransactionMarker, msg.ControlBatchType, msg.ControlBatchVersion, msg.ControlBatchCoordinatorEpoch, base64.StdEncoding.EncodeToString(msg.ControlBatchKey), base64.StdEncoding.EncodeToString(msg.ControlBatchValue), msg.Payload)
+		resp := ch.handlePublish(cmd)
+		if !strings.HasPrefix(resp, "OK") && !strings.HasPrefix(resp, "{") {
+			return fmt.Errorf("%s", resp)
+		}
+		return nil
+	}
+	return ch.TopicManager.PublishToPartitionWithAckIdempotent(topicName, partition, &msg)
+}
+func (ch *CommandHandler) publishCommittedTransactionMessage(op transaction.MessageOperation) error {
+	msg := op.Message
+	msg.TransactionState = types.TransactionStateOpen
+	msg.TransactionMarker = types.TransactionMarkerNone
+	if ch.isDistributed() {
+		cmd := fmt.Sprintf("PUBLISH topic=%s acks=1 producerId=%s partition=%d seqNum=%d epoch=%d isIdempotent=true internal_txn_publish=true", op.Topic, msg.ProducerID, op.Partition, msg.SeqNum, msg.Epoch)
+		if msg.Key != "" {
+			cmd += fmt.Sprintf(" key=%s", msg.Key)
+		}
+		if msg.TransactionalID != "" {
+			cmd += fmt.Sprintf(" transactional_id=%s transaction_state=%s", msg.TransactionalID, msg.TransactionState)
+		}
+		cmd += " message=" + msg.Payload
+		resp := ch.handlePublish(cmd)
+		if !strings.HasPrefix(resp, "OK") && !strings.HasPrefix(resp, "{") {
+			return fmt.Errorf("%s", resp)
+		}
+		return nil
+	}
+	return ch.TopicManager.PublishToPartitionWithAckIdempotent(op.Topic, op.Partition, &msg)
+}
+
+func (ch *CommandHandler) validateTransactionPublishMetadata(args map[string]string, topicName string, partition int, msg *types.Message) string {
+	if msg == nil {
+		return ""
+	}
+	hasTxnMetadata := msg.TransactionalID != "" || msg.TransactionState != "" || msg.TransactionMarker != ""
+	if !hasTxnMetadata {
+		return ""
+	}
+	if !strings.EqualFold(args["internal_txn_publish"], "true") {
+		return "ERROR: transaction_metadata_forbidden command=PUBLISH"
+	}
+	if msg.TransactionalID == "" {
+		return "ERROR: missing_transactional_id command=PUBLISH"
+	}
+	if ch.TxnManager == nil {
+		return "ERROR: transaction_manager_not_available command=PUBLISH"
+	}
+	tx, err := ch.TxnManager.Status(msg.TransactionalID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: transaction_not_found transactional_id=%s", msg.TransactionalID)
+	}
+	if tx.Epoch != msg.Epoch {
+		return fmt.Sprintf("ERROR: producer_fenced transactional_id=%s current_epoch=%d requested_epoch=%d", msg.TransactionalID, tx.Epoch, msg.Epoch)
+	}
+	if msg.TransactionMarker != types.TransactionMarkerNone {
+		return ch.validateTransactionMarkerPublish(tx, topicName, partition, msg)
+	}
+	if tx.Producer != msg.ProducerID {
+		return fmt.Sprintf("ERROR: producer_fenced transactional_id=%s current_epoch=%d requested_epoch=%d", msg.TransactionalID, tx.Epoch, msg.Epoch)
+	}
+	return ch.validateTransactionRecordPublish(tx, topicName, partition, msg)
+}
+
+func (ch *CommandHandler) validateTransactionRecordPublish(tx *transaction.Transaction, topicName string, partition int, msg *types.Message) string {
+	if tx.State != transaction.StateCommitting {
+		return fmt.Sprintf("ERROR: transaction_not_committing transactional_id=%s state=%s", tx.ID, tx.State)
+	}
+	if msg.TransactionState != types.TransactionStateOpen {
+		return fmt.Sprintf("ERROR: invalid_transaction_state state=%s", msg.TransactionState)
+	}
+	for _, op := range tx.Messages {
+		if op.Topic == topicName && op.Partition == partition && op.Message.ProducerID == msg.ProducerID && op.Message.SeqNum == msg.SeqNum && op.Message.Epoch == msg.Epoch && op.Message.Payload == msg.Payload && op.Message.Key == msg.Key {
+			return ""
+		}
+	}
+	return fmt.Sprintf("ERROR: transaction_record_not_staged transactional_id=%s", tx.ID)
+}
+
+func (ch *CommandHandler) validateTransactionMarkerPublish(tx *transaction.Transaction, topicName string, partition int, msg *types.Message) string {
+	if msg.ControlBatchType != types.ControlBatchTransaction || msg.ControlBatchVersion != types.ControlBatchVersionCursusV2 {
+		return fmt.Sprintf("ERROR: invalid_transaction_control_batch transactional_id=%s type=%s version=%d", tx.ID, msg.ControlBatchType, msg.ControlBatchVersion)
+	}
+	if msg.ControlBatchCoordinatorEpoch != tx.Epoch {
+		return fmt.Sprintf("ERROR: invalid_transaction_control_epoch transactional_id=%s current_epoch=%d control_epoch=%d", tx.ID, tx.Epoch, msg.ControlBatchCoordinatorEpoch)
+	}
+	expectedKey, expectedValue, err := transactionMarkerControlBytes(msg.TransactionMarker, tx.Epoch)
+	if err != nil {
+		return fmt.Sprintf("ERROR: invalid_transaction_control_epoch transactional_id=%s reason=%q", tx.ID, err.Error())
+	}
+	if !bytes.Equal(msg.ControlBatchKey, expectedKey) || !bytes.Equal(msg.ControlBatchValue, expectedValue) {
+		return fmt.Sprintf("ERROR: invalid_transaction_control_record transactional_id=%s", tx.ID)
+	}
+	if msg.TransactionMarker != types.TransactionMarkerCommit && msg.TransactionMarker != types.TransactionMarkerAbort {
+		return fmt.Sprintf("ERROR: invalid_transaction_marker marker=%s", msg.TransactionMarker)
+	}
+	if msg.ProducerID != transactionMarkerProducerID(tx, msg.TransactionMarker) || msg.SeqNum != 1 {
+		return fmt.Sprintf("ERROR: invalid_transaction_marker_producer transactional_id=%s", tx.ID)
+	}
+	if msg.TransactionMarker == types.TransactionMarkerCommit && tx.State != transaction.StateCommitting {
+		return fmt.Sprintf("ERROR: transaction_not_committing transactional_id=%s state=%s", tx.ID, tx.State)
+	}
+	if msg.TransactionMarker == types.TransactionMarkerAbort && tx.State != transaction.StateOpen && tx.State != transaction.StateAborted {
+		return fmt.Sprintf("ERROR: transaction_not_abortable transactional_id=%s state=%s", tx.ID, tx.State)
+	}
+	for _, touched := range touchedTransactionPartitions(tx) {
+		if touched.Topic == topicName && touched.Partition == partition {
+			return ""
+		}
+	}
+	return fmt.Sprintf("ERROR: transaction_marker_partition_not_touched transactional_id=%s topic=%s partition=%d", tx.ID, topicName, partition)
+}
+func (ch *CommandHandler) validateReplicatedTransactionMessage(topicName string, partition int, msg *types.Message) string {
+	if msg == nil {
+		return ""
+	}
+	hasTxnMetadata := msg.TransactionalID != "" || msg.TransactionState != "" || msg.TransactionMarker != ""
+	if !hasTxnMetadata {
+		return ""
+	}
+	if msg.TransactionalID == "" {
+		return "ERROR: missing_transactional_id command=REPLICATE_MESSAGE"
+	}
+	if ch.TxnManager == nil {
+		return "ERROR: transaction_manager_not_available command=REPLICATE_MESSAGE"
+	}
+	tx, err := ch.TxnManager.Status(msg.TransactionalID)
+	if err != nil {
+		return fmt.Sprintf("ERROR: transaction_not_found transactional_id=%s", msg.TransactionalID)
+	}
+	if tx.Epoch != msg.Epoch {
+		return fmt.Sprintf("ERROR: producer_fenced transactional_id=%s current_epoch=%d requested_epoch=%d", msg.TransactionalID, tx.Epoch, msg.Epoch)
+	}
+	if msg.TransactionMarker != types.TransactionMarkerNone {
+		return ch.validateTransactionMarkerPublish(tx, topicName, partition, msg)
+	}
+	if tx.Producer != msg.ProducerID {
+		return fmt.Sprintf("ERROR: producer_fenced transactional_id=%s current_epoch=%d requested_epoch=%d", msg.TransactionalID, tx.Epoch, msg.Epoch)
+	}
+	return ch.validateTransactionRecordPublish(tx, topicName, partition, msg)
+}
+func (ch *CommandHandler) commitTransactionOffset(op transaction.OffsetOperation) error {
+	if ch.isDistributed() && ch.Cluster != nil && ch.Cluster.Router != nil {
+		cmd := fmt.Sprintf("COMMIT_OFFSET topic=%s partition=%d group=%s offset=%d member=%s generation=%d", op.Topic, op.Partition, op.Group, op.Offset, op.Member, op.Generation)
+		encodedCmd := util.EncodeMessage("", cmd)
+		resp, err := ch.Cluster.Router.ForwardToCoordinator(op.Group, string(encodedCmd))
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(resp, "OK") {
+			return fmt.Errorf("%s", resp)
+		}
+		return nil
+	}
+	if err := ch.Coordinator.ValidateAndCommit(op.Group, op.Topic, op.Partition, op.Offset, op.Generation, op.Member); err != nil {
+		return err
+	}
+	ch.recordConsumerLag(op.Topic, op.Partition, op.Offset, op.Group)
+	return nil
+}
+
+func (ch *CommandHandler) ensureTransactionCoordinator(txnID string) string {
+	if !ch.isDistributed() {
+		return ""
+	}
+	coordAddr, isCoord := ch.checkTransactionCoordinator(txnID)
+	if !isCoord {
+		return notCoordinatorResponse(coordAddr)
+	}
+	return ""
+}
+
+func (ch *CommandHandler) syncTransactionState(txnID string) error {
+	if !ch.isDistributed() {
+		return nil
+	}
+	snapshots := ch.TxnManager.ExportState()
+	snap := snapshots[txnID]
+	if snap == nil {
+		return fmt.Errorf("transaction %s not found", txnID)
+	}
+	_, err := ch.applyViaLeader("TXN_SYNC", map[string]interface{}{"transaction": snap})
+	return err
+}
+
+func transactionCoordinatorKey(txnID string) string {
+	return "txn:" + txnID
+}
+
+func parseTxnProducerEpoch(args map[string]string, command string) (string, int64, string) {
+	producerID := firstNonEmpty(args["producerId"], args["producer_id"])
+	if producerID == "" {
+		return "", 0, fmt.Sprintf("ERROR: missing_producer_id command=%s", command)
+	}
+	epoch, err := parseOptionalInt64(args["epoch"])
+	if err != nil {
+		return "", 0, fmt.Sprintf("ERROR: invalid_epoch reason=%q", err.Error())
+	}
+	return producerID, epoch, ""
+}
+
+func parseTxnOffsetPairs(cmd string) (map[int]uint64, error) {
+	partsIdx := strings.LastIndex(cmd, " ")
+	if partsIdx == -1 {
+		return nil, fmt.Errorf("missing offset pairs")
+	}
+	partitionData := cmd[partsIdx+1:]
+	if !strings.Contains(partitionData, ":") {
+		return nil, fmt.Errorf("missing offset pairs")
+	}
+	pairs := strings.Split(partitionData, ",")
+	offsets := make(map[int]uint64, len(pairs))
+	for _, pair := range pairs {
+		kv := strings.Split(pair, ":")
+		if len(kv) != 2 || !strings.HasPrefix(kv[0], "P") {
+			return nil, fmt.Errorf("invalid pair %s", pair)
+		}
+		partition, err := strconv.Atoi(strings.TrimPrefix(kv[0], "P"))
+		if err != nil {
+			return nil, err
+		}
+		offset, err := strconv.ParseUint(kv[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		offsets[partition] = offset
+	}
+	if len(offsets) == 0 {
+		return nil, fmt.Errorf("no offsets supplied")
+	}
+	return offsets, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func parseRequiredPositiveUint64(value string) (uint64, error) {
+	if value == "" {
+		return 0, fmt.Errorf("missing seqNum")
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if parsed == 0 {
+		return 0, fmt.Errorf("seqNum must be greater than zero")
+	}
+	return parsed, nil
+}
+
+func parseOptionalInt64(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(value, 10, 64)
+}
+
+func transactionMarkerControlBytes(marker string, coordinatorEpoch int64) ([]byte, []byte, error) {
+	if coordinatorEpoch < -(1<<31) || coordinatorEpoch > (1<<31)-1 {
+		return nil, nil, fmt.Errorf("coordinator epoch out of int32 range: %d", coordinatorEpoch)
+	}
+	var markerType int16
+	switch marker {
+	case types.TransactionMarkerCommit:
+		markerType = 0
+	case types.TransactionMarkerAbort:
+		markerType = 1
+	default:
+		return nil, nil, fmt.Errorf("invalid transaction marker %q", marker)
+	}
+	key := make([]byte, 4)
+	binary.BigEndian.PutUint16(key[0:2], 0)
+	binary.BigEndian.PutUint16(key[2:4], uint16(markerType))
+	valueBuf := bytes.Buffer{}
+	if err := binary.Write(&valueBuf, binary.BigEndian, int16(0)); err != nil {
+		return nil, nil, fmt.Errorf("encode transaction marker value version: %w", err)
+	}
+	epoch32 := int32(coordinatorEpoch) // #nosec G115 -- bounded to int32 range above.
+	if err := binary.Write(&valueBuf, binary.BigEndian, epoch32); err != nil {
+		return nil, nil, fmt.Errorf("encode transaction marker coordinator epoch: %w", err)
+	}
+	return key, valueBuf.Bytes(), nil
+}

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -313,18 +313,19 @@ func (c *Coordinator) ValidateOwnershipFailure(groupName, memberID string, gener
 }
 func (c *Coordinator) WithOwnershipFence(groupName, memberID string, generation int, partitions []int, fn func() error) error {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
+		c.mu.RUnlock()
 		return fmt.Errorf("%s", errResp)
 	}
 	group := c.groups[groupName]
 	member := group.Members[memberID]
 	for _, partition := range partitions {
 		if !contains(member.Assignments, partition) {
+			c.mu.RUnlock()
 			return fmt.Errorf("ERROR: NOT_OWNER partition=%d member=%s group=%s generation=%d", partition, memberID, groupName, generation)
 		}
 	}
+	c.mu.RUnlock()
 	if fn == nil {
 		return nil
 	}

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -311,6 +311,25 @@ func (c *Coordinator) ValidateOwnershipFailure(groupName, memberID string, gener
 	}
 	return ""
 }
+func (c *Coordinator) WithOwnershipFence(groupName, memberID string, generation int, partitions []int, fn func() error) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
+		return fmt.Errorf("%s", errResp)
+	}
+	group := c.groups[groupName]
+	member := group.Members[memberID]
+	for _, partition := range partitions {
+		if !contains(member.Assignments, partition) {
+			return fmt.Errorf("ERROR: NOT_OWNER partition=%d member=%s group=%s generation=%d", partition, memberID, groupName, generation)
+		}
+	}
+	if fn == nil {
+		return nil
+	}
+	return fn()
+}
 func contains(slice []int, item int) bool {
 	for _, s := range slice {
 		if s == item {

--- a/pkg/coordinator/coordinator_ext_test.go
+++ b/pkg/coordinator/coordinator_ext_test.go
@@ -177,6 +177,43 @@ func (p *persistentOffsetLog) ReadTopicPartition(_ string, partitionID int, offs
 	return out, nil
 }
 
+func TestCoordinatorValidateAndCommitReturnsWireErrors(t *testing.T) {
+	cfg := &config.Config{}
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("topic1", "group1", 2))
+	assignments, err := c.AddConsumer("group1", "member-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, assignments)
+	generation := c.GetGeneration("group1")
+
+	require.NoError(t, c.ValidateAndCommit("group1", "topic1", assignments[0], 10, generation, "member-1"))
+	offset, ok := c.GetOffset("group1", "topic1", assignments[0])
+	require.True(t, ok)
+	assert.Equal(t, uint64(10), offset)
+
+	err = c.ValidateAndCommit("group1", "topic1", assignments[0], 11, generation+1, "member-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: GEN_MISMATCH")
+
+	err = c.ValidateAndCommit("group1", "topic1", assignments[0], 11, generation, "missing-member")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: member_not_found")
+
+	unownedPartition := 1
+	if assignments[0] == 1 {
+		unownedPartition = 0
+	}
+	require.NoError(t, c.RegisterGroup("single-topic", "single-group", 2))
+	_, err = c.AddConsumer("single-group", "single-member")
+	require.NoError(t, err)
+	singleGeneration := c.GetGeneration("single-group")
+	c.mu.Lock()
+	c.groups["single-group"].Members["single-member"].Assignments = []int{assignments[0]}
+	c.mu.Unlock()
+	err = c.ValidateAndCommit("single-group", "single-topic", unownedPartition, 1, singleGeneration, "single-member")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: NOT_OWNER")
+}
 func TestCoordinator_MemberAssignments(t *testing.T) {
 	cfg := &config.Config{}
 	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -252,21 +252,15 @@ func (c *Coordinator) updateOffsetPartitionCount() {
 }
 
 func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, offset uint64, generation int, memberID string) error {
-	// Validate membership under global lock (membership is managed globally)
 	c.mu.RLock()
 	group := c.groups[groupName]
-
-	if group == nil || group.Members[memberID] == nil {
+	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
 		c.mu.RUnlock()
-		return fmt.Errorf("group/member not found")
-	}
-	if group.Generation != generation {
-		c.mu.RUnlock()
-		return fmt.Errorf("generation mismatch")
+		return fmt.Errorf("%s", errResp)
 	}
 	if !contains(group.Members[memberID].Assignments, partition) {
 		c.mu.RUnlock()
-		return fmt.Errorf("not partition owner")
+		return fmt.Errorf("ERROR: NOT_OWNER partition=%d member=%s group=%s generation=%d", partition, memberID, groupName, generation)
 	}
 	c.mu.RUnlock()
 

--- a/pkg/disk/flush_common.go
+++ b/pkg/disk/flush_common.go
@@ -268,18 +268,26 @@ func (d *DiskHandler) WriteDirect(topic string, partition int, msg types.Message
 	defer d.ioMu.Unlock()
 
 	diskMsg := types.DiskMessage{
-		Topic:            topic,
-		Partition:        int32(partition),
-		Offset:           msg.Offset,
-		ProducerID:       msg.ProducerID,
-		SeqNum:           msg.SeqNum,
-		Epoch:            msg.Epoch,
-		Payload:          msg.Payload,
-		Key:              msg.Key,
-		EventType:        msg.EventType,
-		SchemaVersion:    msg.SchemaVersion,
-		AggregateVersion: msg.AggregateVersion,
-		Metadata:         msg.Metadata,
+		Topic:                        topic,
+		Partition:                    int32(partition),
+		Offset:                       msg.Offset,
+		ProducerID:                   msg.ProducerID,
+		SeqNum:                       msg.SeqNum,
+		Epoch:                        msg.Epoch,
+		Payload:                      msg.Payload,
+		Key:                          msg.Key,
+		EventType:                    msg.EventType,
+		SchemaVersion:                msg.SchemaVersion,
+		AggregateVersion:             msg.AggregateVersion,
+		Metadata:                     msg.Metadata,
+		TransactionalID:              msg.TransactionalID,
+		TransactionState:             msg.TransactionState,
+		TransactionMarker:            msg.TransactionMarker,
+		ControlBatchType:             msg.ControlBatchType,
+		ControlBatchVersion:          msg.ControlBatchVersion,
+		ControlBatchCoordinatorEpoch: msg.ControlBatchCoordinatorEpoch,
+		ControlBatchKey:              msg.ControlBatchKey,
+		ControlBatchValue:            msg.ControlBatchValue,
 	}
 
 	serialized, err := util.SerializeDiskMessage(diskMsg)

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -288,18 +288,26 @@ func (d *DiskHandler) AppendMessage(topic string, partition int, msg *types.Mess
 
 	msg.Offset = offset
 	diskMsg := types.DiskMessage{
-		Topic:            topic,
-		Partition:        int32(partition),
-		Offset:           offset,
-		ProducerID:       msg.ProducerID,
-		SeqNum:           msg.SeqNum,
-		Epoch:            msg.Epoch,
-		Payload:          msg.Payload,
-		Key:              msg.Key,
-		EventType:        msg.EventType,
-		SchemaVersion:    msg.SchemaVersion,
-		AggregateVersion: msg.AggregateVersion,
-		Metadata:         msg.Metadata,
+		Topic:                        topic,
+		Partition:                    int32(partition),
+		Offset:                       offset,
+		ProducerID:                   msg.ProducerID,
+		SeqNum:                       msg.SeqNum,
+		Epoch:                        msg.Epoch,
+		Payload:                      msg.Payload,
+		Key:                          msg.Key,
+		EventType:                    msg.EventType,
+		SchemaVersion:                msg.SchemaVersion,
+		AggregateVersion:             msg.AggregateVersion,
+		Metadata:                     msg.Metadata,
+		TransactionalID:              msg.TransactionalID,
+		TransactionState:             msg.TransactionState,
+		TransactionMarker:            msg.TransactionMarker,
+		ControlBatchType:             msg.ControlBatchType,
+		ControlBatchVersion:          msg.ControlBatchVersion,
+		ControlBatchCoordinatorEpoch: msg.ControlBatchCoordinatorEpoch,
+		ControlBatchKey:              msg.ControlBatchKey,
+		ControlBatchValue:            msg.ControlBatchValue,
 	}
 
 	if d.writeTimeout > 0 {
@@ -473,16 +481,24 @@ func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position 
 		}
 
 		messages = append(messages, types.Message{
-			Offset:           diskMsg.Offset,
-			Payload:          diskMsg.Payload,
-			ProducerID:       diskMsg.ProducerID,
-			SeqNum:           diskMsg.SeqNum,
-			Epoch:            diskMsg.Epoch,
-			Key:              diskMsg.Key,
-			EventType:        diskMsg.EventType,
-			SchemaVersion:    diskMsg.SchemaVersion,
-			AggregateVersion: diskMsg.AggregateVersion,
-			Metadata:         diskMsg.Metadata,
+			Offset:                       diskMsg.Offset,
+			Payload:                      diskMsg.Payload,
+			ProducerID:                   diskMsg.ProducerID,
+			SeqNum:                       diskMsg.SeqNum,
+			Epoch:                        diskMsg.Epoch,
+			Key:                          diskMsg.Key,
+			EventType:                    diskMsg.EventType,
+			SchemaVersion:                diskMsg.SchemaVersion,
+			AggregateVersion:             diskMsg.AggregateVersion,
+			Metadata:                     diskMsg.Metadata,
+			TransactionalID:              diskMsg.TransactionalID,
+			TransactionState:             diskMsg.TransactionState,
+			TransactionMarker:            diskMsg.TransactionMarker,
+			ControlBatchType:             diskMsg.ControlBatchType,
+			ControlBatchVersion:          diskMsg.ControlBatchVersion,
+			ControlBatchCoordinatorEpoch: diskMsg.ControlBatchCoordinatorEpoch,
+			ControlBatchKey:              diskMsg.ControlBatchKey,
+			ControlBatchValue:            diskMsg.ControlBatchValue,
 		})
 		pos += 4 + int(msgLen)
 	}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -64,7 +65,6 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 	}
 
 	util.Info("🧩 Broker listening on %s (TLS=%v, Compression=%v)", addr, cfg.UseTLS, cfg.CompressionType)
-	brokerReady.Store(true)
 
 	if cd != nil {
 		cd.Start()
@@ -184,12 +184,10 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 			return err
 		}
 	}
-	go func() {
-		time.Sleep(2 * time.Second)
-		if err := globalCH.RecoverPreparedTransactions(); err != nil {
-			util.Error("Failed to recover prepared transactions: %v", err)
-		}
-	}()
+	if err := globalCH.RecoverPreparedTransactions(); err != nil {
+		return fmt.Errorf("failed to recover prepared transactions: %w", err)
+	}
+	brokerReady.Store(true)
 
 	go func() {
 		<-ctx.Done()
@@ -235,7 +233,16 @@ func startInternalBrokerListener(ctx context.Context, cfg *config.Config, cmdHan
 		<-ctx.Done()
 		_ = ln.Close()
 	}()
+	workerCh := make(chan net.Conn, maxWorkers)
+	for i := 0; i < maxWorkers; i++ {
+		go func() {
+			for conn := range workerCh {
+				handleInternalConn(ctx, conn, cmdHandler)
+			}
+		}()
+	}
 	go func() {
+		defer close(workerCh)
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
@@ -247,14 +254,27 @@ func startInternalBrokerListener(ctx context.Context, cfg *config.Config, cmdHan
 					continue
 				}
 			}
-			go handleConn(ctx, conn, cmdHandler)
+			select {
+			case workerCh <- conn:
+			default:
+				util.Warn("⚠️ Internal worker pool saturated; closing connection from %s", conn.RemoteAddr())
+				_ = conn.Close()
+			}
 		}
 	}()
 	return nil
 }
 
+func handleInternalConn(ctx context.Context, conn net.Conn, cmdHandler *controller.CommandHandler) {
+	handleConnWithContext(ctx, conn, cmdHandler, controller.NewInternalClientContext("default-group", 0))
+}
+
 // handleConn processes a connection using a shared CommandHandler.
 func handleConn(ctx context.Context, conn net.Conn, cmdHandler *controller.CommandHandler) {
+	handleConnWithContext(ctx, conn, cmdHandler, controller.NewClientContext("default-group", 0))
+}
+
+func handleConnWithContext(ctx context.Context, conn net.Conn, cmdHandler *controller.CommandHandler, cmdCtx *controller.ClientContext) {
 	isStreamed := false
 	defer func() {
 		if !isStreamed {
@@ -264,8 +284,6 @@ func handleConn(ctx context.Context, conn net.Conn, cmdHandler *controller.Comma
 
 	clientCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
-	cmdCtx := controller.NewClientContext("default-group", 0)
 
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
@@ -406,7 +424,11 @@ func readMessage(conn net.Conn, compressionType string) ([]byte, error) {
 
 func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *controller.ClientContext, conn net.Conn) (bool, error) {
 	if isBatchMessage(data) {
-		resp, err := cmdHandler.HandleBatchMessage(data, conn)
+		if ctx != nil && ctx.Internal && cmdHandler.Config != nil && cmdHandler.Config.InternalAuthToken != "" && !cmdHandler.Config.InternalUseTLS {
+			writeResponse(conn, "ERROR: internal_batch_requires_token_wrapper")
+			return false, nil
+		}
+		resp, err := cmdHandler.HandleBatchMessage(data, conn, ctx)
 		if err != nil {
 			return false, err
 		}
@@ -418,7 +440,14 @@ func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *con
 	if err != nil {
 		rawInput := string(data)
 		rawInput = strings.Trim(rawInput, "\x00 \t\n\r")
+		if strings.HasPrefix(strings.ToUpper(rawInput), "INTERNAL_BATCH ") {
+			return handleInternalBatchMessage(rawInput, cmdHandler, ctx, conn)
+		}
 		if isCommand(rawInput) {
+			if resp := authorizeInternalListenerCommand(rawInput, cmdHandler, ctx); resp != "" {
+				writeResponse(conn, resp)
+				return false, nil
+			}
 			return handleCommandMessage(rawInput, cmdHandler, ctx, conn)
 		}
 		util.Error("⚠️ Decode error and not a raw command: %v [%s]", err, string(data))
@@ -436,7 +465,14 @@ func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *con
 		return false, nil
 	}
 
+	if strings.HasPrefix(strings.ToUpper(payload), "INTERNAL_BATCH ") {
+		return handleInternalBatchMessage(payload, cmdHandler, ctx, conn)
+	}
 	if isCommand(payload) {
+		if resp := authorizeInternalListenerCommand(payload, cmdHandler, ctx); resp != "" {
+			writeResponse(conn, resp)
+			return false, nil
+		}
 		return handleCommandMessage(payload, cmdHandler, ctx, conn)
 	}
 
@@ -446,6 +482,60 @@ func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *con
 	return true, nil
 }
 
+func authorizeInternalListenerCommand(payload string, cmdHandler *controller.CommandHandler, ctx *controller.ClientContext) string {
+	if ctx == nil || !ctx.Internal || cmdHandler == nil || cmdHandler.Config == nil {
+		return ""
+	}
+	if cmdHandler.Config.InternalUseTLS {
+		return ""
+	}
+	token := strings.TrimSpace(cmdHandler.Config.InternalAuthToken)
+	if token == "" {
+		return "ERROR: internal_auth_not_configured command=INTERNAL_LISTENER"
+	}
+	if parseInternalCommandArgs(payload)["internal_token"] != token {
+		return "ERROR: internal_command_unauthorized command=INTERNAL_LISTENER"
+	}
+	return ""
+}
+
+func handleInternalBatchMessage(payload string, cmdHandler *controller.CommandHandler, ctx *controller.ClientContext, conn net.Conn) (bool, error) {
+	if ctx == nil || !ctx.Internal {
+		writeResponse(conn, "ERROR: internal_command_unauthorized command=INTERNAL_BATCH")
+		return false, nil
+	}
+	if resp := authorizeInternalListenerCommand(payload, cmdHandler, ctx); resp != "" {
+		writeResponse(conn, resp)
+		return false, nil
+	}
+	encoded := parseInternalCommandArgs(payload)["payload"]
+	if encoded == "" {
+		writeResponse(conn, "ERROR: missing_payload command=INTERNAL_BATCH")
+		return false, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		writeResponse(conn, fmt.Sprintf("ERROR: invalid_payload command=INTERNAL_BATCH reason=%q", err.Error()))
+		return false, nil
+	}
+	resp, err := cmdHandler.HandleBatchMessage(data, conn, ctx)
+	if err != nil {
+		return false, err
+	}
+	writeResponse(conn, resp)
+	return false, nil
+}
+
+func parseInternalCommandArgs(payload string) map[string]string {
+	args := map[string]string{}
+	for _, field := range strings.Fields(payload) {
+		key, value, ok := strings.Cut(field, "=")
+		if ok {
+			args[key] = value
+		}
+	}
+	return args
+}
 func handleCommandMessage(payload string, cmdHandler *controller.CommandHandler, ctx *controller.ClientContext, conn net.Conn) (bool, error) {
 	if strings.HasPrefix(strings.ToUpper(payload), "READ_STREAM ") {
 		cmdHandler.HandleReadStreamCommand(conn, payload)
@@ -499,7 +589,7 @@ func isCommand(s string) bool {
 		"GROUP_STATUS", "FETCH_OFFSET", "LIST_GROUPS", "SYNC_GROUP", "DESCRIBE",
 		"APPEND_STREAM", "READ_STREAM", "SAVE_SNAPSHOT", "READ_SNAPSHOT", "STREAM_VERSION",
 		"REPLICATE_MESSAGE", "REPLICATE_SNAPSHOT", "LIST_SNAPSHOTS", "FETCH_SNAPSHOT", "CATCHUP_SNAPSHOTS",
-		"FIND_COORDINATOR", "RAFT_APPLY", "METADATA"}
+		"FIND_COORDINATOR", "RAFT_APPLY", "METADATA", "INTERNAL_BATCH"}
 	for _, k := range keywords {
 		if strings.HasPrefix(strings.ToUpper(s), k) {
 			return true

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -139,7 +139,7 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 							"id": brokerID, "addr": localAddr, "client_addr": clientAddr,
 							"status": "active",
 						})
-						raftCmd := fmt.Sprintf("RAFT_APPLY type=REGISTER payload=%s", string(brokerJSON))
+						raftCmd := fmt.Sprintf("RAFT_APPLY %stype=REGISTER payload=%s", internalAuthPrefix(cfg), string(brokerJSON))
 						encodedCmd := util.EncodeMessage("", raftCmd)
 						if resp, err := cc.Router.ForwardToLeader(string(encodedCmd)); err == nil && !strings.HasPrefix(resp, "ERROR") {
 							util.Info("✅ Registered via leader with client address %s", clientAddr)
@@ -179,6 +179,18 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 	if cc != nil {
 		cc.SetLocalProcessor(globalCH)
 	}
+	if cfg.EnabledDistribution && cfg.InternalBrokerPort > 0 {
+		if err := startInternalBrokerListener(ctx, cfg, globalCH); err != nil {
+			return err
+		}
+	}
+	go func() {
+		time.Sleep(2 * time.Second)
+		if err := globalCH.RecoverPreparedTransactions(); err != nil {
+			util.Error("Failed to recover prepared transactions: %v", err)
+		}
+	}()
+
 	go func() {
 		<-ctx.Done()
 		if err := globalCH.Close(); err != nil {
@@ -203,6 +215,42 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 		}
 		workerCh <- conn
 	}
+}
+
+func startInternalBrokerListener(ctx context.Context, cfg *config.Config, cmdHandler *controller.CommandHandler) error {
+	addr := fmt.Sprintf(":%d", cfg.InternalBrokerPort)
+	var ln net.Listener
+	var err error
+	if cfg.InternalUseTLS {
+		ln, err = tls.Listen("tcp", addr, cfg.InternalServerTLSConfig())
+	} else {
+		ln, err = net.Listen("tcp", addr)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to start internal broker listener on %s: %w", addr, err)
+	}
+
+	util.Info("🔒 Internal broker listener started on %s (mTLS=%v)", addr, cfg.InternalUseTLS)
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					util.Error("⚠️ Internal accept error: %v", err)
+					continue
+				}
+			}
+			go handleConn(ctx, conn, cmdHandler)
+		}
+	}()
+	return nil
 }
 
 // handleConn processes a connection using a shared CommandHandler.
@@ -314,6 +362,13 @@ func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager
 			return
 		}
 	}
+}
+
+func internalAuthPrefix(cfg *config.Config) string {
+	if cfg != nil && cfg.InternalAuthToken != "" {
+		return "internal_token=" + cfg.InternalAuthToken + " "
+	}
+	return ""
 }
 
 func initializeConnection(cfg *config.Config, tm *topic.TopicManager, cd *coordinator.Coordinator, sm *stream.StreamManager, cc *clusterController.ClusterController) (*controller.CommandHandler, *controller.ClientContext) {
@@ -443,7 +498,7 @@ func isCommand(s string) bool {
 		"HEARTBEAT", "JOIN_GROUP", "LEAVE_GROUP", "COMMIT_OFFSET", "BATCH_COMMIT", "REGISTER_GROUP",
 		"GROUP_STATUS", "FETCH_OFFSET", "LIST_GROUPS", "SYNC_GROUP", "DESCRIBE",
 		"APPEND_STREAM", "READ_STREAM", "SAVE_SNAPSHOT", "READ_SNAPSHOT", "STREAM_VERSION",
-		"REPLICATE_SNAPSHOT", "LIST_SNAPSHOTS", "FETCH_SNAPSHOT", "CATCHUP_SNAPSHOTS",
+		"REPLICATE_MESSAGE", "REPLICATE_SNAPSHOT", "LIST_SNAPSHOTS", "FETCH_SNAPSHOT", "CATCHUP_SNAPSHOTS",
 		"FIND_COORDINATOR", "RAFT_APPLY", "METADATA"}
 	for _, k := range keywords {
 		if strings.HasPrefix(strings.ToUpper(s), k) {

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -142,11 +142,11 @@ func (tm *TopicManager) Publish(topicName string, msg *types.Message) error {
 	}
 
 	partition := t.GetPartitionForMessage(*msg)
-	return tm.publishInternal(topicName, partition, msg, false)
+	return tm.publishInternal(topicName, partition, msg, false, false)
 }
 
 func (tm *TopicManager) PublishToPartition(topicName string, partition int, msg *types.Message) error {
-	return tm.publishInternal(topicName, partition, msg, false)
+	return tm.publishInternal(topicName, partition, msg, false, false)
 }
 
 // Sync (acks=1)
@@ -157,11 +157,14 @@ func (tm *TopicManager) PublishWithAck(topicName string, msg *types.Message) err
 	}
 
 	partition := t.GetPartitionForMessage(*msg)
-	return tm.publishInternal(topicName, partition, msg, true)
+	return tm.publishInternal(topicName, partition, msg, true, false)
 }
 
 func (tm *TopicManager) PublishToPartitionWithAck(topicName string, partition int, msg *types.Message) error {
-	return tm.publishInternal(topicName, partition, msg, true)
+	return tm.publishInternal(topicName, partition, msg, true, false)
+}
+func (tm *TopicManager) PublishToPartitionWithAckIdempotent(topicName string, partition int, msg *types.Message) error {
+	return tm.publishInternal(topicName, partition, msg, true, true)
 }
 
 func (tm *TopicManager) processBatchMessages(topicName string, messages []types.Message, async bool) error {
@@ -254,8 +257,8 @@ func (tm *TopicManager) PublishBatchAsync(topicName string, messages []types.Mes
 	return tm.processBatchMessages(topicName, messages, true)
 }
 
-func (tm *TopicManager) publishInternal(topicName string, partition int, msg *types.Message, requireAck bool) error {
-	util.Debug("Starting publish. Topic: %s, RequireAck: %v, ProducerID: %s, SeqNum: %d", topicName, requireAck, msg.ProducerID, msg.SeqNum)
+func (tm *TopicManager) publishInternal(topicName string, partition int, msg *types.Message, requireAck bool, forceIdempotent bool) error {
+	util.Debug("Starting publish. Topic: %s, RequireAck: %v, ForceIdempotent: %v, ProducerID: %s, SeqNum: %d", topicName, requireAck, forceIdempotent, msg.ProducerID, msg.SeqNum)
 	start := time.Now()
 
 	t := tm.GetTopic(topicName)
@@ -264,8 +267,16 @@ func (tm *TopicManager) publishInternal(topicName string, partition int, msg *ty
 		return fmt.Errorf("topic '%s' does not exist", topicName)
 	}
 
+	if forceIdempotent && !requireAck {
+		return fmt.Errorf("forced idempotent publish requires acknowledgements")
+	}
+
 	if requireAck {
-		if err := t.PublishToPartitionSync(partition, *msg); err != nil {
+		if forceIdempotent {
+			if err := t.PublishToPartitionSyncIdempotent(partition, *msg); err != nil {
+				return fmt.Errorf("sync idempotent publish failed: %w", err)
+			}
+		} else if err := t.PublishToPartitionSync(partition, *msg); err != nil {
 			return fmt.Errorf("sync publish failed: %w", err)
 		}
 	} else {

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -32,6 +32,15 @@ type stagedProducerEntry struct {
 	lastSeq   uint64
 }
 
+// PartitionOffsetRange describes the retained and committed offsets for a partition.
+// Latest is the next readable committed offset, capped by the flushed disk tail.
+type PartitionOffsetRange struct {
+	Earliest uint64
+	Latest   uint64
+	LEO      uint64
+	HWM      uint64
+}
+
 // Partition handles messages for one shard of a topic.
 type Partition struct {
 	id                int
@@ -53,6 +62,9 @@ type Partition struct {
 	producerStateWG   sync.WaitGroup
 	producerState     sync.Map // map[string]*producerEntry
 	isIdempotent      bool
+	producerStateTTL  time.Duration
+	txnMarkerMu       sync.RWMutex
+	txnMarkers        map[transactionMarkerKey]transactionMarkerInfo
 	closeCh           chan struct{}
 }
 
@@ -62,12 +74,14 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 	initialOffset := latest + 1
 
 	p := &Partition{
-		id:            id,
-		topic:         topic,
-		dh:            dh,
-		streamManager: sm,
-		newMessageCh:  make(chan struct{}, 1),
-		closeCh:       make(chan struct{}),
+		id:               id,
+		topic:            topic,
+		dh:               dh,
+		streamManager:    sm,
+		newMessageCh:     make(chan struct{}, 1),
+		closeCh:          make(chan struct{}),
+		txnMarkers:       make(map[transactionMarkerKey]transactionMarkerInfo),
+		producerStateTTL: producerStateTTLFromConfig(cfg),
 	}
 
 	p.LEO.Store(initialOffset)
@@ -104,24 +118,31 @@ func NewPartition(id int, topic string, dh types.StorageHandler, sm StreamManage
 	}
 	if p.producerStateCh != nil {
 		p.loadProducerStateCheckpoint()
-		p.producerStateWG.Add(1)
-		go p.runProducerStateCheckpointLoop()
+	}
+	if _, ok := dh.(*disk.DiskHandler); ok {
+		p.rebuildTransactionMarkerIndex()
 	}
 
 	return p
 }
 
 func (p *Partition) validateProducerMessage(msg *types.Message) (bool, error) {
-	return p.validateProducerMessageWithStage(msg, nil)
+	return p.validateProducerMessageWithStage(msg, nil, false)
 }
 
-func (p *Partition) validateProducerMessageWithStage(msg *types.Message, staged map[string]stagedProducerEntry) (bool, error) {
-	if !p.isIdempotent {
+func (p *Partition) validateProducerMessageWithStage(msg *types.Message, staged map[string]stagedProducerEntry, force bool) (bool, error) {
+	if !p.isIdempotent && !force {
 		return false, nil
 	}
-	// SeqNum == 0 means the producer did not explicitly set a sequence number;
-	// skip dedup to avoid incorrectly rejecting every message after the first.
-	if msg.ProducerID == "" || msg.SeqNum == 0 {
+	if msg.ProducerID == "" {
+		return false, nil
+	}
+	if msg.SeqNum == 0 {
+		if force {
+			return false, fmt.Errorf("idempotency error: producer %s must set seqNum > 0", msg.ProducerID)
+		}
+		// SeqNum == 0 means a non-transactional producer did not explicitly set a sequence number;
+		// skip dedup to avoid incorrectly rejecting every message after the first.
 		return false, nil
 	}
 
@@ -142,7 +163,6 @@ func (p *Partition) validateProducerMessageWithStage(msg *types.Message, staged 
 
 	return false, nil
 }
-
 func (p *Partition) validateAgainstProducerState(msg *types.Message, lastEpoch int64, lastSeq uint64, allowDuplicate bool) (bool, error) {
 	if msg.Epoch < lastEpoch {
 		return false, fmt.Errorf("stale_producer_epoch producer=%s current=%d got=%d", msg.ProducerID, lastEpoch, msg.Epoch)
@@ -164,7 +184,11 @@ func (p *Partition) validateAgainstProducerState(msg *types.Message, lastEpoch i
 }
 
 func (p *Partition) updateProducerState(msg *types.Message) {
-	if !p.isIdempotent || msg.ProducerID == "" {
+	p.updateProducerStateWithMode(msg, false)
+}
+
+func (p *Partition) updateProducerStateWithMode(msg *types.Message, force bool) {
+	if (!p.isIdempotent && !force) || msg.ProducerID == "" {
 		return
 	}
 	if msg.SeqNum > 0 {
@@ -214,6 +238,7 @@ func (p *Partition) Enqueue(msg types.Message) {
 
 	p.updateProducerState(&msg)
 	msg.Offset = offset
+	p.indexTransactionMarker(msg)
 	p.LEO.Store(offset + 1)
 	p.setHWMLocked(offset + 1)
 
@@ -221,13 +246,21 @@ func (p *Partition) Enqueue(msg types.Message) {
 }
 
 func (p *Partition) EnqueueSync(msg types.Message) error {
+	return p.enqueueSync(msg, false)
+}
+
+func (p *Partition) EnqueueSyncIdempotent(msg types.Message) error {
+	return p.enqueueSync(msg, true)
+}
+
+func (p *Partition) enqueueSync(msg types.Message, forceIdempotent bool) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.closed {
 		return fmt.Errorf("partition %d is closed", p.id)
 	}
 
-	duplicate, err := p.validateProducerMessage(&msg)
+	duplicate, err := p.validateProducerMessageWithStage(&msg, nil, forceIdempotent)
 	if err != nil {
 		return err
 	}
@@ -241,13 +274,22 @@ func (p *Partition) EnqueueSync(msg types.Message) error {
 		return fmt.Errorf("disk write failed: %w", err)
 	}
 
-	p.updateProducerState(&msg)
+	p.updateProducerStateWithMode(&msg, forceIdempotent)
 	msg.Offset = offset
+	p.indexTransactionMarker(msg)
 	p.LEO.Store(offset + 1)
 	p.setHWMLocked(offset + 1)
 
 	p.NotifyNewMessage()
 	return nil
+}
+func batchHasTransactionalMessages(msgs []types.Message) bool {
+	for _, msg := range msgs {
+		if msg.TransactionalID != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // EnqueueBatchSync pushes multiple messages into the partition queue synchronously.
@@ -277,6 +319,7 @@ func (p *Partition) EnqueueBatchSync(msgs []types.Message) error {
 
 		p.updateProducerState(&msgs[i])
 		msgs[i].Offset = offset
+		p.indexTransactionMarker(msgs[i])
 		p.LEO.Store(offset + 1)
 		p.setHWMLocked(offset + 1)
 	}
@@ -310,6 +353,7 @@ func (p *Partition) EnqueueBatch(msgs []types.Message) error {
 
 		p.updateProducerState(&msgs[i])
 		msgs[i].Offset = offset
+		p.indexTransactionMarker(msgs[i])
 		p.LEO.Store(offset + 1)
 		p.setHWMLocked(offset + 1)
 	}
@@ -339,16 +383,17 @@ func (p *Partition) EnqueueBatchLeader(msgs []types.Message) error {
 	pending := make([]pendingLeaderMessage, 0, len(msgs))
 	diskBatch := make([]types.DiskMessage, 0, len(msgs))
 	staged := make(map[string]stagedProducerEntry)
+	forceIdempotent := batchHasTransactionalMessages(msgs)
 
 	for i := range msgs {
-		duplicate, err := p.validateProducerMessageWithStage(&msgs[i], staged)
+		duplicate, err := p.validateProducerMessageWithStage(&msgs[i], staged, forceIdempotent)
 		if err != nil {
 			return err
 		}
 		if duplicate {
 			continue
 		}
-		if p.isIdempotent && msgs[i].ProducerID != "" && msgs[i].SeqNum > 0 {
+		if (p.isIdempotent || forceIdempotent) && msgs[i].ProducerID != "" && msgs[i].SeqNum > 0 {
 			staged[msgs[i].ProducerID] = stagedProducerEntry{
 				lastEpoch: msgs[i].Epoch,
 				lastSeq:   msgs[i].SeqNum,
@@ -362,18 +407,26 @@ func (p *Partition) EnqueueBatchLeader(msgs []types.Message) error {
 			index: i,
 		})
 		diskBatch = append(diskBatch, types.DiskMessage{
-			Topic:            p.topic,
-			Partition:        partitionID,
-			Offset:           offset,
-			ProducerID:       msgs[i].ProducerID,
-			SeqNum:           msgs[i].SeqNum,
-			Epoch:            msgs[i].Epoch,
-			Payload:          msgs[i].Payload,
-			Key:              msgs[i].Key,
-			EventType:        msgs[i].EventType,
-			SchemaVersion:    msgs[i].SchemaVersion,
-			AggregateVersion: msgs[i].AggregateVersion,
-			Metadata:         msgs[i].Metadata,
+			Topic:                        p.topic,
+			Partition:                    partitionID,
+			Offset:                       offset,
+			ProducerID:                   msgs[i].ProducerID,
+			SeqNum:                       msgs[i].SeqNum,
+			Epoch:                        msgs[i].Epoch,
+			Payload:                      msgs[i].Payload,
+			Key:                          msgs[i].Key,
+			EventType:                    msgs[i].EventType,
+			SchemaVersion:                msgs[i].SchemaVersion,
+			AggregateVersion:             msgs[i].AggregateVersion,
+			Metadata:                     msgs[i].Metadata,
+			TransactionalID:              msgs[i].TransactionalID,
+			TransactionState:             msgs[i].TransactionState,
+			TransactionMarker:            msgs[i].TransactionMarker,
+			ControlBatchType:             msgs[i].ControlBatchType,
+			ControlBatchVersion:          msgs[i].ControlBatchVersion,
+			ControlBatchCoordinatorEpoch: msgs[i].ControlBatchCoordinatorEpoch,
+			ControlBatchKey:              msgs[i].ControlBatchKey,
+			ControlBatchValue:            msgs[i].ControlBatchValue,
 		})
 	}
 
@@ -391,7 +444,8 @@ func (p *Partition) EnqueueBatchLeader(msgs []types.Message) error {
 	}
 
 	for _, msg := range pending {
-		p.updateProducerState(&msgs[msg.index])
+		p.updateProducerStateWithMode(&msgs[msg.index], forceIdempotent)
+		p.indexTransactionMarker(msgs[msg.index])
 	}
 	p.LEO.Store(nextOffset)
 	p.NotifyNewMessage()
@@ -424,6 +478,7 @@ func (p *Partition) ReplicaAppend(msgs []types.Message) error {
 			p.LEO.Store(newLEO)
 		}
 		p.setHWMLocked(newLEO)
+		p.indexTransactionMarker(msgs[i])
 	}
 	p.NotifyNewMessage()
 	return nil
@@ -469,7 +524,289 @@ func (p *Partition) ReadCommitted(offset uint64, max int) ([]types.Message, erro
 		max = int(canRead) // #nosec G115 -- canRead is bounded by math.MaxInt before narrowing.
 	}
 
-	return p.ReadMessages(offset, max)
+	return p.readVisibleCommitted(offset, max, hwm)
+}
+
+func (p *Partition) readVisibleCommitted(offset uint64, max int, hwm uint64) ([]types.Message, error) {
+	if max <= 0 {
+		return nil, nil
+	}
+
+	markers := p.transactionMarkersBefore(hwm)
+	messages, err := p.readCommittedScanRange(offset, hwm, max, markers)
+	if err != nil {
+		return nil, err
+	}
+	markers = mergeScannedTransactionMarkers(markers, messages, hwm)
+
+	firstUnresolved := hwm
+	for _, msg := range messages {
+		if msg.Offset >= hwm {
+			break
+		}
+		if msg.TransactionalID == "" || msg.TransactionState != types.TransactionStateOpen {
+			continue
+		}
+		if !hasResolvingMarkerAfter(msg, markers) && msg.Offset < firstUnresolved {
+			firstUnresolved = msg.Offset
+		}
+	}
+
+	visible := make([]types.Message, 0, max)
+	for _, msg := range messages {
+		if msg.Offset >= hwm || msg.Offset >= firstUnresolved {
+			break
+		}
+		if isReadCommittedVisible(msg, markers) {
+			visible = append(visible, msg)
+			if len(visible) == max {
+				break
+			}
+		}
+	}
+	return visible, nil
+}
+
+func (p *Partition) readCommittedScanRange(offset uint64, hwm uint64, maxVisible int, markers map[transactionMarkerKey]transactionMarkerInfo) ([]types.Message, error) {
+	if offset >= hwm {
+		return nil, nil
+	}
+
+	messages := make([]types.Message, 0)
+	current := offset
+	const scanBatchSize = 1024
+	for current < hwm {
+		remaining := hwm - current
+		readMax := scanBatchSize
+		if remaining <= math.MaxInt && readMax > int(remaining) { // #nosec G115 -- remaining is bounded by math.MaxInt before narrowing.
+			readMax = int(remaining) // #nosec G115 -- remaining is bounded by math.MaxInt before narrowing.
+		}
+		if readMax <= 0 {
+			break
+		}
+
+		batch, err := p.ReadMessages(current, readMax)
+		if err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, msg := range batch {
+			if msg.Offset >= hwm {
+				break
+			}
+			messages = append(messages, msg)
+			next := msg.Offset + 1
+			if next <= current {
+				next = current + 1
+			}
+			current = next
+		}
+		if len(batch) < readMax || readCommittedScanHasEnoughVisible(messages, hwm, maxVisible, markers) {
+			break
+		}
+	}
+	return messages, nil
+}
+
+func readCommittedScanHasEnoughVisible(messages []types.Message, hwm uint64, maxVisible int, markers map[transactionMarkerKey]transactionMarkerInfo) bool {
+	if maxVisible <= 0 {
+		return true
+	}
+	markers = mergeScannedTransactionMarkers(markers, messages, hwm)
+	firstUnresolved := hwm
+	for _, msg := range messages {
+		if msg.Offset >= hwm {
+			break
+		}
+		if msg.TransactionalID == "" || msg.TransactionState != types.TransactionStateOpen {
+			continue
+		}
+		if !hasResolvingMarkerAfter(msg, markers) && msg.Offset < firstUnresolved {
+			firstUnresolved = msg.Offset
+		}
+	}
+	if firstUnresolved != hwm {
+		return false
+	}
+
+	visible := 0
+	for _, msg := range messages {
+		if msg.Offset >= hwm {
+			break
+		}
+		if isReadCommittedVisible(msg, markers) {
+			visible++
+			if visible >= maxVisible {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mergeScannedTransactionMarkers(base map[transactionMarkerKey]transactionMarkerInfo, messages []types.Message, hwm uint64) map[transactionMarkerKey]transactionMarkerInfo {
+	markers := make(map[transactionMarkerKey]transactionMarkerInfo, len(base))
+	for key, marker := range base {
+		markers[key] = marker
+	}
+	for _, msg := range messages {
+		if msg.Offset >= hwm {
+			break
+		}
+		if msg.TransactionMarker == types.TransactionMarkerNone || msg.TransactionalID == "" {
+			continue
+		}
+		key := messageTransactionMarkerKey(msg)
+		if existing, ok := markers[key]; !ok || msg.Offset >= existing.offset {
+			markers[key] = transactionMarkerInfo{marker: msg.TransactionMarker, offset: msg.Offset}
+		}
+	}
+	return markers
+}
+func (p *Partition) indexTransactionMarker(msg types.Message) {
+	if msg.TransactionalID == "" || msg.TransactionMarker == types.TransactionMarkerNone {
+		return
+	}
+	key := messageTransactionMarkerKey(msg)
+	p.txnMarkerMu.Lock()
+	defer p.txnMarkerMu.Unlock()
+	if p.txnMarkers == nil {
+		p.txnMarkers = make(map[transactionMarkerKey]transactionMarkerInfo)
+	}
+	if existing, ok := p.txnMarkers[key]; !ok || msg.Offset >= existing.offset {
+		p.txnMarkers[key] = transactionMarkerInfo{marker: msg.TransactionMarker, offset: msg.Offset}
+	}
+}
+
+func (p *Partition) transactionMarkersBefore(hwm uint64) map[transactionMarkerKey]transactionMarkerInfo {
+	p.txnMarkerMu.RLock()
+	defer p.txnMarkerMu.RUnlock()
+	markers := make(map[transactionMarkerKey]transactionMarkerInfo, len(p.txnMarkers))
+	for key, marker := range p.txnMarkers {
+		if marker.offset < hwm {
+			markers[key] = marker
+		}
+	}
+	return markers
+}
+
+func (p *Partition) rebuildTransactionMarkerIndex() {
+	if p.dh == nil {
+		return
+	}
+	first := p.dh.GetFirstOffset()
+	durableTail := p.dh.GetAbsoluteOffset()
+	if durableTail <= first {
+		return
+	}
+	markers := make(map[transactionMarkerKey]transactionMarkerInfo)
+	offset := first
+	const batchSize = 1024
+	for offset < durableTail {
+		msgs, err := p.dh.ReadMessages(offset, batchSize)
+		if err != nil || len(msgs) == 0 {
+			break
+		}
+		for _, msg := range msgs {
+			if msg.TransactionalID != "" && msg.TransactionMarker != types.TransactionMarkerNone {
+				key := messageTransactionMarkerKey(msg)
+				if existing, ok := markers[key]; !ok || msg.Offset >= existing.offset {
+					markers[key] = transactionMarkerInfo{marker: msg.TransactionMarker, offset: msg.Offset}
+				}
+			}
+			next := msg.Offset + 1
+			if next <= offset {
+				next = offset + 1
+			}
+			offset = next
+		}
+		if len(msgs) < batchSize {
+			break
+		}
+	}
+	p.txnMarkerMu.Lock()
+	p.txnMarkers = markers
+	p.txnMarkerMu.Unlock()
+}
+
+type transactionMarkerKey struct {
+	transactionalID string
+	epoch           int64
+}
+
+type transactionMarkerInfo struct {
+	marker string
+	offset uint64
+}
+
+func messageTransactionMarkerKey(msg types.Message) transactionMarkerKey {
+	return transactionMarkerKey{transactionalID: msg.TransactionalID, epoch: msg.Epoch}
+}
+
+func hasResolvingMarkerAfter(msg types.Message, markers map[transactionMarkerKey]transactionMarkerInfo) bool {
+	marker, ok := markers[messageTransactionMarkerKey(msg)]
+	return ok && marker.offset > msg.Offset
+}
+
+func isReadCommittedVisible(msg types.Message, markers map[transactionMarkerKey]transactionMarkerInfo) bool {
+	if msg.TransactionMarker != types.TransactionMarkerNone {
+		return false
+	}
+	if msg.TransactionalID == "" {
+		return true
+	}
+	if msg.TransactionState == types.TransactionStateAborted {
+		return false
+	}
+	marker, ok := markers[messageTransactionMarkerKey(msg)]
+	return ok && marker.offset > msg.Offset && marker.marker == types.TransactionMarkerCommit
+}
+
+func (p *Partition) RecoverProducerStateFromLog() {
+	if p.dh == nil || p.producerStateCh == nil {
+		return
+	}
+
+	first := p.dh.GetFirstOffset()
+	durableTail := p.dh.GetAbsoluteOffset()
+	if durableTail <= first {
+		return
+	}
+	offset := first
+	const batchSize = 1024
+	now := time.Now()
+
+	for {
+		msgs, err := p.dh.ReadMessages(offset, batchSize)
+		if err != nil || len(msgs) == 0 {
+			break
+		}
+		for _, msg := range msgs {
+			if msg.ProducerID != "" && msg.SeqNum > 0 {
+				p.producerState.Store(msg.ProducerID, &producerEntry{lastEpoch: msg.Epoch, lastSeq: msg.SeqNum, lastSeen: now})
+			}
+			next := msg.Offset + 1
+			if next <= offset {
+				next = offset + 1
+			}
+			offset = next
+		}
+		if len(msgs) < batchSize || offset >= durableTail {
+			break
+		}
+	}
+	p.signalProducerStateCheckpoint()
+}
+
+func (p *Partition) StartProducerStateMaintenance() {
+	if p.producerStateCh == nil {
+		return
+	}
+	p.producerStateWG.Add(1)
+	go p.runProducerStateCheckpointLoop()
+	go p.runProducerCleanup()
 }
 
 // FlushDisk forces all pending async writes to disk.
@@ -492,6 +829,28 @@ func (p *Partition) GetLatestOffset() uint64 {
 	return p.dh.GetLatestOffset()
 }
 
+func (p *Partition) OffsetRange() PartitionOffsetRange {
+	if p.dh == nil {
+		return PartitionOffsetRange{}
+	}
+
+	p.mu.RLock()
+	hwm := p.HWM
+	p.mu.RUnlock()
+
+	latest := hwm
+	flushed := p.dh.GetFlushedOffset()
+	if flushed < latest {
+		latest = flushed
+	}
+
+	return PartitionOffsetRange{
+		Earliest: p.dh.GetFirstOffset(),
+		Latest:   latest,
+		LEO:      p.LEO.Load(),
+		HWM:      hwm,
+	}
+}
 func (p *Partition) ID() int {
 	return p.id
 }
@@ -820,11 +1179,22 @@ const hwmCheckpointInterval = 250 * time.Millisecond
 
 const producerStateCheckpointInterval = 250 * time.Millisecond
 
-const producerStateTTL = 30 * time.Minute
+const defaultProducerStateTTL = 30 * time.Minute
+
+func producerStateTTLFromConfig(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.ProducerStateTTLMS <= 0 {
+		return defaultProducerStateTTL
+	}
+	return time.Duration(cfg.ProducerStateTTLMS) * time.Millisecond
+}
 
 // cleanStaleProducers removes producer entries that have not been seen within the TTL.
 func (p *Partition) cleanStaleProducers() {
-	cutoff := time.Now().Add(-producerStateTTL)
+	ttl := p.producerStateTTL
+	if ttl <= 0 {
+		ttl = defaultProducerStateTTL
+	}
+	cutoff := time.Now().Add(-ttl)
 	p.producerState.Range(func(key, value any) bool {
 		if entry := value.(*producerEntry); entry.lastSeen.Before(cutoff) {
 			p.producerState.Delete(key)

--- a/pkg/topic/partition_hwm_test.go
+++ b/pkg/topic/partition_hwm_test.go
@@ -2,6 +2,7 @@ package topic
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/cursus-io/cursus/pkg/config"
@@ -102,6 +103,37 @@ func TestPartition_RestoresProducerStateCheckpoint(t *testing.T) {
 	require.Equal(t, "second", msgs[1].Payload)
 }
 
+func TestPartition_RecoversProducerStateFromLogWithoutCheckpoint(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.DiskFlushIntervalMS = 1
+
+	dh, err := disk.NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	p := NewPartition(0, "orders", dh, nil, cfg)
+
+	msg := types.Message{Payload: "first", ProducerID: "producer-1", SeqNum: 1, TransactionalID: "tx-1", TransactionState: types.TransactionStateCommitted}
+	require.NoError(t, p.EnqueueSyncIdempotent(msg))
+	p.FlushDisk()
+	checkpointPath := p.producerStatePath
+	p.Close()
+	require.NoError(t, dh.Close())
+	require.NoError(t, os.Remove(checkpointPath))
+
+	restartedDH, err := disk.NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { _ = restartedDH.Close() }()
+	restarted := NewPartition(0, "orders", restartedDH, nil, cfg)
+	defer restarted.Close()
+	restarted.RecoverProducerStateFromLog()
+
+	retry := types.Message{Payload: "duplicate", ProducerID: "producer-1", SeqNum: 1, TransactionalID: "tx-1", TransactionState: types.TransactionStateCommitted}
+	require.NoError(t, restarted.EnqueueSyncIdempotent(retry))
+	msgs, err := restarted.ReadMessages(0, 10)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "first", msgs[0].Payload)
+}
 func TestPartition_ProducerEpochFencing(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.LogDir = t.TempDir()
@@ -250,4 +282,141 @@ func TestPartition_ReadCommittedReturnsOutOfRangeWhenEarliestEqualsHWM(t *testin
 	_, err := p.ReadCommitted(4, 10)
 	var offsetErr *types.OffsetOutOfRangeError
 	require.ErrorAs(t, err, &offsetErr)
+}
+func TestPartition_ReadCommittedStopsAtUnresolvedOpenTransaction(t *testing.T) {
+	cfg := config.DefaultConfig()
+	dh := new(MockStorageHandler)
+	dh.On("GetLatestOffset").Return(uint64(0)).Once()
+	dh.On("GetFlushedOffset").Return(uint64(5)).Once()
+	dh.On("GetFirstOffset").Return(uint64(0)).Once()
+	dh.On("ReadMessages", uint64(0), 5).Return([]types.Message{
+		{Offset: 0, Payload: "plain"},
+		{Offset: 1, Payload: "open", TransactionalID: "tx-open", TransactionState: types.TransactionStateOpen},
+		{Offset: 2, Payload: "committed", TransactionalID: "tx-commit", TransactionState: types.TransactionStateCommitted},
+		{Offset: 3, Payload: "marker", TransactionalID: "tx-commit", TransactionMarker: types.TransactionMarkerCommit},
+		{Offset: 4, Payload: "aborted", TransactionalID: "tx-abort", TransactionState: types.TransactionStateAborted},
+	}, nil).Once()
+
+	p := NewPartition(0, "orders", dh, nil, cfg)
+	p.SetHWM(5)
+
+	msgs, err := p.ReadCommitted(0, 5)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "plain", msgs[0].Payload)
+	dh.AssertExpectations(t)
+}
+
+func TestPartition_ReadCommittedUsesTransactionMarkers(t *testing.T) {
+	cfg := config.DefaultConfig()
+	dh := new(MockStorageHandler)
+	dh.On("GetLatestOffset").Return(uint64(0)).Once()
+	dh.On("GetFlushedOffset").Return(uint64(6)).Once()
+	dh.On("GetFirstOffset").Return(uint64(0)).Once()
+	dh.On("ReadMessages", uint64(0), 6).Return([]types.Message{
+		{Offset: 0, Payload: "before"},
+		{Offset: 1, Payload: "committed-by-marker", TransactionalID: "tx-commit", TransactionState: types.TransactionStateOpen},
+		{Offset: 2, Payload: "commit-marker", TransactionalID: "tx-commit", TransactionMarker: types.TransactionMarkerCommit},
+		{Offset: 3, Payload: "aborted-by-marker", TransactionalID: "tx-abort", TransactionState: types.TransactionStateOpen},
+		{Offset: 4, Payload: "abort-marker", TransactionalID: "tx-abort", TransactionMarker: types.TransactionMarkerAbort},
+		{Offset: 5, Payload: "after"},
+	}, nil).Once()
+
+	p := NewPartition(0, "orders", dh, nil, cfg)
+	p.SetHWM(6)
+
+	msgs, err := p.ReadCommitted(0, 10)
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	require.Equal(t, "before", msgs[0].Payload)
+	require.Equal(t, "committed-by-marker", msgs[1].Payload)
+	require.Equal(t, "after", msgs[2].Payload)
+	dh.AssertExpectations(t)
+}
+
+func TestPartition_ReadCommittedScansPastSmallVisibleBatchToFindMarker(t *testing.T) {
+	cfg := config.DefaultConfig()
+	dh := new(MockStorageHandler)
+	dh.On("GetLatestOffset").Return(uint64(0)).Once()
+	dh.On("GetFlushedOffset").Return(uint64(3)).Once()
+	dh.On("GetFirstOffset").Return(uint64(0)).Once()
+	dh.On("ReadMessages", uint64(0), 3).Return([]types.Message{
+		{Offset: 0, Payload: "committed-by-marker", TransactionalID: "tx-commit", TransactionState: types.TransactionStateOpen},
+		{Offset: 1, Payload: "commit-marker", TransactionalID: "tx-commit", TransactionMarker: types.TransactionMarkerCommit},
+		{Offset: 2, Payload: "after"},
+	}, nil).Once()
+
+	p := NewPartition(0, "orders", dh, nil, cfg)
+	p.SetHWM(3)
+
+	msgs, err := p.ReadCommitted(0, 1)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "committed-by-marker", msgs[0].Payload)
+	dh.AssertExpectations(t)
+}
+
+func TestPartition_ReadCommittedRequiresMarkerForTransactionalRecord(t *testing.T) {
+	cfg := config.DefaultConfig()
+	dh := new(MockStorageHandler)
+	dh.On("GetLatestOffset").Return(uint64(0)).Once()
+	dh.On("GetFlushedOffset").Return(uint64(2)).Once()
+	dh.On("GetFirstOffset").Return(uint64(0)).Once()
+	dh.On("ReadMessages", uint64(0), 2).Return([]types.Message{
+		{Offset: 0, Payload: "committed-state-without-marker", TransactionalID: "tx-state", TransactionState: types.TransactionStateCommitted},
+		{Offset: 1, Payload: "plain"},
+	}, nil).Once()
+
+	p := NewPartition(0, "orders", dh, nil, cfg)
+	p.SetHWM(2)
+
+	msgs, err := p.ReadCommitted(0, 10)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "plain", msgs[0].Payload)
+	dh.AssertExpectations(t)
+}
+
+func TestPartition_ReadCommittedSeparatesMarkersByEpoch(t *testing.T) {
+	cfg := config.DefaultConfig()
+	dh := new(MockStorageHandler)
+	dh.On("GetLatestOffset").Return(uint64(0)).Once()
+	dh.On("GetFlushedOffset").Return(uint64(4)).Once()
+	dh.On("GetFirstOffset").Return(uint64(0)).Once()
+	dh.On("ReadMessages", uint64(0), 4).Return([]types.Message{
+		{Offset: 0, Payload: "epoch0", TransactionalID: "tx-reused", TransactionState: types.TransactionStateOpen, Epoch: 0},
+		{Offset: 1, Payload: "epoch0-marker", TransactionalID: "tx-reused", TransactionMarker: types.TransactionMarkerCommit, Epoch: 0},
+		{Offset: 2, Payload: "epoch1-open", TransactionalID: "tx-reused", TransactionState: types.TransactionStateOpen, Epoch: 1},
+		{Offset: 3, Payload: "after"},
+	}, nil).Once()
+
+	p := NewPartition(0, "orders", dh, nil, cfg)
+	p.SetHWM(4)
+
+	msgs, err := p.ReadCommitted(0, 10)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "epoch0", msgs[0].Payload)
+	dh.AssertExpectations(t)
+}
+
+func TestPartition_ReadCommittedIgnoresMarkerBeforeRecord(t *testing.T) {
+	cfg := config.DefaultConfig()
+	dh := new(MockStorageHandler)
+	dh.On("GetLatestOffset").Return(uint64(0)).Once()
+	dh.On("GetFlushedOffset").Return(uint64(3)).Once()
+	dh.On("GetFirstOffset").Return(uint64(0)).Once()
+	dh.On("ReadMessages", uint64(0), 3).Return([]types.Message{
+		{Offset: 0, Payload: "early-marker", TransactionalID: "tx-order", TransactionMarker: types.TransactionMarkerCommit, Epoch: 0},
+		{Offset: 1, Payload: "late-record", TransactionalID: "tx-order", TransactionState: types.TransactionStateOpen, Epoch: 0},
+		{Offset: 2, Payload: "after"},
+	}, nil).Once()
+
+	p := NewPartition(0, "orders", dh, nil, cfg)
+	p.SetHWM(3)
+
+	msgs, err := p.ReadCommitted(0, 10)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+	dh.AssertExpectations(t)
 }

--- a/pkg/topic/policy.go
+++ b/pkg/topic/policy.go
@@ -11,13 +11,16 @@ const (
 	AuthPolicyOpen        = "open"
 	AuthPolicyDenyWrite   = "deny_write"
 	AuthPolicyDenyRead    = "deny_read"
+	AuthPolicyACL         = "acl"
 )
 
 type Policy struct {
-	RetentionHours int    `json:"retention_hours,omitempty"`
-	RetentionBytes int64  `json:"retention_bytes,omitempty"`
-	Partitioner    string `json:"partitioner"`
-	AuthPolicy     string `json:"auth_policy"`
+	RetentionHours int      `json:"retention_hours,omitempty"`
+	RetentionBytes int64    `json:"retention_bytes,omitempty"`
+	Partitioner    string   `json:"partitioner"`
+	AuthPolicy     string   `json:"auth_policy"`
+	ReadACL        []string `json:"read_acl,omitempty"`
+	WriteACL       []string `json:"write_acl,omitempty"`
 }
 
 func DefaultPolicy() Policy {
@@ -43,7 +46,7 @@ func (p Policy) Normalize() (Policy, error) {
 	}
 	p.AuthPolicy = strings.ToLower(strings.TrimSpace(p.AuthPolicy))
 	switch p.AuthPolicy {
-	case AuthPolicyOpen, AuthPolicyDenyWrite, AuthPolicyDenyRead:
+	case AuthPolicyOpen, AuthPolicyDenyWrite, AuthPolicyDenyRead, AuthPolicyACL:
 	default:
 		return p, fmt.Errorf("invalid auth policy %q", p.AuthPolicy)
 	}
@@ -63,4 +66,38 @@ func (p Policy) CanRead() bool {
 
 func (p Policy) CanWrite() bool {
 	return p.AuthPolicy != AuthPolicyDenyWrite
+}
+
+func (p Policy) CanReadPrincipal(principal string) bool {
+	if p.AuthPolicy == AuthPolicyDenyRead {
+		return false
+	}
+	if p.AuthPolicy != AuthPolicyACL {
+		return true
+	}
+	return aclContains(p.ReadACL, principal)
+}
+
+func (p Policy) CanWritePrincipal(principal string) bool {
+	if p.AuthPolicy == AuthPolicyDenyWrite {
+		return false
+	}
+	if p.AuthPolicy != AuthPolicyACL {
+		return true
+	}
+	return aclContains(p.WriteACL, principal)
+}
+
+func aclContains(acl []string, principal string) bool {
+	principal = strings.TrimSpace(principal)
+	if principal == "" {
+		return false
+	}
+	for _, item := range acl {
+		item = strings.TrimSpace(item)
+		if item == "*" || item == principal {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -47,9 +47,8 @@ func NewTopicWithPolicy(name string, partitionCount int, hp HandlerProvider, cfg
 		}
 		p := NewPartition(i, name, dh, sm, cfg)
 		p.isIdempotent = idempotent
-		if idempotent {
-			go p.runProducerCleanup()
-		}
+		p.RecoverProducerStateFromLog()
+		p.StartProducerStateMaintenance()
 		partitions[i] = p
 	}
 	return &Topic{
@@ -105,9 +104,8 @@ func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
 		}
 		newP := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
 		newP.isIdempotent = t.IsIdempotent
-		if t.IsIdempotent {
-			go newP.runProducerCleanup()
-		}
+		newP.RecoverProducerStateFromLog()
+		newP.StartProducerStateMaintenance()
 		t.Partitions = append(t.Partitions, newP)
 	}
 	return nil
@@ -203,6 +201,16 @@ func (t *Topic) PublishToPartitionSync(partition int, msg types.Message) error {
 	}
 
 	return t.Partitions[partition].EnqueueSync(msg)
+}
+func (t *Topic) PublishToPartitionSyncIdempotent(partition int, msg types.Message) error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if partition < 0 || partition >= len(t.Partitions) {
+		return fmt.Errorf("partition %d out of range for topic '%s' (0-%d)", partition, t.Name, len(t.Partitions)-1)
+	}
+
+	return t.Partitions[partition].EnqueueSyncIdempotent(msg)
 }
 
 // PublishBatchSync sends a batch of messages synchronously, grouping by partition.

--- a/pkg/topic/topic_ext_test.go
+++ b/pkg/topic/topic_ext_test.go
@@ -142,7 +142,7 @@ func TestPartition_Basic(t *testing.T) {
 	t.Run("ReadCommitted", func(t *testing.T) {
 		p.SetHWM(20)
 		mh.On("GetFlushedOffset").Return(uint64(20)).Maybe()
-		mh.On("ReadMessages", uint64(11), 2).Return([]types.Message{{Payload: "m1"}, {Payload: "m2"}}, nil).Once()
+		mh.On("ReadMessages", uint64(11), 9).Return([]types.Message{{Offset: 11, Payload: "m1"}, {Offset: 12, Payload: "m2"}}, nil).Once()
 		msgs, err := p.ReadCommitted(11, 2)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(msgs))

--- a/pkg/transaction/manager.go
+++ b/pkg/transaction/manager.go
@@ -1,0 +1,425 @@
+package transaction
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/types"
+)
+
+type State string
+
+const (
+	StateOpen       State = "open"
+	StateCommitting State = "committing"
+	StateCommitted  State = "committed"
+	StateAborted    State = "aborted"
+)
+
+type MessageOperation struct {
+	Topic     string
+	Partition int
+	Message   types.Message
+}
+
+type OffsetOperation struct {
+	Topic      string
+	Group      string
+	Member     string
+	Generation int
+	Partition  int
+	Offset     uint64
+}
+
+type Transaction struct {
+	ID        string
+	Producer  string
+	Epoch     int64
+	State     State
+	Messages  []MessageOperation
+	Offsets   []OffsetOperation
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type Snapshot struct {
+	ID        string             `json:"id"`
+	Producer  string             `json:"producer"`
+	Epoch     int64              `json:"epoch"`
+	State     State              `json:"state"`
+	Messages  []MessageOperation `json:"messages,omitempty"`
+	Offsets   []OffsetOperation  `json:"offsets,omitempty"`
+	CreatedAt time.Time          `json:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at"`
+}
+
+type Manager struct {
+	mu         sync.Mutex
+	txns       map[string]*Transaction
+	expiration time.Duration
+}
+
+func NewManager() *Manager {
+	return NewManagerWithExpiration(7 * 24 * time.Hour)
+}
+
+func NewManagerWithExpiration(expiration time.Duration) *Manager {
+	if expiration <= 0 {
+		expiration = 7 * 24 * time.Hour
+	}
+	return &Manager{txns: make(map[string]*Transaction), expiration: expiration}
+}
+
+func (m *Manager) PruneExpired(now time.Time) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pruneExpiredLocked(now)
+}
+
+func (m *Manager) pruneExpiredLocked(now time.Time) int {
+	if m.expiration <= 0 {
+		return 0
+	}
+	cutoff := now.Add(-m.expiration)
+	removed := 0
+	for id, tx := range m.txns {
+		if tx == nil {
+			delete(m.txns, id)
+			removed++
+			continue
+		}
+		switch tx.State {
+		case StateCommitted, StateAborted:
+			if tx.UpdatedAt.Before(cutoff) {
+				delete(m.txns, id)
+				removed++
+			}
+		}
+	}
+	return removed
+}
+func (m *Manager) InitProducer(id string) (string, int64, error) {
+	if id == "" {
+		return "", 0, fmt.Errorf("missing transaction id")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneExpiredLocked(time.Now())
+
+	producer := producerIDForTransactionalID(id)
+	epoch := int64(0)
+	if tx, ok := m.txns[id]; ok {
+		if tx.State == StateCommitting {
+			return "", 0, fmt.Errorf("transaction %s is committing; retry END_TXN before reinitializing producer", id)
+		}
+		if tx.Producer != "" {
+			producer = tx.Producer
+		}
+		epoch = tx.Epoch + 1
+	}
+
+	now := time.Now()
+	m.txns[id] = &Transaction{
+		ID:        id,
+		Producer:  producer,
+		Epoch:     epoch,
+		State:     StateAborted,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	return producer, epoch, nil
+}
+func (m *Manager) Begin(id, producer string, epoch int64) error {
+	if id == "" {
+		return fmt.Errorf("missing transaction id")
+	}
+	if producer == "" {
+		return fmt.Errorf("missing transactional producer")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, ok := m.txns[id]
+	if !ok {
+		return fmt.Errorf("transaction %s is not initialized; call INIT_PRODUCER_ID first", id)
+	}
+	if tx.Producer != "" && tx.Producer != producer {
+		return fmt.Errorf("transaction owner mismatch transactional_id=%s producer=%s requested=%s", id, tx.Producer, producer)
+	}
+	if epoch < tx.Epoch {
+		return fmt.Errorf("producer fenced transactional_id=%s current_epoch=%d requested_epoch=%d", id, tx.Epoch, epoch)
+	}
+	if epoch > tx.Epoch {
+		return fmt.Errorf("producer epoch not initialized transactional_id=%s current_epoch=%d requested_epoch=%d", id, tx.Epoch, epoch)
+	}
+	if tx.State != StateCommitted && tx.State != StateAborted {
+		return fmt.Errorf("transaction %s is already active", id)
+	}
+
+	now := time.Now()
+	m.txns[id] = &Transaction{
+		ID:        id,
+		Producer:  producer,
+		Epoch:     epoch,
+		State:     StateOpen,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	return nil
+}
+
+func (m *Manager) AddMessage(id, producer string, epoch int64, op MessageOperation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, err := m.activeLocked(id)
+	if err != nil {
+		return err
+	}
+	if err := validateOwner(tx, producer, epoch); err != nil {
+		return err
+	}
+	tx.Messages = append(tx.Messages, op)
+	tx.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *Manager) AddOffsets(id, producer string, epoch int64, offsets []OffsetOperation) error {
+	if len(offsets) == 0 {
+		return fmt.Errorf("no offsets supplied")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, err := m.activeLocked(id)
+	if err != nil {
+		return err
+	}
+	if err := validateOwner(tx, producer, epoch); err != nil {
+		return err
+	}
+	tx.Offsets = append(tx.Offsets, offsets...)
+	tx.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *Manager) PrepareCommit(id, producer string, epoch int64) (*Transaction, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, ok := m.txns[id]
+	if !ok {
+		return nil, fmt.Errorf("transaction %s not found", id)
+	}
+	if err := validateOwner(tx, producer, epoch); err != nil {
+		return nil, err
+	}
+	switch tx.State {
+	case StateOpen:
+		tx.State = StateCommitting
+		tx.UpdatedAt = time.Now()
+		return clone(tx), nil
+	case StateCommitting:
+		return clone(tx), nil
+	case StateCommitted:
+		return clone(tx), nil
+	case StateAborted:
+		return nil, fmt.Errorf("transaction %s is aborted", id)
+	default:
+		return nil, fmt.Errorf("transaction %s is %s", id, tx.State)
+	}
+}
+
+func (m *Manager) Commit(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, ok := m.txns[id]
+	if !ok {
+		return fmt.Errorf("transaction %s not found", id)
+	}
+	if tx.State != StateCommitting {
+		return fmt.Errorf("transaction %s is not prepared for commit", id)
+	}
+	tx.State = StateCommitted
+	tx.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *Manager) Abort(id, producer string, epoch int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, ok := m.txns[id]
+	if !ok {
+		return fmt.Errorf("transaction %s not found", id)
+	}
+	if err := validateOwner(tx, producer, epoch); err != nil {
+		return err
+	}
+	if tx.State == StateCommitted {
+		return fmt.Errorf("transaction %s is already committed", id)
+	}
+	if tx.State == StateAborted {
+		return nil
+	}
+	tx.State = StateAborted
+	tx.Messages = nil
+	tx.Offsets = nil
+	tx.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *Manager) ValidateOwner(id, producer string, epoch int64) (*Transaction, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, ok := m.txns[id]
+	if !ok {
+		return nil, fmt.Errorf("transaction %s not found", id)
+	}
+	if err := validateOwner(tx, producer, epoch); err != nil {
+		return nil, err
+	}
+	return clone(tx), nil
+}
+func (m *Manager) Status(id string) (*Transaction, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tx, ok := m.txns[id]
+	if !ok {
+		return nil, fmt.Errorf("transaction %s not found", id)
+	}
+	return clone(tx), nil
+}
+
+func (m *Manager) TransactionsByState(states ...State) []*Transaction {
+	wanted := make(map[State]struct{}, len(states))
+	for _, state := range states {
+		wanted[state] = struct{}{}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make([]*Transaction, 0)
+	for _, tx := range m.txns {
+		if _, ok := wanted[tx.State]; ok {
+			out = append(out, clone(tx))
+		}
+	}
+	return out
+}
+func (m *Manager) ExportState() map[string]*Snapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make(map[string]*Snapshot, len(m.txns))
+	for id, tx := range m.txns {
+		out[id] = snapshot(tx)
+	}
+	return out
+}
+
+func (m *Manager) ImportState(state map[string]*Snapshot) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.txns = make(map[string]*Transaction, len(state))
+	for id, snap := range state {
+		if snap == nil {
+			continue
+		}
+		m.txns[id] = transactionFromSnapshot(snap)
+	}
+}
+
+func (m *Manager) ApplySnapshot(snap *Snapshot) {
+	if snap == nil || snap.ID == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.txns[snap.ID] = transactionFromSnapshot(snap)
+}
+
+func (m *Manager) Delete(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.txns, id)
+}
+
+func (m *Manager) activeLocked(id string) (*Transaction, error) {
+	tx, ok := m.txns[id]
+	if !ok {
+		return nil, fmt.Errorf("transaction %s not found", id)
+	}
+	if tx.State != StateOpen {
+		return nil, fmt.Errorf("transaction %s is %s", id, tx.State)
+	}
+	return tx, nil
+}
+
+func validateOwner(tx *Transaction, producer string, epoch int64) error {
+	if producer == "" {
+		return fmt.Errorf("missing transactional producer")
+	}
+	if tx.Producer != producer {
+		return fmt.Errorf("transaction owner mismatch transactional_id=%s producer=%s requested=%s", tx.ID, tx.Producer, producer)
+	}
+	if epoch != tx.Epoch {
+		return fmt.Errorf("producer fenced transactional_id=%s current_epoch=%d requested_epoch=%d", tx.ID, tx.Epoch, epoch)
+	}
+	return nil
+}
+
+func clone(tx *Transaction) *Transaction {
+	if tx == nil {
+		return nil
+	}
+	out := *tx
+	out.Messages = append([]MessageOperation(nil), tx.Messages...)
+	out.Offsets = append([]OffsetOperation(nil), tx.Offsets...)
+	return &out
+}
+
+func snapshot(tx *Transaction) *Snapshot {
+	if tx == nil {
+		return nil
+	}
+	return &Snapshot{
+		ID:        tx.ID,
+		Producer:  tx.Producer,
+		Epoch:     tx.Epoch,
+		State:     tx.State,
+		Messages:  append([]MessageOperation(nil), tx.Messages...),
+		Offsets:   append([]OffsetOperation(nil), tx.Offsets...),
+		CreatedAt: tx.CreatedAt,
+		UpdatedAt: tx.UpdatedAt,
+	}
+}
+
+func transactionFromSnapshot(snap *Snapshot) *Transaction {
+	return &Transaction{
+		ID:        snap.ID,
+		Producer:  snap.Producer,
+		Epoch:     snap.Epoch,
+		State:     snap.State,
+		Messages:  append([]MessageOperation(nil), snap.Messages...),
+		Offsets:   append([]OffsetOperation(nil), snap.Offsets...),
+		CreatedAt: snap.CreatedAt,
+		UpdatedAt: snap.UpdatedAt,
+	}
+}
+
+func producerIDForTransactionalID(id string) string {
+	sum := sha256.Sum256([]byte(id))
+	return "txn-" + hex.EncodeToString(sum[:8])
+}

--- a/pkg/transaction/manager_test.go
+++ b/pkg/transaction/manager_test.go
@@ -1,0 +1,190 @@
+package transaction
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/types"
+)
+
+func beginInitialized(t *testing.T, m *Manager, txnID string) (string, int64) {
+	t.Helper()
+	producer, epoch, err := m.InitProducer(txnID)
+	if err != nil {
+		t.Fatalf("init producer failed: %v", err)
+	}
+	if err := m.Begin(txnID, producer, epoch); err != nil {
+		t.Fatalf("begin failed: %v", err)
+	}
+	return producer, epoch
+}
+
+func TestManagerRejectsBeginWithoutInitProducer(t *testing.T) {
+	m := NewManager()
+	if err := m.Begin("tx-1", "producer-1", 0); err == nil {
+		t.Fatal("expected uninitialized transaction begin to fail")
+	}
+}
+
+func TestManagerFencesLowerProducerEpoch(t *testing.T) {
+	m := NewManager()
+	producer, epoch := beginInitialized(t, m, "tx-1")
+	if err := m.Abort("tx-1", producer, epoch); err != nil {
+		t.Fatalf("abort failed: %v", err)
+	}
+	if err := m.Begin("tx-1", producer, epoch-1); err == nil {
+		t.Fatal("expected lower epoch to be fenced")
+	}
+	if err := m.Begin("tx-1", producer, epoch+1); err == nil {
+		t.Fatal("expected uninitialized higher epoch to be fenced")
+	}
+}
+
+func TestManagerRejectsNonOwnerOperations(t *testing.T) {
+	m := NewManager()
+	producer, epoch := beginInitialized(t, m, "tx-1")
+	err := m.AddMessage("tx-1", "other-producer", epoch, MessageOperation{Topic: "t1", Message: types.Message{Payload: "x"}})
+	if err == nil {
+		t.Fatal("expected producer mismatch to fail")
+	}
+	err = m.AddMessage("tx-1", producer, epoch-1, MessageOperation{Topic: "t1", Message: types.Message{Payload: "x"}})
+	if err == nil {
+		t.Fatal("expected stale epoch to fail")
+	}
+}
+
+func TestManagerExportImportState(t *testing.T) {
+	m := NewManager()
+	producer, epoch := beginInitialized(t, m, "tx-1")
+	if err := m.AddOffsets("tx-1", producer, epoch, []OffsetOperation{{Topic: "t1", Group: "g1", Member: "m1", Generation: 2, Partition: 0, Offset: 9}}); err != nil {
+		t.Fatalf("add offsets failed: %v", err)
+	}
+
+	restored := NewManager()
+	restored.ImportState(m.ExportState())
+	tx, err := restored.Status("tx-1")
+	if err != nil {
+		t.Fatalf("restored status failed: %v", err)
+	}
+	if tx.Producer != producer || tx.Epoch != epoch || len(tx.Offsets) != 1 || tx.Offsets[0].Offset != 9 {
+		t.Fatalf("unexpected restored transaction: %+v", tx)
+	}
+}
+
+func TestManagerFinalStateIsIdempotentForSameOwner(t *testing.T) {
+	m := NewManager()
+	producer, epoch := beginInitialized(t, m, "tx-1")
+	if _, err := m.PrepareCommit("tx-1", producer, epoch); err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if err := m.Commit("tx-1"); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+	if _, err := m.PrepareCommit("tx-1", producer, epoch); err != nil {
+		t.Fatalf("same-owner retry should be idempotent: %v", err)
+	}
+	if _, err := m.PrepareCommit("tx-1", producer, epoch-1); err == nil {
+		t.Fatal("expected stale epoch retry to be fenced")
+	}
+}
+
+func TestManagerInitProducerBumpsEpochAndFencesOldProducer(t *testing.T) {
+	m := NewManager()
+	producer, epoch, err := m.InitProducer("tx-init")
+	if err != nil {
+		t.Fatalf("init producer failed: %v", err)
+	}
+	if producer == "" || epoch != 0 {
+		t.Fatalf("unexpected first producer session producer=%s epoch=%d", producer, epoch)
+	}
+	if err := m.Begin("tx-init", producer, epoch); err != nil {
+		t.Fatalf("begin failed: %v", err)
+	}
+
+	producer2, epoch2, err := m.InitProducer("tx-init")
+	if err != nil {
+		t.Fatalf("second init producer failed: %v", err)
+	}
+	if producer2 != producer || epoch2 != epoch+1 {
+		t.Fatalf("unexpected bumped producer session producer=%s epoch=%d", producer2, epoch2)
+	}
+	if err := m.AddMessage("tx-init", producer, epoch, MessageOperation{Topic: "t1", Message: types.Message{Payload: "zombie"}}); err == nil {
+		t.Fatal("expected old epoch to be fenced")
+	}
+	if err := m.Begin("tx-init", producer2, epoch2); err != nil {
+		t.Fatalf("begin with bumped epoch failed: %v", err)
+	}
+}
+
+func TestManagerInitProducerStateSurvivesExportImport(t *testing.T) {
+	m := NewManager()
+	producer, epoch, err := m.InitProducer("tx-restore-producer")
+	if err != nil {
+		t.Fatalf("init producer failed: %v", err)
+	}
+
+	restored := NewManager()
+	restored.ImportState(m.ExportState())
+	producer2, epoch2, err := restored.InitProducer("tx-restore-producer")
+	if err != nil {
+		t.Fatalf("restored init producer failed: %v", err)
+	}
+	if producer2 != producer || epoch2 != epoch+1 {
+		t.Fatalf("expected restored epoch bump producer=%s epoch=%d, got producer=%s epoch=%d", producer, epoch+1, producer2, epoch2)
+	}
+}
+
+func TestManagerInitProducerRejectsCommittingTransaction(t *testing.T) {
+	m := NewManager()
+	producer, epoch := beginInitialized(t, m, "tx-committing")
+	if _, err := m.PrepareCommit("tx-committing", producer, epoch); err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if _, _, err := m.InitProducer("tx-committing"); err == nil {
+		t.Fatal("expected committing transaction to reject producer reinitialization")
+	}
+}
+
+func TestManagerDeleteRemovesOneTransaction(t *testing.T) {
+	m := NewManager()
+	_, _ = beginInitialized(t, m, "tx-delete")
+	keepProducer, keepEpoch := beginInitialized(t, m, "tx-keep")
+
+	m.Delete("tx-delete")
+
+	if _, err := m.Status("tx-delete"); err == nil {
+		t.Fatal("expected deleted transaction to be missing")
+	}
+	tx, err := m.Status("tx-keep")
+	if err != nil {
+		t.Fatalf("expected unrelated transaction to remain: %v", err)
+	}
+	if tx.Producer != keepProducer || tx.Epoch != keepEpoch {
+		t.Fatalf("unexpected remaining transaction: %+v", tx)
+	}
+}
+
+func TestManagerPruneExpiredKeepsActiveTransactions(t *testing.T) {
+	m := NewManagerWithExpiration(time.Hour)
+	old := time.Now().Add(-2 * time.Hour)
+	m.ApplySnapshot(&Snapshot{ID: "committed", Producer: "p1", Epoch: 0, State: StateCommitted, CreatedAt: old, UpdatedAt: old})
+	m.ApplySnapshot(&Snapshot{ID: "aborted", Producer: "p2", Epoch: 0, State: StateAborted, CreatedAt: old, UpdatedAt: old})
+	m.ApplySnapshot(&Snapshot{ID: "open", Producer: "p3", Epoch: 0, State: StateOpen, CreatedAt: old, UpdatedAt: old})
+	m.ApplySnapshot(&Snapshot{ID: "committing", Producer: "p4", Epoch: 0, State: StateCommitting, CreatedAt: old, UpdatedAt: old})
+
+	if removed := m.PruneExpired(time.Now()); removed != 2 {
+		t.Fatalf("expected 2 terminal transactions to expire, got %d", removed)
+	}
+	if _, err := m.Status("committed"); err == nil {
+		t.Fatal("expected committed transaction to expire")
+	}
+	if _, err := m.Status("aborted"); err == nil {
+		t.Fatal("expected aborted transaction to expire")
+	}
+	if _, err := m.Status("open"); err != nil {
+		t.Fatalf("expected open transaction to remain: %v", err)
+	}
+	if _, err := m.Status("committing"); err != nil {
+		t.Fatalf("expected committing transaction to remain: %v", err)
+	}
+}

--- a/pkg/types/message.go
+++ b/pkg/types/message.go
@@ -2,6 +2,21 @@ package types
 
 import "fmt"
 
+const (
+	TransactionStateNone      = ""
+	TransactionStateOpen      = "open"
+	TransactionStateCommitted = "committed"
+	TransactionStateAborted   = "aborted"
+
+	TransactionMarkerNone   = ""
+	TransactionMarkerCommit = "commit"
+	TransactionMarkerAbort  = "abort"
+
+	ControlBatchNone            = ""
+	ControlBatchTransaction     = "transaction"
+	ControlBatchVersionCursusV2 = 2
+)
+
 // Message represents a single message
 type Message struct {
 	Offset     uint64
@@ -15,6 +30,15 @@ type Message struct {
 	SchemaVersion    uint32
 	AggregateVersion uint64
 	Metadata         string
+
+	TransactionalID              string
+	TransactionState             string
+	TransactionMarker            string
+	ControlBatchType             string
+	ControlBatchVersion          int16
+	ControlBatchCoordinatorEpoch int64
+	ControlBatchKey              []byte
+	ControlBatchValue            []byte
 
 	RetryCount int
 	Retry      bool
@@ -50,6 +74,15 @@ type DiskMessage struct {
 	SchemaVersion    uint32
 	AggregateVersion uint64
 	Metadata         string
+
+	TransactionalID              string
+	TransactionState             string
+	TransactionMarker            string
+	ControlBatchType             string
+	ControlBatchVersion          int16
+	ControlBatchCoordinatorEpoch int64
+	ControlBatchKey              []byte
+	ControlBatchValue            []byte
 }
 
 // AppendResult represents the result of appending a message to storage

--- a/sdk/consumer_client.go
+++ b/sdk/consumer_client.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -136,4 +138,102 @@ func (c *ConsumerClient) ConnectWithFailover() (net.Conn, string, error) {
 		return nil, "", fmt.Errorf("all brokers unreachable: %w", lastErr)
 	}
 	return nil, "", fmt.Errorf("all brokers unreachable")
+}
+
+// ListOffsets queries the broker for retained and readable offsets on a topic.
+func (c *ConsumerClient) ListOffsets(topic string, partition ...int) ([]PartitionOffsetRange, error) {
+	if topic == "" {
+		return nil, fmt.Errorf("topic is required")
+	}
+	if len(partition) > 1 {
+		return nil, fmt.Errorf("at most one partition can be requested")
+	}
+
+	conn, _, err := c.ConnectWithFailover()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	cmd := fmt.Sprintf("LIST_OFFSETS topic=%s", topic)
+	if len(partition) == 1 {
+		cmd = fmt.Sprintf("%s partition=%d", cmd, partition[0])
+	}
+	if err := WriteWithLength(conn, EncodeMessage("", cmd)); err != nil {
+		return nil, fmt.Errorf("send list offsets: %w", err)
+	}
+
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return nil, fmt.Errorf("read list offsets: %w", err)
+	}
+	return parseListOffsetsResponse(strings.TrimSpace(string(resp)))
+}
+
+func parseListOffsetsResponse(resp string) ([]PartitionOffsetRange, error) {
+	if strings.HasPrefix(resp, "ERROR:") {
+		return nil, fmt.Errorf("list offsets broker error: %s", resp)
+	}
+	if !strings.HasPrefix(resp, "OK") {
+		return nil, fmt.Errorf("unexpected list offsets response: %s", resp)
+	}
+
+	offsetsValue := parseOKFields(resp)["offsets"]
+	if offsetsValue == "" {
+		return nil, fmt.Errorf("missing offsets in response: %s", resp)
+	}
+
+	entries := strings.Split(offsetsValue, ",")
+	ranges := make([]PartitionOffsetRange, 0, len(entries))
+	for _, entry := range entries {
+		r, err := parseListOffsetEntry(entry)
+		if err != nil {
+			return nil, err
+		}
+		ranges = append(ranges, r)
+	}
+	return ranges, nil
+}
+
+func parseListOffsetEntry(entry string) (PartitionOffsetRange, error) {
+	parts := strings.Split(entry, ":")
+	if len(parts) != 5 || !strings.HasPrefix(parts[0], "P") {
+		return PartitionOffsetRange{}, fmt.Errorf("invalid list offsets entry: %s", entry)
+	}
+	partition, err := strconv.Atoi(strings.TrimPrefix(parts[0], "P"))
+	if err != nil {
+		return PartitionOffsetRange{}, fmt.Errorf("invalid list offsets partition: %s", entry)
+	}
+
+	r := PartitionOffsetRange{Partition: partition}
+	seen := map[string]bool{}
+	for _, part := range parts[1:] {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return PartitionOffsetRange{}, fmt.Errorf("invalid list offsets field: %s", part)
+		}
+		value, err := strconv.ParseUint(kv[1], 10, 64)
+		if err != nil {
+			return PartitionOffsetRange{}, fmt.Errorf("invalid list offsets value: %s", part)
+		}
+		switch kv[0] {
+		case "earliest":
+			r.Earliest = value
+		case "latest":
+			r.Latest = value
+		case "leo":
+			r.LEO = value
+		case "hwm":
+			r.HWM = value
+		default:
+			return PartitionOffsetRange{}, fmt.Errorf("unknown list offsets field: %s", kv[0])
+		}
+		seen[kv[0]] = true
+	}
+	for _, key := range []string{"earliest", "latest", "leo", "hwm"} {
+		if !seen[key] {
+			return PartitionOffsetRange{}, fmt.Errorf("missing list offsets field %s: %s", key, entry)
+		}
+	}
+	return r, nil
 }

--- a/sdk/consumer_test.go
+++ b/sdk/consumer_test.go
@@ -304,3 +304,23 @@ type fetchOffsetTestError struct {
 }
 
 func (e *fetchOffsetTestError) Error() string { return e.msg }
+
+func TestParseListOffsetsResponse(t *testing.T) {
+	ranges, err := parseListOffsetsResponse("OK topic=t partitions=2 offsets=P0:earliest=0:latest=10:leo=12:hwm=11,P1:earliest=3:latest=7:leo=8:hwm=7")
+	require.NoError(t, err)
+	require.Len(t, ranges, 2)
+	assert.Equal(t, PartitionOffsetRange{Partition: 0, Earliest: 0, Latest: 10, LEO: 12, HWM: 11}, ranges[0])
+	assert.Equal(t, PartitionOffsetRange{Partition: 1, Earliest: 3, Latest: 7, LEO: 8, HWM: 7}, ranges[1])
+
+	_, err = parseListOffsetsResponse("42")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected list offsets response")
+
+	_, err = parseListOffsetsResponse("OK topic=t partitions=1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing offsets")
+
+	_, err = parseListOffsetsResponse("ERROR: topic_not_found topic=t")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list offsets broker error")
+}

--- a/sdk/response.go
+++ b/sdk/response.go
@@ -1,0 +1,17 @@
+package sdk
+
+import (
+	"strings"
+)
+
+func parseOKFields(resp string) map[string]string {
+	out := make(map[string]string)
+	for _, field := range strings.Fields(resp) {
+		if field == "OK" || !strings.Contains(field, "=") {
+			continue
+		}
+		parts := strings.SplitN(field, "=", 2)
+		out[parts[0]] = parts[1]
+	}
+	return out
+}

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -46,6 +46,9 @@ func (c *ConsumerClient) BeginTransaction(transactionalID, producerID string, ep
 func (c *ConsumerClient) TransactionalPublish(transactionalID, topic string, partition int, msg Message) error {
 	cmd := fmt.Sprintf("TXN_PUBLISH transactional_id=%s topic=%s partition=%d producerId=%s seqNum=%d epoch=%d", transactionalID, topic, partition, msg.ProducerID, msg.SeqNum, msg.Epoch)
 	if msg.Key != "" {
+		if strings.ContainsAny(msg.Key, " \t\r\n") {
+			return fmt.Errorf("transactional publish key must not contain whitespace")
+		}
 		cmd += fmt.Sprintf(" key=%s", msg.Key)
 	}
 	cmd += " message=" + msg.Payload

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -1,0 +1,107 @@
+package sdk
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type ProducerSession struct {
+	TransactionalID string
+	ProducerID      string
+	Epoch           int64
+}
+
+func (c *ConsumerClient) InitProducerID(transactionalID string) (ProducerSession, error) {
+	resp, err := c.execTxnCommand(fmt.Sprintf("INIT_PRODUCER_ID transactional_id=%s", transactionalID))
+	if err != nil {
+		return ProducerSession{}, err
+	}
+	return parseProducerSession(resp)
+}
+func parseProducerSession(resp string) (ProducerSession, error) {
+	fields := parseOKFields(resp)
+	txnID := fields["transactional_id"]
+	producerID := fields["producerId"]
+	if producerID == "" {
+		producerID = fields["producer_id"]
+	}
+	if txnID == "" || producerID == "" {
+		return ProducerSession{}, fmt.Errorf("producer session response missing transactional_id or producerId: %s", resp)
+	}
+	epoch, err := strconv.ParseInt(fields["epoch"], 10, 64)
+	if err != nil {
+		return ProducerSession{}, fmt.Errorf("invalid producer session epoch %q: %w", fields["epoch"], err)
+	}
+	return ProducerSession{TransactionalID: txnID, ProducerID: producerID, Epoch: epoch}, nil
+}
+
+func (c *ConsumerClient) BeginTransaction(transactionalID, producerID string, epoch int64) error {
+	cmd := fmt.Sprintf("BEGIN_TXN transactional_id=%s producerId=%s epoch=%d", transactionalID, producerID, epoch)
+	_, err := c.execTxnCommand(cmd)
+	return err
+}
+
+func (c *ConsumerClient) TransactionalPublish(transactionalID, topic string, partition int, msg Message) error {
+	cmd := fmt.Sprintf("TXN_PUBLISH transactional_id=%s topic=%s partition=%d producerId=%s seqNum=%d epoch=%d", transactionalID, topic, partition, msg.ProducerID, msg.SeqNum, msg.Epoch)
+	if msg.Key != "" {
+		cmd += fmt.Sprintf(" key=%s", msg.Key)
+	}
+	cmd += " message=" + msg.Payload
+	_, err := c.execTxnCommand(cmd)
+	return err
+}
+
+func (c *ConsumerClient) SendOffsetsToTransaction(transactionalID, producerID, topic, group, member string, generation int, epoch int64, offsets map[int]uint64) error {
+	pairs := make([]string, 0, len(offsets))
+	partitions := make([]int, 0, len(offsets))
+	for partition := range offsets {
+		partitions = append(partitions, partition)
+	}
+	sort.Ints(partitions)
+	for _, partition := range partitions {
+		pairs = append(pairs, fmt.Sprintf("P%d:%d", partition, offsets[partition]))
+	}
+	cmd := fmt.Sprintf("SEND_OFFSETS_TO_TXN transactional_id=%s producerId=%s epoch=%d topic=%s group=%s member=%s generation=%d %s", transactionalID, producerID, epoch, topic, group, member, generation, strings.Join(pairs, ","))
+	_, err := c.execTxnCommand(cmd)
+	return err
+}
+
+func (c *ConsumerClient) EndTransaction(transactionalID, producerID string, epoch int64, commit bool) error {
+	result := "abort"
+	if commit {
+		result = "commit"
+	}
+	cmd := fmt.Sprintf("END_TXN transactional_id=%s producerId=%s epoch=%d result=%s", transactionalID, producerID, epoch, result)
+	_, err := c.execTxnCommand(cmd)
+	return err
+}
+
+func (c *ConsumerClient) TransactionStatus(transactionalID string) (string, error) {
+	return c.execTxnCommand(fmt.Sprintf("TXN_STATUS transactional_id=%s", transactionalID))
+}
+
+func (c *ConsumerClient) execTxnCommand(cmd string) (string, error) {
+	conn, _, err := c.ConnectWithFailover()
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := WriteWithLength(conn, EncodeMessage("", cmd)); err != nil {
+		return "", fmt.Errorf("send transaction command: %w", err)
+	}
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return "", fmt.Errorf("read transaction response: %w", err)
+	}
+	respStr := strings.TrimSpace(string(resp))
+	if strings.HasPrefix(respStr, "ERROR:") {
+		return "", fmt.Errorf("transaction command failed: %s", respStr)
+	}
+	if !strings.HasPrefix(respStr, "OK") {
+		return "", fmt.Errorf("unexpected transaction response: %s", respStr)
+	}
+	return respStr, nil
+}

--- a/sdk/transaction_test.go
+++ b/sdk/transaction_test.go
@@ -1,0 +1,22 @@
+package sdk
+
+import "testing"
+
+func TestParseProducerSession(t *testing.T) {
+	session, err := parseProducerSession("OK transactional_id=tx-1 producerId=txn-abcd epoch=7")
+	if err != nil {
+		t.Fatalf("parseProducerSession failed: %v", err)
+	}
+	if session.TransactionalID != "tx-1" || session.ProducerID != "txn-abcd" || session.Epoch != 7 {
+		t.Fatalf("unexpected session: %+v", session)
+	}
+}
+
+func TestParseProducerSessionRejectsMissingFields(t *testing.T) {
+	if _, err := parseProducerSession("OK transactional_id=tx-1 epoch=7"); err == nil {
+		t.Fatal("expected missing producer id to fail")
+	}
+	if _, err := parseProducerSession("OK transactional_id=tx-1 producerId=p1 epoch=bad"); err == nil {
+		t.Fatal("expected invalid epoch to fail")
+	}
+}

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -28,6 +28,15 @@ func (m Message) String() string {
 		m.ProducerID, m.SeqNum, m.Payload, m.Offset, m.Key, m.Epoch, m.RetryCount)
 }
 
+// PartitionOffsetRange describes broker-reported offsets for one partition.
+type PartitionOffsetRange struct {
+	Partition int
+	Earliest  uint64
+	Latest    uint64
+	LEO       uint64
+	HWM       uint64
+}
+
 // AckResponse represents the broker's response to a produce request
 type AckResponse struct {
 	Status        string `json:"status"`

--- a/test/cluster/config.yaml
+++ b/test/cluster/config.yaml
@@ -6,6 +6,8 @@ log_level: "info"
 
 # Distributed Clustering
 enabled_distribution: true
+internal_auth_token: "cursus-test-internal-token"
+internal_broker_port: 19000
 raft_port: 9001
 discovery_port: 8000
 min_insync_replicas: 2

--- a/test/e2e-cluster/chaos_test.go
+++ b/test/e2e-cluster/chaos_test.go
@@ -1,0 +1,42 @@
+package e2e_cluster
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestChaosLeaderFailoverRetryAndOffsetDurability is intentionally opt-in because
+// it restarts Docker cluster members and waits for multiple elections. Run with
+// RUN_E2E_CHAOS=1 when validating broker failure semantics before release.
+func TestChaosLeaderFailoverRetryAndOffsetDurability(t *testing.T) {
+	if os.Getenv("RUN_E2E_CHAOS") != "1" {
+		t.Skip("set RUN_E2E_CHAOS=1 to run long cluster chaos validation")
+	}
+
+	ctx := GivenClusterRestart(t).
+		WithClusterSize(3).
+		WithTopic("chaos-eos-test").
+		WithPartitions(1).
+		WithNumMessages(100).
+		WithAcks("all").
+		WithMinInSyncReplicas(2)
+	defer ctx.Cleanup()
+
+	leaderNode, actions := ctx.WhenCluster().
+		StartCluster().
+		CreateTopic().
+		PublishMessages().
+		JoinGroup().
+		CommitOffset(0, 50).
+		SimulateLeaderFailure()
+
+	time.Sleep(10 * time.Second)
+
+	actions.RetryPublishMessages().
+		RecoverFollower(leaderNode).
+		Then().
+		Expect(MessagesPublishedWithQuorum()).
+		And(ExpectDataConsistent()).
+		And(ExpectOffsetMatched(0, 50))
+}

--- a/test/e2e-cluster/docker-compose.yml
+++ b/test/e2e-cluster/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       - CONFIG_PATH=/root/config.yaml
       - ADVERTISED_HOST=broker-1
+      - ADVERTISED_CLIENT_HOST=localhost
+      - ADVERTISED_BROKER_PORT=9001
       - RAFT_PORT=9001
       - DISCOVERY_PORT=8000
     ports:
@@ -33,6 +35,8 @@ services:
     environment:
       - CONFIG_PATH=/root/config.yaml
       - ADVERTISED_HOST=broker-2
+      - ADVERTISED_CLIENT_HOST=localhost
+      - ADVERTISED_BROKER_PORT=9002
       - RAFT_PORT=9001
       - DISCOVERY_PORT=8000
     ports:
@@ -61,6 +65,8 @@ services:
     environment:
       - CONFIG_PATH=/root/config.yaml
       - ADVERTISED_HOST=broker-3
+      - ADVERTISED_CLIENT_HOST=localhost
+      - ADVERTISED_BROKER_PORT=9003
       - RAFT_PORT=9001
       - DISCOVERY_PORT=8000
     ports:

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -175,6 +175,14 @@ func (bc *BrokerClient) SendCommand(cmdTopic, cmdPayload string, readTimeout tim
 		}
 
 		respStr := strings.TrimSpace(string(respBuf))
+		if redirectAddr, ok := parseNotCoordinator(respStr); ok {
+			bc.closeInternal()
+			bc.preferAddr(redirectAddr)
+			lastErr = fmt.Errorf("broker error: %s", respStr)
+			util.Debug("Coordinator moved to %s, retrying (%d/%d)", redirectAddr, i, maxRetries)
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
 		if strings.Contains(respStr, "NOT_AUTHORIZED_FOR_PARTITION") {
 			bc.closeInternal()
 			bc.rotateAddrs()
@@ -187,6 +195,38 @@ func (bc *BrokerClient) SendCommand(cmdTopic, cmdPayload string, readTimeout tim
 		return respStr, nil
 	}
 	return "", fmt.Errorf("command failed after retries: %w", lastErr)
+}
+
+func parseNotCoordinator(resp string) (string, bool) {
+	if !strings.Contains(resp, "NOT_COORDINATOR") {
+		return "", false
+	}
+	host := ""
+	port := ""
+	for _, part := range strings.Fields(resp) {
+		if strings.HasPrefix(part, "host=") {
+			host = strings.TrimPrefix(part, "host=")
+		} else if strings.HasPrefix(part, "port=") {
+			port = strings.TrimPrefix(part, "port=")
+		}
+	}
+	if host == "" || port == "" {
+		return "", false
+	}
+	return net.JoinHostPort(host, port), true
+}
+
+func (bc *BrokerClient) preferAddr(addr string) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	next := []string{addr}
+	for _, existing := range bc.addrs {
+		if existing != addr {
+			next = append(next, existing)
+		}
+	}
+	bc.addrs = next
 }
 
 func (bc *BrokerClient) closeInternal() {

--- a/util/serialize.go
+++ b/util/serialize.go
@@ -151,7 +151,7 @@ var diskMsgBufPool = sync.Pool{
 func EstimateDiskMessageSize(msg types.DiskMessage) int {
 	return 2 + len(msg.Topic) + 4 + 8 + 2 + len(msg.ProducerID) + 8 + 8 +
 		4 + len(msg.Payload) + 2 + len(msg.Key) +
-		2 + len(msg.EventType) + 4 + 8 + 2 + len(msg.Metadata)
+		2 + len(msg.EventType) + 4 + 8 + 2 + len(msg.Metadata) + 2 + len(msg.TransactionalID) + 2 + len(msg.TransactionState) + 2 + len(msg.TransactionMarker) + 2 + len(msg.ControlBatchType) + 2 + 8 + 2 + len(msg.ControlBatchKey) + 2 + len(msg.ControlBatchValue)
 }
 
 // SerializeDiskMessage serializes a DiskMessage for disk storage
@@ -183,6 +183,30 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	keyLen, ok := SafeIntToUint16(len(msg.Key))
 	if !ok {
 		return nil, fmt.Errorf("key too long: %d", len(msg.Key))
+	}
+	txnIDLen, ok := SafeIntToUint16(len(msg.TransactionalID))
+	if !ok {
+		return nil, fmt.Errorf("transactionalID too long: %d", len(msg.TransactionalID))
+	}
+	txnStateLen, ok := SafeIntToUint16(len(msg.TransactionState))
+	if !ok {
+		return nil, fmt.Errorf("transactionState too long: %d", len(msg.TransactionState))
+	}
+	txnMarkerLen, ok := SafeIntToUint16(len(msg.TransactionMarker))
+	if !ok {
+		return nil, fmt.Errorf("transactionMarker too long: %d", len(msg.TransactionMarker))
+	}
+	controlBatchTypeLen, ok := SafeIntToUint16(len(msg.ControlBatchType))
+	if !ok {
+		return nil, fmt.Errorf("controlBatchType too long: %d", len(msg.ControlBatchType))
+	}
+	controlBatchKeyLen, ok := SafeIntToUint16(len(msg.ControlBatchKey))
+	if !ok {
+		return nil, fmt.Errorf("controlBatchKey too long: %d", len(msg.ControlBatchKey))
+	}
+	controlBatchValueLen, ok := SafeIntToUint16(len(msg.ControlBatchValue))
+	if !ok {
+		return nil, fmt.Errorf("controlBatchValue too long: %d", len(msg.ControlBatchValue))
 	}
 	epochVal, ok := SafeInt64ToUint64(msg.Epoch)
 	if !ok {
@@ -251,6 +275,44 @@ func SerializeDiskMessage(msg types.DiskMessage) ([]byte, error) {
 	binary.BigEndian.PutUint16(tmp[:2], keyLen)
 	buf = append(buf, tmp[:2]...)
 	buf = append(buf, msg.Key...)
+
+	// Transaction metadata (optional trailer; empty for non-transactional records)
+	binary.BigEndian.PutUint16(tmp[:2], txnIDLen)
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.TransactionalID...)
+
+	binary.BigEndian.PutUint16(tmp[:2], txnStateLen)
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.TransactionState...)
+
+	binary.BigEndian.PutUint16(tmp[:2], txnMarkerLen)
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.TransactionMarker...)
+
+	// Control batch metadata (optional trailer; Cursus transaction marker semantics)
+	binary.BigEndian.PutUint16(tmp[:2], controlBatchTypeLen)
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.ControlBatchType...)
+
+	controlVersionBuf := bytes.Buffer{}
+	if err := binary.Write(&controlVersionBuf, binary.BigEndian, msg.ControlBatchVersion); err != nil {
+		return nil, fmt.Errorf("write control batch version: %w", err)
+	}
+	buf = append(buf, controlVersionBuf.Bytes()...)
+
+	controlEpochBuf := bytes.Buffer{}
+	if err := binary.Write(&controlEpochBuf, binary.BigEndian, msg.ControlBatchCoordinatorEpoch); err != nil {
+		return nil, fmt.Errorf("write control batch coordinator epoch: %w", err)
+	}
+	buf = append(buf, controlEpochBuf.Bytes()...)
+
+	binary.BigEndian.PutUint16(tmp[:2], controlBatchKeyLen)
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.ControlBatchKey...)
+
+	binary.BigEndian.PutUint16(tmp[:2], controlBatchValueLen)
+	buf = append(buf, tmp[:2]...)
+	buf = append(buf, msg.ControlBatchValue...)
 
 	// Return a copy so the pooled buffer can be reused
 	result := make([]byte, len(buf))
@@ -342,7 +404,7 @@ func DeserializeDiskMessage(data []byte) (types.DiskMessage, error) {
 	msg.Payload = string(data[offset : offset+payloadLen])
 	offset += payloadLen
 
-	// Event sourcing fields (optional — backward compatible with old messages)
+	// Event sourcing fields (optional - backward compatible with old messages)
 	// If event-sourcing trailer is present, all fields must be complete.
 	if offset < len(data) {
 		if offset+2 > len(data) {
@@ -379,15 +441,88 @@ func DeserializeDiskMessage(data []byte) (types.DiskMessage, error) {
 		msg.Metadata = string(data[offset : offset+metadataLen])
 		offset += metadataLen
 
-		// Key (optional — backward compatible with messages before Key was added)
+		// Key (optional - backward compatible with messages before Key was added)
 		if offset+2 <= len(data) {
 			keyLen := int(binary.BigEndian.Uint16(data[offset : offset+2]))
 			offset += 2
-			if offset+keyLen <= len(data) {
-				msg.Key = string(data[offset : offset+keyLen])
+			if offset+keyLen > len(data) {
+				return msg, fmt.Errorf("incomplete key field: truncated key")
+			}
+			msg.Key = string(data[offset : offset+keyLen])
+			offset += keyLen
+		}
+
+		if offset < len(data) {
+			if err := readDiskString(data, &offset, &msg.TransactionalID, "transactional ID"); err != nil {
+				return msg, err
+			}
+			if err := readDiskString(data, &offset, &msg.TransactionState, "transaction state"); err != nil {
+				return msg, err
+			}
+			if err := readDiskString(data, &offset, &msg.TransactionMarker, "transaction marker"); err != nil {
+				return msg, err
+			}
+			if offset < len(data) {
+				if err := readDiskString(data, &offset, &msg.ControlBatchType, "control batch type"); err != nil {
+					return msg, err
+				}
+				if offset+2 > len(data) {
+					return msg, fmt.Errorf("incomplete control batch version field: truncated value")
+				}
+				if err := binary.Read(bytes.NewReader(data[offset:offset+2]), binary.BigEndian, &msg.ControlBatchVersion); err != nil {
+					return msg, fmt.Errorf("read control batch version: %w", err)
+				}
+				offset += 2
+				if offset+8 > len(data) {
+					return msg, fmt.Errorf("incomplete control batch coordinator epoch field: truncated value")
+				}
+				if err := binary.Read(bytes.NewReader(data[offset:offset+8]), binary.BigEndian, &msg.ControlBatchCoordinatorEpoch); err != nil {
+					return msg, fmt.Errorf("read control batch coordinator epoch: %w", err)
+				}
+				offset += 8
+				if offset < len(data) {
+					if err := readDiskBytes(data, &offset, &msg.ControlBatchKey, "control batch key"); err != nil {
+						return msg, err
+					}
+					if err := readDiskBytes(data, &offset, &msg.ControlBatchValue, "control batch value"); err != nil {
+						return msg, err
+					}
+				}
 			}
 		}
 	}
 
 	return msg, nil
+}
+
+func readDiskString(data []byte, offset *int, out *string, field string) error {
+	if *offset+2 > len(data) {
+		return fmt.Errorf("incomplete %s field: truncated length", field)
+	}
+	fieldLen := int(binary.BigEndian.Uint16(data[*offset : *offset+2]))
+	*offset += 2
+	if *offset+fieldLen > len(data) {
+		return fmt.Errorf("incomplete %s field: truncated value", field)
+	}
+	*out = string(data[*offset : *offset+fieldLen])
+	*offset += fieldLen
+	return nil
+}
+
+func readDiskBytes(data []byte, offset *int, dest *[]byte, field string) error {
+	if *offset+2 > len(data) {
+		return fmt.Errorf("incomplete %s length field: truncated value", field)
+	}
+	length := int(binary.BigEndian.Uint16(data[*offset : *offset+2]))
+	*offset += 2
+	if *offset+length > len(data) {
+		return fmt.Errorf("incomplete %s field: expected %d bytes", field, length)
+	}
+	if length == 0 {
+		*dest = nil
+	} else {
+		*dest = append((*dest)[:0], data[*offset:*offset+length]...)
+	}
+	*offset += length
+	return nil
 }

--- a/util/serialize_test.go
+++ b/util/serialize_test.go
@@ -141,7 +141,7 @@ func TestDeserializeDiskMessage_OldFormatNoEventSourcing(t *testing.T) {
 	data, err := SerializeDiskMessage(msg)
 	assert.NoError(t, err)
 
-	// ES + Key + transaction + control-batch trailer for empty fields: 18 bytes + 6 transaction length bytes + 12 control bytes = 36 bytes
+	// Empty-field trailer: ES(16) + Key(2) + transaction(6) + control-batch(16) = 40 bytes
 	oldData := data[:len(data)-40]
 
 	got, err := DeserializeDiskMessage(oldData)

--- a/util/serialize_test.go
+++ b/util/serialize_test.go
@@ -123,7 +123,7 @@ func TestDeserializeDiskMessage_TruncatedEventSourcingFields(t *testing.T) {
 	truncated := data[:len(data)-10]
 	_, err = DeserializeDiskMessage(truncated)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "incomplete event-sourcing fields")
+	assert.Contains(t, err.Error(), "incomplete")
 }
 
 func TestDeserializeDiskMessage_OldFormatNoEventSourcing(t *testing.T) {
@@ -141,8 +141,8 @@ func TestDeserializeDiskMessage_OldFormatNoEventSourcing(t *testing.T) {
 	data, err := SerializeDiskMessage(msg)
 	assert.NoError(t, err)
 
-	// ES + Key trailer for empty fields: 2 (eventType len) + 4 (schema) + 8 (aggVer) + 2 (metadata len) + 2 (key len) = 18 bytes
-	oldData := data[:len(data)-18]
+	// ES + Key + transaction + control-batch trailer for empty fields: 18 bytes + 6 transaction length bytes + 12 control bytes = 36 bytes
+	oldData := data[:len(data)-40]
 
 	got, err := DeserializeDiskMessage(oldData)
 	assert.NoError(t, err)
@@ -177,4 +177,36 @@ func TestDiskMessageSerialization_EmptyFields(t *testing.T) {
 	assert.Equal(t, "", got.Payload)
 	assert.Equal(t, "", got.EventType)
 	assert.Equal(t, "", got.Metadata)
+}
+func TestDiskMessageTransactionMetadataRoundTrip(t *testing.T) {
+	msg := types.DiskMessage{
+		Topic:                        "txn-topic",
+		Partition:                    0,
+		Offset:                       7,
+		ProducerID:                   "producer-1",
+		SeqNum:                       3,
+		Epoch:                        2,
+		Payload:                      "payload",
+		Key:                          "key",
+		TransactionalID:              "tx-1",
+		TransactionState:             types.TransactionStateCommitted,
+		TransactionMarker:            types.TransactionMarkerCommit,
+		ControlBatchType:             types.ControlBatchTransaction,
+		ControlBatchVersion:          types.ControlBatchVersionCursusV2,
+		ControlBatchCoordinatorEpoch: 3,
+		ControlBatchKey:              []byte{0, 0, 0, 0},
+		ControlBatchValue:            []byte{0, 0, 0, 0, 0, 3},
+	}
+
+	data, err := SerializeDiskMessage(msg)
+	if err != nil {
+		t.Fatalf("serialize failed: %v", err)
+	}
+	got, err := DeserializeDiskMessage(data)
+	if err != nil {
+		t.Fatalf("deserialize failed: %v", err)
+	}
+	if got.TransactionalID != msg.TransactionalID || got.TransactionState != msg.TransactionState || got.TransactionMarker != msg.TransactionMarker || got.ControlBatchType != msg.ControlBatchType || got.ControlBatchVersion != msg.ControlBatchVersion || got.ControlBatchCoordinatorEpoch != msg.ControlBatchCoordinatorEpoch || string(got.ControlBatchKey) != string(msg.ControlBatchKey) || string(got.ControlBatchValue) != string(msg.ControlBatchValue) {
+		t.Fatalf("transaction metadata mismatch: %+v", got)
+	}
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes

## Summary

This PR adds broker semantics around coordinator-owned routing, durable transaction state, transactional publish/offset commit, transaction markers, and `read_committed` consumption.

Key changes:

- Add `LIST_OFFSETS` / offset-range contract for retained log recovery and SDK `auto_offset_reset` behavior.
- Add broker-managed transaction coordinator commands: `INIT_PRODUCER_ID`, `BEGIN_TXN`, `TXN_PUBLISH`, `SEND_OFFSETS_TO_TXN`, `END_TXN`, and `TXN_STATUS`.
- Persist transaction state through the metadata FSM/snapshot path and recover prepared/committing transactions.
- Add producer epoch fencing and idempotent replay handling for transactional records.
- Add transaction control markers and `read_committed` filtering with stable-boundary behavior.
- Route transactional publish through the normal partition leader path instead of direct local append.
- Validate transactional offset commits against consumer group member/generation ownership.
- Harden internal broker command handling and coordinator redirect behavior for cluster failover.
- Add ACL/SASL-style topic policy foundations and internal broker mTLS config/runtime support.
- Update protocol/docs and e2e/benchmark coverage for the new contracts.

## Validation

- `go test ./pkg/... ./sdk ./util`
- `go test ./pkg/controller ./pkg/server ./pkg/cluster/controller`
- `go test ./test/e2e ./test/e2e-cluster ./pkg/controller ./pkg/server ./pkg/cluster/controller`
- `RUN_E2E_CHAOS=1 go test ./test/e2e-cluster -run TestChaosLeaderFailoverRetryAndOffsetDurability -count=1 -timeout 15m`
- `RUN_E2E_BENCHMARK=1 go test -v ./test/e2e-benchmark -run 'TestStandaloneBenchmark|TestClusterBenchmark' -count=1 -timeout 25m`

Benchmark verification:

- Standalone: published `100000 / 100000`, consumed `100000`, duplicate message ID `0`, duplicate offset `0`, missing `0`.
- Cluster: published `100000 / 100000`, consumed `100000`, duplicate message ID `0`, duplicate offset `0`, missing `0`.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.
