### PR TITLE
feat: strengthen consumer group lifecycle contracts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,17 +249,19 @@ sequenceDiagram
     C->>B1: FIND_COORDINATOR group=G1
     B1-->>C: OK host=B2 port=9002
 
-    C->>B2: JOIN_GROUP topic=T group=G1
-    B2-->>C: OK generation=1 assignments=[0,1]
+    C->>B2: JOIN_GROUP topic=T group=G1 member=M
+    B2-->>C: OK generation=1 member=M-1234 assignments=[0,1]
+    C->>B2: SYNC_GROUP topic=T group=G1 member=M-1234 generation=1
+    B2-->>C: OK generation=1 member=M-1234 assignments=[0,1]
 
-    C->>B2: HEARTBEAT group=G1
-    B2-->>C: OK
+    C->>B2: HEARTBEAT topic=T group=G1 member=M-1234 generation=1
+    B2-->>C: OK member=M-1234 generation=1
 
     Note over C,B3: If coordinator changes...
-    C->>B2: HEARTBEAT group=G1
+    C->>B2: HEARTBEAT topic=T group=G1 member=M-1234 generation=1
     B2-->>C: ERROR: NOT_COORDINATOR host=B3 port=9003
-    C->>B3: HEARTBEAT group=G1
-    B3-->>C: OK
+    C->>B3: HEARTBEAT topic=T group=G1 member=M-1234 generation=1
+    B3-->>C: OK member=M-1234 generation=1
 ```
 
 ### Partition Leader Routing

--- a/docs/cluster-consumer.md
+++ b/docs/cluster-consumer.md
@@ -4,7 +4,7 @@ Consumer가 클러스터 환경에서 메시지를 소비하기 위한 FindCoord
 
 ## Overview
 
-Consumer Group 관련 커맨드는 Coordinator 브로커로, 데이터 커맨드는 파티션 리더로 라우팅합니다.
+Consumer Group 관련 커맨드는 group coordinator로, 데이터 커맨드는 partition leader로 라우팅합니다.
 
 ## Command Routing
 
@@ -76,8 +76,11 @@ sequenceDiagram
     C->>CO: JOIN_GROUP topic=T group=G member=M
     CO-->>C: OK generation=1 member=M-1234 assignments=[0,1]
 
+    C->>CO: SYNC_GROUP topic=T group=G member=M-1234 generation=1
+    CO-->>C: OK generation=1 member=M-1234 assignments=[0,1]
+
     C->>CO: FETCH_OFFSET topic=T partition=0 group=G
-    CO-->>C: 0
+    CO-->>C: OK offset=0
 
     C->>B: METADATA topic=T
     B-->>C: OK leaders=H1:P1,H2:P2
@@ -92,6 +95,14 @@ sequenceDiagram
         CO-->>C: OK
     end
 ```
+
+Transient connection failures do not require a new member. The SDK first retries
+`JOIN_GROUP` with the broker-assigned member ID and generation. A successful
+resume preserves assignments and does not advance the generation. A stale
+generation is synchronized for an existing member; `member_not_found` causes a
+fresh join. When group coordinator ownership changes, the new owner waits one
+session timeout before expiring members, while clients rediscover it and resume
+heartbeats.
 
 ## Error Recovery
 
@@ -124,10 +135,5 @@ flowchart TD
 - `ensureConnection()` — prefers partition leader address, falls back to any broker
 - `handleBrokerError()` — parses NOT_LEADER, updates partition leader, triggers rebalance on GEN_MISMATCH
 - `handleNotCoordinator()` — re-discovers coordinator from response or via FIND_COORDINATOR
-
-### Known Issue: Cluster Consumer Blocking
-
-Go SDK의 Consumer가 클러스터에서 `FETCH_OFFSET` 응답을 기다리면서 블로킹되는 문제가 있습니다.
-Python/Java SDK는 매 커맨드마다 새 TCP 연결을 사용하여 이 문제를 회피합니다.
-Go SDK는 persistent 연결을 사용하기 때문에, 브로커가 같은 coordinator 주소의 다른 TCP 연결에서 온
-FETCH_OFFSET을 처리하지 못하는 것으로 추정됩니다.
+- `joinGroup()` — resumes the current member and generation before creating a fresh member
+- `fetchOffset()` — uses a bounded, per-request coordinator connection and parses `OK offset=<N>`

--- a/docs/core/topic/consumer-groups.md
+++ b/docs/core/topic/consumer-groups.md
@@ -168,12 +168,17 @@ restart. In distributed mode, offset updates also flow through the Raft FSM and
 are included in FSM snapshots.
 
 ### Commit and Resume Contract
+A group is bound to the topic supplied at registration. `JOIN_GROUP`,
+`SYNC_GROUP`, `HEARTBEAT`, and `LEAVE_GROUP` must name that topic (or a topic
+accepted by the registered topic pattern). A mismatch returns
+`ERROR: topic_not_assigned_to_group ...` without changing membership.
+
 
 Use these broker commands:
 
 ```
 FETCH_OFFSET topic=<topic> group=<group> partition=<partition>
-COMMIT_OFFSET topic=<topic> group=<group> partition=<partition> offset=<nextOffset>
+COMMIT_OFFSET topic=<topic> group=<group> partition=<partition> offset=<nextOffset> member=<actual-id> generation=<N>
 BATCH_COMMIT topic=<topic> group=<group> member=<member> generation=<N> P0:<nextOffset>,P1:<nextOffset>
 ```
 
@@ -188,6 +193,13 @@ group/partition, even if the request includes a lower explicit `offset=`.
 
 Commits are monotonic. A commit lower than the current offset is rejected and the
 stored offset is left unchanged. Recommitting the same offset is idempotent.
+Every commit is fenced by the current member, generation, and partition
+assignment. In distributed mode this validation runs again when the replicated
+metadata entry is applied, so a rebalance between request parsing and state
+application cannot commit an offset for a stale owner. A rejected batch applies
+none of its offsets. Batch entries are parsed strictly, so malformed entries,
+invalid partitions or offsets, and duplicate partitions also reject the whole
+batch.
 
 ### Recommended Commit Timing
 
@@ -195,10 +207,14 @@ For at-least-once delivery, process the records first, then commit
 `lastProcessedOffset + 1`. If the process crashes after handling a record but
 before committing, the record may be delivered again after restart.
 
+If a record handler returns an error, the SDK leaves the failed batch
+uncommitted and resumes from the last broker committed offset.
+
 Committing before processing gives at-most-once behavior for that client: a crash
-after the commit can skip unprocessed records. Cursus does not provide
-exactly-once processing guarantees; make downstream game state updates
-idempotent if duplicate delivery must be harmless.
+after the commit can skip unprocessed records. Consumer-group commits alone do
+not make external side effects exactly once. Use broker transactions for
+consume-process-produce workflows, and keep non-broker effects idempotent or
+transactional in their own system.
 
 ### Game Server Example
 
@@ -207,10 +223,11 @@ offsets:
 
 ```
 JOIN_GROUP topic=match-events group=wargame-iocp member=game-01
-SYNC_GROUP topic=match-events group=wargame-iocp member=<assigned-member-id>
+# broker returns an actual member ID and generation
+SYNC_GROUP topic=match-events group=wargame-iocp member=<actual-id> generation=<N>
 FETCH_OFFSET topic=match-events partition=0 group=wargame-iocp
-CONSUME topic=match-events partition=0 offset=0 group=wargame-iocp member=<assigned-member-id> batch=128
-COMMIT_OFFSET topic=match-events partition=0 group=wargame-iocp offset=<lastProcessedOffset+1>
+CONSUME topic=match-events partition=0 offset=0 group=wargame-iocp member=<actual-id> generation=<N> batch=128
+COMMIT_OFFSET topic=match-events partition=0 group=wargame-iocp offset=<lastProcessedOffset+1> member=<actual-id> generation=<N>
 ```
 
 After this migration, the game server should not need an external
@@ -218,6 +235,42 @@ After this migration, the game server should not need an external
 different group names and will receive independent offsets.
 
 ## Concurrency and Thread Safety
+
+## Coordinator Membership Lifecycle
+
+The broker coordinator owns dynamic group membership for pull and stream
+consumers:
+
+1. `REGISTER_GROUP` establishes the topic and partition set.
+2. A fresh `JOIN_GROUP` creates a broker-assigned member ID, increments the
+   generation, and runs deterministic range assignment.
+3. `SYNC_GROUP` confirms assignments for that member and generation.
+4. `HEARTBEAT` refreshes the session only when both values are current.
+5. `COMMIT_OFFSET` and `BATCH_COMMIT` apply only to partitions owned by
+   that member in the current generation.
+6. `LEAVE_GROUP` or session expiration removes membership, increments the
+   generation once, and reassigns partitions.
+
+After a transient connection failure, a client should first send:
+
+```text
+JOIN_GROUP topic=<topic> group=<group> member=<actual-id> generation=<N>
+```
+
+If the member is still active and the generation is current, the broker returns
+`resumed=true` with unchanged assignments. `GEN_MISMATCH` tells the client
+to sync the authoritative generation when the member still exists.
+`member_not_found` requires a fresh join.
+
+In a cluster, only the broker selected by the group coordinator ring evaluates
+session expiration. A broker that newly acquires a group waits one full session
+timeout before expiring members, allowing redirected clients to heartbeat.
+Timeout removals are written through the replicated metadata log with the
+expected generation. Members found in the same scan are removed together and
+advance the generation once.
+
+Coordinator snapshots preserve the registered partition set, assignments,
+generation, offsets, and last rebalance time. This allows assignment and fencing
 
 ### Locking Strategy
 
@@ -239,26 +292,30 @@ The locking hierarchy ensures:
 
 ## Key Characteristics
 
-### Behavior Summary
+### Embedded Channel Layer Behavior
+
+The table below describes the in-process `TopicManager.RegisterConsumerGroup`
+channel layer. It is separate from the network protocol coordinator described
+above.
 
 | Aspect                  | Behavior                                           |
 |-------------------------|---------------------------------------------------|
-| Partition assignment     | Static, established at registration             |
-| Distribution algorithm   | Modulo: partition_id % consumer_count           |
-| Ordering guarantee       | Per-partition ordering maintained               |
-| Group isolation          | Groups consume independently                     |
-| Rebalancing              | Not supported (static assignment)               |
-| Consumer failure         | Channel blocks, may lead to backpressure        |
-| Buffer overflow          | Goroutine blocks if consumer channel full       |
-| Offset storage           | Durable per topic/group/partition next offset   |
+| Partition assignment     | Static at direct channel registration            |
+| Distribution algorithm   | Modulo: partition_id % consumer_count            |
+| Ordering guarantee       | Per-partition ordering maintained                |
+| Group isolation          | Groups receive independent channels              |
+| Rebalancing              | Owned by the protocol coordinator, not this layer|
+| Consumer failure         | Channel blocks and propagates backpressure       |
+| Buffer overflow          | Goroutine blocks if the consumer channel is full |
+| Offset storage           | Owned by the broker coordinator                  |
 
-### Limitations
+### Embedded Channel Layer Limitations
 
-- **Static assignment**: Consumers cannot be added/removed without re-registration
-- **No automatic rebalancing**: Partition distribution doesn't adjust to consumer changes
-- **Channel-based only**: Active consumption through channels, no pull-based API in this layer
+- **Static direct registration**: In-process consumers cannot be added or removed without re-registration.
+- **Coordinator boundary**: Dynamic membership and range rebalancing belong to the text protocol coordinator.
+- **Channel-only layer**: Network consumers use `CONSUME` or `STREAM` instead.
 
-## Consumer Group Lifecycle
+## Embedded Channel Registration Lifecycle
 
 ```mermaid
 sequenceDiagram
@@ -293,7 +350,7 @@ sequenceDiagram
     APP->>CONS: receive from Consumer.MsgCh
 ```
 
-## Rebalance Flow
+## Embedded Channel Registration Flow
 
 ```mermaid
 flowchart TD
@@ -318,8 +375,9 @@ flowchart TD
 
 # Summary
 
-Consumer groups in cursus provide load balancing and ordering guarantees through a deterministic partition assignment mechanism. The modulo-based distribution ensures even load across consumers while maintaining per-partition message ordering.
-
-Multiple consumer groups can independently consume the same topic, each with its own partition-to-consumer mapping and isolated message delivery channels.
-
-The implementation uses goroutines to bridge partition group channels to consumer message channels, with buffering at multiple levels (partition: 10000, group channel: 10000, consumer: 1000) to handle bursts and provide backpressure protection.
+Network consumers use the broker coordinator for generation-fenced membership,
+range assignment, replicated timeout removal, and durable offsets. Separate
+groups retain independent offsets and assignments. The in-process TopicManager
+channel layer uses static modulo distribution and buffered goroutines; its
+registration lifecycle should not be confused with the dynamic protocol
+coordinator lifecycle.

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -361,6 +361,8 @@ STREAM topic=<name> partition=<N> member=<id> group=<name> [isolation=<read_comm
 
 Opens a continuous stream. Server pushes binary batches at ~100ms intervals. The connection stays open until the client disconnects, the broker removes the stream, the stream times out, or an unrecoverable stream error occurs. Like `CONSUME`, `STREAM` is a stateless partition-leader data path and does not validate group ownership or generation on every read. `STREAM` uses the same `isolation` contract as `CONSUME`; the default is `read_committed`.
 
+Stream delivery never advances the consumer group's committed offset. Delivery to a TCP connection is not processing acknowledgement. After processing a batch, the client must explicitly send `COMMIT_OFFSET` or `BATCH_COMMIT` with its current member and generation.
+
 Keepalive: Server sends `[00 00 00 00]` (4 zero bytes as length prefix) when no messages are available. Clients MUST treat zero-length frames as keepalive and continue reading.
 
 Control frames: The broker may send UTF-8 text frames with the prefix `STREAM_CONTROL` on the same length-prefixed connection. Clients MUST inspect text control frames before binary batch decoding.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -212,6 +212,8 @@ STREAM_CONTROL type=CLOSE reason=<stopped|removed|timeout|error|offset_out_of_ra
 
 Clients must treat zero-length frames as keepalive. Like `CONSUME`, `STREAM` is a stateless partition-leader data path and does not validate group ownership or generation on every read. `STREAM` uses the same `isolation` contract as `CONSUME`; the default is `read_committed`. A `STREAM_CONTROL type=CLOSE` frame is a graceful terminator; `reason=offset_out_of_range` means the requested stream offset is older than the retained log. Clients should close the socket and resume through the consumer group offset contract or reset according to policy. Raw TCP disconnect without a close control frame remains possible on broker crash or network failure and should be treated as retryable.
 
+The broker does not commit offsets when records are written to a stream socket or when the stream closes. The client must commit the next offset explicitly after processing, using its current member and generation. This keeps stream delivery consistent with the at-least-once consumer-group contract.
+
 Common errors:
 
 ```text

--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -85,8 +85,10 @@ sequenceDiagram
     SDK->>ANY: FIND_COORDINATOR group=G
     ANY-->>SDK: OK host=H port=P
 
-    SDK->>COORD: JOIN_GROUP / SYNC_GROUP
-    COORD-->>SDK: OK assignments=[0,1,2]
+    SDK->>COORD: JOIN_GROUP topic=T group=G member=M
+    COORD-->>SDK: OK member=M-1234 generation=N assignments=[0,1,2]
+    SDK->>COORD: SYNC_GROUP topic=T group=G member=M-1234 generation=N
+    COORD-->>SDK: OK member=M-1234 generation=N assignments=[0,1,2]
 
     SDK->>ANY: METADATA topic=T
     ANY-->>SDK: OK leaders=L0,L1,L2
@@ -97,7 +99,7 @@ sequenceDiagram
     end
 
     loop Heartbeat
-        SDK->>COORD: HEARTBEAT
-        COORD-->>SDK: OK
+        SDK->>COORD: HEARTBEAT topic=T group=G member=M-1234 generation=N
+        COORD-->>SDK: OK member=M-1234 generation=N
     end
 ```

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -212,10 +212,12 @@ func (f *BrokerFSM) applyJoinGroupCommand(jsonData string) interface{} {
 
 func (f *BrokerFSM) applyGroupSyncCommand(jsonData string) interface{} {
 	var cmd struct {
-		Type   string `json:"type"`
-		Group  string `json:"group"`
-		Member string `json:"member"`
-		Topic  string `json:"topic"`
+		Type       string   `json:"type"`
+		Group      string   `json:"group"`
+		Member     string   `json:"member"`
+		Members    []string `json:"members"`
+		Topic      string   `json:"topic"`
+		Generation *int     `json:"generation"`
 	}
 
 	if err := json.Unmarshal([]byte(jsonData), &cmd); err != nil {
@@ -250,7 +252,20 @@ func (f *BrokerFSM) applyGroupSyncCommand(jsonData string) interface{} {
 			return err
 		}
 	case "LEAVE":
-		_ = f.cd.RemoveConsumer(cmd.Group, cmd.Member)
+		if cmd.Generation == nil {
+			// Compatibility with metadata entries written before generation
+			// fencing was introduced.
+			return f.cd.RemoveConsumer(cmd.Group, cmd.Member)
+		}
+		return f.cd.RemoveConsumerForGeneration(cmd.Group, cmd.Member, *cmd.Generation)
+	case "EXPIRE":
+		if cmd.Generation == nil {
+			return fmt.Errorf("missing generation for group expiration")
+		}
+		if len(cmd.Members) == 0 {
+			return fmt.Errorf("missing members for group expiration")
+		}
+		return f.cd.ExpireConsumers(cmd.Group, *cmd.Generation, cmd.Members)
 	}
 
 	return nil

--- a/pkg/cluster/replication/fsm/fsm_offset.go
+++ b/pkg/cluster/replication/fsm/fsm_offset.go
@@ -10,10 +10,12 @@ import (
 
 func (f *BrokerFSM) applyOffsetSyncCommand(jsonData string) interface{} {
 	var cmd struct {
-		Group     string `json:"group"`
-		Topic     string `json:"topic"`
-		Partition int    `json:"partition"`
-		Offset    uint64 `json:"offset"`
+		Group      string `json:"group"`
+		Topic      string `json:"topic"`
+		Member     string `json:"member"`
+		Generation *int   `json:"generation"`
+		Partition  int    `json:"partition"`
+		Offset     uint64 `json:"offset"`
 	}
 
 	if err := json.Unmarshal([]byte(jsonData), &cmd); err != nil {
@@ -27,6 +29,13 @@ func (f *BrokerFSM) applyOffsetSyncCommand(jsonData string) interface{} {
 		return err
 	}
 
+	if cmd.Member != "" && cmd.Generation != nil {
+		return f.cd.ApplyFencedOffsetUpdateFromFSM(cmd.Group, cmd.Topic, cmd.Member, *cmd.Generation,
+			[]coordinator.OffsetItem{{
+				Partition: cmd.Partition,
+				Offset:    cmd.Offset,
+			}})
+	}
 	err := f.cd.ApplyOffsetUpdateFromFSM(cmd.Group, cmd.Topic,
 		[]coordinator.OffsetItem{
 			{
@@ -43,9 +52,11 @@ func (f *BrokerFSM) applyOffsetSyncCommand(jsonData string) interface{} {
 
 func (f *BrokerFSM) applyBatchOffsetSyncCommand(jsonData string) interface{} {
 	var cmd struct {
-		Group   string                   `json:"group"`
-		Topic   string                   `json:"topic"`
-		Offsets []coordinator.OffsetItem `json:"offsets"`
+		Group      string                   `json:"group"`
+		Topic      string                   `json:"topic"`
+		Member     string                   `json:"member"`
+		Generation *int                     `json:"generation"`
+		Offsets    []coordinator.OffsetItem `json:"offsets"`
 	}
 
 	if err := json.Unmarshal([]byte(jsonData), &cmd); err != nil {
@@ -59,6 +70,9 @@ func (f *BrokerFSM) applyBatchOffsetSyncCommand(jsonData string) interface{} {
 		return err
 	}
 
+	if cmd.Member != "" && cmd.Generation != nil {
+		return f.cd.ApplyFencedOffsetUpdateFromFSM(cmd.Group, cmd.Topic, cmd.Member, *cmd.Generation, cmd.Offsets)
+	}
 	err := f.cd.ApplyOffsetUpdateFromFSM(cmd.Group, cmd.Topic, cmd.Offsets)
 	if err != nil {
 		util.Error("FSM: Failed to update coordinator state: %v", err)

--- a/pkg/cluster/replication/fsm/fsm_test.go
+++ b/pkg/cluster/replication/fsm/fsm_test.go
@@ -984,3 +984,82 @@ func TestBrokerFSM_RestoreDefersTransactionStateUntilManagerAttached(t *testing.
 		t.Fatalf("unexpected restored transaction: %+v", tx)
 	}
 }
+func TestBrokerFSMOffsetSyncRejectsStaleGeneration(t *testing.T) {
+	cfg := config.DefaultConfig()
+	tm := topic.NewTopicManager(cfg, &MockHandlerProvider{}, nil)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
+	if err := cd.RegisterGroup("events", "workers", 2); err != nil {
+		t.Fatalf("register group: %v", err)
+	}
+	if _, err := cd.AddConsumer("workers", "member-1"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	f := NewBrokerFSM(tm, cd)
+
+	valid := &raft.Log{Data: []byte(`OFFSET_SYNC:{"group":"workers","topic":"events","member":"member-1","generation":1,"partition":0,"offset":5}`)}
+	if result := f.Apply(valid); result != nil {
+		t.Fatalf("valid fenced offset apply failed: %v", result)
+	}
+
+	if _, err := cd.AddConsumer("workers", "member-2"); err != nil {
+		t.Fatalf("add second member: %v", err)
+	}
+	stale := &raft.Log{Data: []byte(`OFFSET_SYNC:{"group":"workers","topic":"events","member":"member-1","generation":1,"partition":0,"offset":6}`)}
+	result := f.Apply(stale)
+	err, ok := result.(error)
+	if !ok {
+		t.Fatalf("expected stale generation error, got %T %v", result, result)
+	}
+	if got, want := err.Error(), "ERROR: GEN_MISMATCH current=2 requested=1 group=workers member=member-1"; got != want {
+		t.Fatalf("unexpected stale generation error: got %q want %q", got, want)
+	}
+
+	offset, found := cd.GetOffset("workers", "events", 0)
+	if !found || offset != 5 {
+		t.Fatalf("stale replicated commit changed offset: found=%v offset=%d", found, offset)
+	}
+}
+
+func TestBrokerFSMGroupExpirationIsGenerationFenced(t *testing.T) {
+	cfg := config.DefaultConfig()
+	tm := topic.NewTopicManager(cfg, &MockHandlerProvider{}, nil)
+	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
+	if err := cd.RegisterGroup("events", "workers", 2); err != nil {
+		t.Fatalf("register group: %v", err)
+	}
+	if _, err := cd.AddConsumer("workers", "member-1"); err != nil {
+		t.Fatalf("add first member: %v", err)
+	}
+	if _, err := cd.AddConsumer("workers", "member-2"); err != nil {
+		t.Fatalf("add second member: %v", err)
+	}
+	f := NewBrokerFSM(tm, cd)
+
+	expire := &raft.Log{Data: []byte(`GROUP_SYNC:{"type":"EXPIRE","group":"workers","generation":2,"members":["member-1"]}`)}
+	if result := f.Apply(expire); result != nil {
+		t.Fatalf("group expiration failed: %v", result)
+	}
+	status, err := cd.GetGroupStatus("workers")
+	if err != nil {
+		t.Fatalf("group status: %v", err)
+	}
+	if status.Generation != 3 || status.MemberCount != 1 {
+		t.Fatalf("unexpected status after expiration: generation=%d members=%d", status.Generation, status.MemberCount)
+	}
+
+	result := f.Apply(expire)
+	applyErr, ok := result.(error)
+	if !ok {
+		t.Fatalf("expected retry to be generation fenced, got %T %v", result, result)
+	}
+	if got, want := applyErr.Error(), "ERROR: GEN_MISMATCH current=3 requested=2 group=workers"; got != want {
+		t.Fatalf("unexpected expiration retry error: got %q want %q", got, want)
+	}
+	status, err = cd.GetGroupStatus("workers")
+	if err != nil {
+		t.Fatalf("group status after retry: %v", err)
+	}
+	if status.Generation != 3 || status.MemberCount != 1 {
+		t.Fatalf("expiration retry changed state: generation=%d members=%d", status.Generation, status.MemberCount)
+	}
+}

--- a/pkg/config/properties.go
+++ b/pkg/config/properties.go
@@ -97,7 +97,8 @@ type Config struct {
 	MaxStreamConnections    int           `yaml:"max_stream_connections" json:"max.stream.connections"`
 	StreamTimeout           time.Duration `yaml:"stream_timeout" json:"stream.timeout"`
 	StreamHeartbeatInterval time.Duration `yaml:"stream_heartbeat_interval" json:"stream.heartbeat.interval"`
-	StreamCommitInterval    time.Duration `yaml:"stream_commit_interval" json:"stream.commit.interval"`
+	// Deprecated: stream delivery never commits consumer offsets; clients commit after processing.
+	StreamCommitInterval time.Duration `yaml:"stream_commit_interval" json:"stream.commit.interval"`
 
 	// security
 	UseTLS                  bool `yaml:"use_tls" json:"tls.enable"`
@@ -270,7 +271,7 @@ func LoadConfig() (*Config, error) {
 	flag.IntVar(&cfg.MaxStreamConnections, "max-stream-connections", cfg.MaxStreamConnections, "Max stream connections")
 	flag.DurationVar(&cfg.StreamTimeout, "stream-timeout", cfg.StreamTimeout, "Stream timeout")
 	flag.DurationVar(&cfg.StreamHeartbeatInterval, "stream-heartbeat-interval", cfg.StreamHeartbeatInterval, "Stream heartbeat")
-	flag.DurationVar(&cfg.StreamCommitInterval, "stream-commit-interval", cfg.StreamCommitInterval, "Stream commit interval")
+	flag.DurationVar(&cfg.StreamCommitInterval, "stream-commit-interval", cfg.StreamCommitInterval, "Deprecated and ignored; clients commit stream offsets after processing")
 
 	// security
 	flag.BoolVar(&cfg.UseTLS, "tls", cfg.UseTLS, "Enable TLS")

--- a/pkg/controller/auth_test.go
+++ b/pkg/controller/auth_test.go
@@ -122,14 +122,19 @@ func TestPublicPublishCannotUseInternalTxnFlag(t *testing.T) {
 		t.Fatalf("expected public internal transaction publish to be rejected, got %q", resp)
 	}
 }
-func TestCommitOffsetOwnershipOnlyRequiresMemberGeneration(t *testing.T) {
+func TestCommitOffsetRequiresMemberGeneration(t *testing.T) {
 	cfg := config.DefaultConfig()
 	coord := coordinator.NewCoordinator(context.Background(), cfg, &dummyPublisher{})
 	ch := NewCommandHandler(nil, cfg, coord, nil, nil)
 
 	resp := ch.HandleCommand("COMMIT_OFFSET topic=t1 group=g1 partition=0 offset=1 validate_only=true ownership_only=true", NewClientContext("", 0))
-	if !strings.Contains(resp, "missing_ownership_params") {
-		t.Fatalf("expected missing ownership params, got %q", resp)
+	if !strings.Contains(resp, "missing_member") {
+		t.Fatalf("expected missing member, got %q", resp)
+	}
+
+	resp = ch.HandleCommand("COMMIT_OFFSET topic=t1 group=g1 partition=0 offset=1 member=m1 validate_only=true", NewClientContext("", 0))
+	if !strings.Contains(resp, "missing_generation") {
+		t.Fatalf("expected missing generation, got %q", resp)
 	}
 }
 

--- a/pkg/controller/cluster_handler.go
+++ b/pkg/controller/cluster_handler.go
@@ -114,6 +114,35 @@ type coordCacheEntry struct {
 
 const coordCacheTTL = 30 * time.Second
 
+// IsGroupCoordinator is the strict ownership check used by session expiration.
+// Discovery failures return false so multiple brokers cannot expire the same
+// group while the coordinator ring is unavailable.
+func (ch *CommandHandler) IsGroupCoordinator(groupName string) bool {
+	if !ch.isDistributed() {
+		return true
+	}
+	if !ch.hasRouter() {
+		return false
+	}
+	id, _, err := ch.Cluster.Router.FindCoordinator(groupName)
+	return err == nil && id == ch.Cluster.Router.BrokerID()
+}
+
+// ExpireGroupMembers serializes timeout-driven membership removal through the
+// replicated metadata log.
+func (ch *CommandHandler) ExpireGroupMembers(groupName string, generation int, memberIDs []string) error {
+	if !ch.isDistributed() {
+		return ch.Coordinator.ExpireConsumers(groupName, generation, memberIDs)
+	}
+	_, err := ch.applyViaLeader("GROUP_SYNC", map[string]interface{}{
+		"type":       "EXPIRE",
+		"group":      groupName,
+		"generation": generation,
+		"members":    memberIDs,
+	})
+	return err
+}
+
 // checkCoordinator checks if this broker is the coordinator for the given group.
 // Returns (addr, false) if another broker is coordinator, or (_, true) if we are.
 func (ch *CommandHandler) checkCoordinator(groupName string) (AdvertisedAddr, bool) {
@@ -295,7 +324,7 @@ func (ch *CommandHandler) handleRaftApply(cmd string) string {
 
 	_, err := ch.applyAndWait(cmdType, payload)
 	if err != nil {
-		return fmt.Sprintf("ERROR: raft_apply_failed reason=%q", err.Error())
+		return formatReplicatedGroupError(err, "raft_apply_failed")
 	}
 	return "OK"
 }

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -276,6 +276,38 @@ func (ch *CommandHandler) handleJoinGroup(cmd string, ctx *ClientContext) string
 		return "ERROR: missing_member command=JOIN_GROUP"
 	}
 
+	if ch.isDistributed() {
+		coordAddr, isCoord := ch.checkCoordinator(groupName)
+		if !isCoord {
+			return notCoordinatorResponse(coordAddr)
+		}
+	}
+	if _, topicErr := ch.resolveGroupOffsetTopic(groupName, topicName); topicErr != "" {
+		return topicErr
+	}
+
+	if generationText := args["generation"]; generationText != "" {
+		generation, parseErr := strconv.Atoi(generationText)
+		if parseErr != nil {
+			return "ERROR: invalid_generation command=JOIN_GROUP"
+		}
+		if ch.Coordinator == nil {
+			return "ERROR: coordinator_not_available"
+		}
+		assignments, resumeErr := ch.Coordinator.ResumeConsumer(groupName, consumerID, generation)
+		if resumeErr != nil {
+			return formatCoordinatorError(resumeErr)
+		}
+		ctx.MemberID = consumerID
+		ctx.Generation = generation
+		return fmt.Sprintf(
+			"OK generation=%d member=%s assignments=%v resumed=true",
+			generation,
+			consumerID,
+			assignments,
+		)
+	}
+
 	n, err := rand.Int(rand.Reader, big.NewInt(10000))
 	var randSuffix string
 	if err != nil {
@@ -288,11 +320,6 @@ func (ch *CommandHandler) handleJoinGroup(cmd string, ctx *ClientContext) string
 
 	var assignments []int
 	if ch.isDistributed() {
-		coordAddr, isCoord := ch.checkCoordinator(groupName)
-		if !isCoord {
-			return notCoordinatorResponse(coordAddr)
-		}
-
 		joinPayload := map[string]interface{}{
 			"type":   "JOIN",
 			"group":  groupName,
@@ -369,12 +396,23 @@ func (ch *CommandHandler) handleSyncGroup(cmd string) string {
 			return notCoordinatorResponse(coordAddr)
 		}
 	}
-
-	assignments := ch.Coordinator.GetMemberAssignments(groupName, memberID)
-	if assignments == nil {
-		return fmt.Sprintf("ERROR: member_not_found member=%s group=%s", memberID, groupName)
+	if _, topicErr := ch.resolveGroupOffsetTopic(groupName, topicName); topicErr != "" {
+		return topicErr
 	}
-	return fmt.Sprintf("OK assignments=%v", assignments)
+
+	generationText := args["generation"]
+	if generationText == "" {
+		return "ERROR: missing_generation command=SYNC_GROUP"
+	}
+	generation, parseErr := strconv.Atoi(generationText)
+	if parseErr != nil {
+		return "ERROR: invalid_generation command=SYNC_GROUP"
+	}
+	assignments, syncErr := ch.Coordinator.ResumeConsumer(groupName, memberID, generation)
+	if syncErr != nil {
+		return formatCoordinatorError(syncErr)
+	}
+	return fmt.Sprintf("OK generation=%d member=%s assignments=%v", generation, memberID, assignments)
 }
 
 // handleLeaveGroup processes LEAVE_GROUP command
@@ -394,26 +432,47 @@ func (ch *CommandHandler) handleLeaveGroup(cmd string) string {
 		return "ERROR: missing_member command=LEAVE_GROUP"
 	}
 
+	generationText := args["generation"]
+	if generationText == "" {
+		return "ERROR: missing_generation command=LEAVE_GROUP"
+	}
+	generation, parseErr := strconv.Atoi(generationText)
+	if parseErr != nil {
+		return "ERROR: invalid_generation command=LEAVE_GROUP"
+	}
+	if ch.Coordinator == nil {
+		return "ERROR: coordinator_not_available"
+	}
+
 	if ch.isDistributed() {
 		coordAddr, isCoord := ch.checkCoordinator(groupName)
 		if !isCoord {
 			return notCoordinatorResponse(coordAddr)
 		}
 
+	}
+	if _, topicErr := ch.resolveGroupOffsetTopic(groupName, topicName); topicErr != "" {
+		return topicErr
+	}
+	if errResp := ch.Coordinator.ValidateMemberGeneration(groupName, consumerID, generation); errResp != "" {
+		return errResp
+	}
+	if ch.isDistributed() {
 		payload := map[string]interface{}{
-			"type":   "LEAVE",
-			"group":  groupName,
-			"member": consumerID,
+			"type":       "LEAVE",
+			"group":      groupName,
+			"member":     consumerID,
+			"generation": generation,
 		}
 
 		_, err := ch.applyViaLeader("GROUP_SYNC", payload)
 		if err != nil {
-			return fmt.Sprintf("ERROR: register_group_failed reason=%q", err.Error())
+			return formatReplicatedGroupError(err, "register_group_failed")
 		}
 	} else {
 		if ch.Coordinator != nil {
-			if err := ch.Coordinator.RemoveConsumer(groupName, consumerID); err != nil {
-				return fmt.Sprintf("ERROR: register_group_failed reason=%q", err.Error())
+			if err := ch.Coordinator.RemoveConsumerForGeneration(groupName, consumerID, generation); err != nil {
+				return formatCoordinatorError(err)
 			}
 		}
 	}
@@ -578,30 +637,30 @@ func (ch *CommandHandler) handleHeartbeat(cmd string) string {
 	if ch.Coordinator == nil {
 		return "ERROR: coordinator_not_available"
 	}
+	if _, topicErr := ch.resolveGroupOffsetTopic(groupName, topicName); topicErr != "" {
+		return topicErr
+	}
 
-	generation := -1
-	if genStr := args["generation"]; genStr != "" {
-		parsed, parseErr := strconv.Atoi(genStr)
-		if parseErr != nil {
-			return "ERROR: invalid_generation command=HEARTBEAT"
-		}
-		generation = parsed
+	generationText := args["generation"]
+	if generationText == "" {
+		return "ERROR: missing_generation command=HEARTBEAT"
 	}
-	if errResp := ch.Coordinator.ValidateMemberGeneration(groupName, consumerID, generation); errResp != "" {
-		return errResp
+	generation, parseErr := strconv.Atoi(generationText)
+	if parseErr != nil {
+		return "ERROR: invalid_generation command=HEARTBEAT"
 	}
-	if err := ch.Coordinator.RecordHeartbeat(groupName, consumerID); err != nil {
+	if err := ch.Coordinator.RecordHeartbeatForGeneration(groupName, consumerID, generation); err != nil {
 		return formatCoordinatorError(err)
 	}
-	return fmt.Sprintf("OK member=%s generation=%d", consumerID, ch.Coordinator.GetGeneration(groupName))
+	return fmt.Sprintf("OK member=%s generation=%d", consumerID, generation)
 }
 
 // handleCommitOffset processes COMMIT_OFFSET command
 func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 	args := parseKeyValueArgs(cmd[14:])
 	validateOnly := strings.EqualFold(args["validate_only"], "true")
-	ownershipOnly := strings.EqualFold(args["ownership_only"], "true")
 
+	ownershipOnly := strings.EqualFold(args["ownership_only"], "true")
 	topicName, ok := args["topic"]
 	if !ok || topicName == "" {
 		return "ERROR: missing_topic command=COMMIT_OFFSET"
@@ -611,7 +670,7 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 		return "ERROR: missing_partition command=COMMIT_OFFSET"
 	}
 	partition, err := strconv.Atoi(partitionStr)
-	if err != nil {
+	if err != nil || partition < 0 {
 		return "ERROR: invalid_partition"
 	}
 	groupID, ok := args["group"]
@@ -639,21 +698,22 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 	if ch.Coordinator == nil {
 		return "ERROR: offset_manager_not_available"
 	}
-	ownershipChecked := false
-	if memberID := args["member"]; memberID != "" || args["generation"] != "" {
-		generation, genErr := strconv.Atoi(args["generation"])
-		if genErr != nil {
-			return "ERROR: invalid_generation command=COMMIT_OFFSET"
-		}
-		if errResp := ch.Coordinator.ValidateOwnershipFailure(groupID, memberID, generation, partition); errResp != "" {
-			return errResp
-		}
-		ownershipChecked = true
+	memberID := args["member"]
+	if memberID == "" {
+		return "ERROR: missing_member command=COMMIT_OFFSET"
+	}
+	generationText := args["generation"]
+	if generationText == "" {
+		return "ERROR: missing_generation command=COMMIT_OFFSET"
+	}
+	generation, genErr := strconv.Atoi(generationText)
+	if genErr != nil {
+		return "ERROR: invalid_generation command=COMMIT_OFFSET"
+	}
+	if errResp := ch.Coordinator.ValidateOwnershipFailure(groupID, memberID, generation, partition); errResp != "" {
+		return errResp
 	}
 	if validateOnly && ownershipOnly {
-		if !ownershipChecked {
-			return "ERROR: missing_ownership_params command=COMMIT_OFFSET"
-		}
 		return "OK validated=true"
 	}
 	if current, ok := ch.Coordinator.GetOffset(groupID, offsetTopic, partition); ok && offset < current {
@@ -665,20 +725,22 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 
 	if ch.isDistributed() {
 		payload := map[string]interface{}{
-			"type":      "COMMIT",
-			"group":     groupID,
-			"topic":     offsetTopic,
-			"partition": partition,
-			"offset":    offset,
+			"type":       "COMMIT",
+			"group":      groupID,
+			"topic":      offsetTopic,
+			"member":     memberID,
+			"generation": generation,
+			"partition":  partition,
+			"offset":     offset,
 		}
 		_, err := ch.applyViaLeader("OFFSET_SYNC", payload)
 		if err != nil {
-			return fmt.Sprintf("ERROR: offset_sync_failed reason=%q", err.Error())
+			return formatReplicatedGroupError(err, "offset_sync_failed")
 		}
 		return "OK"
 	}
 
-	err = ch.Coordinator.CommitOffset(groupID, offsetTopic, partition, offset)
+	err = ch.Coordinator.ValidateAndCommit(groupID, offsetTopic, partition, offset, generation, memberID)
 	if err != nil {
 		return formatCoordinatorError(err)
 	}
@@ -702,7 +764,11 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 	if memberID == "" {
 		return "ERROR: missing_member command=BATCH_COMMIT"
 	}
-	generation, genErr := strconv.Atoi(args["generation"])
+	generationText := args["generation"]
+	if generationText == "" {
+		return "ERROR: missing_generation command=BATCH_COMMIT"
+	}
+	generation, genErr := strconv.Atoi(generationText)
 	if genErr != nil {
 		return "ERROR: invalid_generation command=BATCH_COMMIT"
 	}
@@ -731,24 +797,22 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 
 	var offsetList []coordinator.OffsetItem
 	for _, pair := range partitionPairs {
+		pair = strings.TrimSpace(pair)
 		kv := strings.Split(pair, ":")
 		if len(kv) != 2 {
-			continue
+			return fmt.Sprintf("ERROR: invalid_batch_commit_entry entry=%q", pair)
 		}
 		if !strings.HasPrefix(kv[0], "P") {
-			util.Warn("Invalid partition in batch commit: missing P prefix: %s", kv[0])
-			continue
+			return fmt.Sprintf("ERROR: invalid_partition entry=%q", pair)
 		}
 		partStr := strings.TrimPrefix(kv[0], "P")
 		p, err := strconv.Atoi(partStr)
-		if err != nil {
-			util.Warn("Invalid partition in batch commit: %s", kv[0])
-			continue
+		if err != nil || p < 0 {
+			return fmt.Sprintf("ERROR: invalid_partition entry=%q", pair)
 		}
 		o, err := strconv.ParseUint(kv[1], 10, 64)
 		if err != nil {
-			util.Warn("Invalid offset in batch commit: %s", kv[1])
-			continue
+			return fmt.Sprintf("ERROR: invalid_offset entry=%q", pair)
 		}
 		if errResp := ch.ValidateOwnershipFailure(groupID, memberID, generation, p); errResp != "" {
 			util.Warn("Batch commit ownership rejected for partition %d: %s", p, errResp)
@@ -764,18 +828,20 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 
 	if ch.isDistributed() {
 		batchCommitData := map[string]interface{}{
-			"type":    "BATCH_COMMIT",
-			"group":   groupID,
-			"topic":   offsetTopic,
-			"offsets": offsetList,
+			"type":       "BATCH_COMMIT",
+			"group":      groupID,
+			"topic":      offsetTopic,
+			"member":     memberID,
+			"generation": generation,
+			"offsets":    offsetList,
 		}
 		_, err := ch.applyViaLeader("BATCH_OFFSET", batchCommitData)
 		if err != nil {
 			util.Error("Raft batch apply failed: %v", err)
-			return fmt.Sprintf("ERROR: raft_batch_apply_failed reason=%q", err.Error())
+			return formatReplicatedGroupError(err, "raft_batch_apply_failed")
 		}
 	} else if ch.Coordinator != nil {
-		err := ch.Coordinator.CommitOffsetsBulk(groupID, offsetTopic, offsetList)
+		err := ch.Coordinator.ValidateAndCommitOffsetsBulk(groupID, offsetTopic, memberID, generation, offsetList)
 		if err != nil {
 			return formatCoordinatorError(err)
 		}
@@ -815,6 +881,14 @@ func resolveOffsetTopic(groupTopic, requestedTopic string) (string, bool) {
 		return groupTopic, true
 	}
 	return "", false
+}
+
+func formatReplicatedGroupError(err error, fallbackCode string) string {
+	msg := err.Error()
+	if idx := strings.Index(msg, "ERROR:"); idx >= 0 {
+		return msg[idx:]
+	}
+	return fmt.Sprintf("ERROR: %s reason=%q", fallbackCode, msg)
 }
 
 func formatCoordinatorError(err error) string {

--- a/pkg/controller/consume_handler.go
+++ b/pkg/controller/consume_handler.go
@@ -247,9 +247,6 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 	streamConn := stream.NewStreamConnection(conn, cArgs.TopicName, cArgs.PartitionID, cArgs.GroupName, actualOffset)
 	streamConn.SetBatchSize(cArgs.BatchSize)
 	streamConn.SetInterval(100 * time.Millisecond)
-	if ch.Coordinator != nil {
-		streamConn.SetCommitter(ch.Coordinator)
-	}
 
 	// Pass partition's message signal for event-driven streaming
 	signalCh := t.NewMessageSignal(cArgs.PartitionID)
@@ -261,7 +258,7 @@ func (ch *CommandHandler) HandleStreamCommand(conn net.Conn, rawCmd string, ctx 
 		return readPartitionMessages(p, offset, max, cArgs.ReadIsolation)
 	}
 
-	return ch.StreamManager.AddStream(streamKey, streamConn, readFn, ch.Config.StreamCommitInterval)
+	return ch.StreamManager.AddStream(streamKey, streamConn, readFn, 0)
 }
 
 func readPartitionMessages(p *topic.Partition, offset uint64, max int, isolation string) ([]types.Message, error) {

--- a/pkg/controller/handler_coverage_test.go
+++ b/pkg/controller/handler_coverage_test.go
@@ -413,8 +413,8 @@ func TestHandleSyncGroup_MemberNotFound(t *testing.T) {
 	_ = coord.RegisterGroup("sync-topic", "sg1", 2)
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("SYNC_GROUP topic=sync-topic group=sg1 member=nonexistent", ctx)
-	assert.Contains(t, resp, "assignments=[]")
+	resp := ch.HandleCommand("SYNC_GROUP topic=sync-topic group=sg1 member=nonexistent generation=0", ctx)
+	assert.Contains(t, resp, "member_not_found")
 }
 
 func TestHandleLeaveGroup_MissingParams(t *testing.T) {
@@ -727,7 +727,7 @@ func TestHandleBatchCommit_NoValidOffsets(t *testing.T) {
 	ctx := NewClientContext("", 0)
 
 	resp := ch.HandleCommand("BATCH_COMMIT topic=bc-topic group=bc-g1 generation=1 member=bc-m1 invalid", ctx)
-	assert.Contains(t, resp, "no_valid_offsets")
+	assert.Contains(t, resp, "invalid_batch_commit_entry")
 }
 
 func TestHandleBatchCommit_ValidBulk(t *testing.T) {
@@ -896,7 +896,7 @@ func TestHandleHeartbeat_WithCoordinator(t *testing.T) {
 	_, _ = coord.AddConsumer("hb-g1", "hb-m1")
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("HEARTBEAT topic=hb-topic group=hb-g1 member=hb-m1", ctx)
+	resp := ch.HandleCommand(fmt.Sprintf("HEARTBEAT topic=hb-topic group=hb-g1 member=hb-m1 generation=%d", coord.GetGeneration("hb-g1")), ctx)
 	assert.Contains(t, resp, "OK member=")
 }
 
@@ -906,7 +906,7 @@ func TestHandleHeartbeat_InvalidMember(t *testing.T) {
 	_ = coord.RegisterGroup("hb-topic2", "hb-g2", 2)
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("HEARTBEAT topic=hb-topic2 group=hb-g2 member=nonexistent", ctx)
+	resp := ch.HandleCommand("HEARTBEAT topic=hb-topic2 group=hb-g2 member=nonexistent generation=0", ctx)
 	assert.Contains(t, resp, "ERROR")
 }
 
@@ -914,9 +914,12 @@ func TestHandleCommitOffset_WithCoordinator(t *testing.T) {
 	ch, tm, coord := newTestHandlerWithCoordinator(t)
 	_ = tm.CreateTopic("commit-topic", 2, false, false)
 	_ = coord.RegisterGroup("commit-topic", "commit-g1", 2)
+	assignments, err := coord.AddConsumer("commit-g1", "commit-m1")
+	require.NoError(t, err)
+	require.Contains(t, assignments, 0)
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("COMMIT_OFFSET topic=commit-topic partition=0 group=commit-g1 offset=50", ctx)
+	resp := ch.HandleCommand(fmt.Sprintf("COMMIT_OFFSET topic=commit-topic partition=0 group=commit-g1 offset=50 member=commit-m1 generation=%d", coord.GetGeneration("commit-g1")), ctx)
 	assert.Equal(t, "OK", resp)
 
 	resp = ch.HandleCommand("FETCH_OFFSET topic=commit-topic partition=0 group=commit-g1", ctx)
@@ -1004,7 +1007,7 @@ func TestHandleLeaveGroup_WithCoordinator(t *testing.T) {
 	_, _ = coord.AddConsumer("leave-g1", "leave-m1")
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("LEAVE_GROUP topic=leave-topic group=leave-g1 member=leave-m1", ctx)
+	resp := ch.HandleCommand(fmt.Sprintf("LEAVE_GROUP topic=leave-topic group=leave-g1 member=leave-m1 generation=%d", coord.GetGeneration("leave-g1")), ctx)
 	assert.Contains(t, resp, "left=true")
 }
 
@@ -1013,8 +1016,8 @@ func TestHandleLeaveGroup_NilCoordinator(t *testing.T) {
 	_ = tm.CreateTopic("leave-topic2", 2, false, false)
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("LEAVE_GROUP topic=leave-topic2 group=leave-g2 member=m1", ctx)
-	assert.Contains(t, resp, "left=true")
+	resp := ch.HandleCommand("LEAVE_GROUP topic=leave-topic2 group=leave-g2 member=m1 generation=1", ctx)
+	assert.Contains(t, resp, "coordinator_not_available")
 }
 
 func TestHandleBatchCommit_InvalidPartitionFormat(t *testing.T) {
@@ -1028,7 +1031,7 @@ func TestHandleBatchCommit_InvalidPartitionFormat(t *testing.T) {
 
 	cmd := fmt.Sprintf("BATCH_COMMIT topic=bc3-topic group=bc3-g1 generation=%d member=bc3-m1 Pabc:100", gen)
 	resp := ch.HandleCommand(cmd, ctx)
-	assert.Contains(t, resp, "no_valid_offsets")
+	assert.Contains(t, resp, "invalid_partition")
 }
 
 func TestHandleBatchCommit_InvalidOffsetFormat(t *testing.T) {
@@ -1042,7 +1045,7 @@ func TestHandleBatchCommit_InvalidOffsetFormat(t *testing.T) {
 
 	cmd := fmt.Sprintf("BATCH_COMMIT topic=bc4-topic group=bc4-g1 generation=%d member=bc4-m1 P0:abc", gen)
 	resp := ch.HandleCommand(cmd, ctx)
-	assert.Contains(t, resp, "no_valid_offsets")
+	assert.Contains(t, resp, "invalid_offset")
 }
 
 func TestHandleBatchCommit_StaleGeneration(t *testing.T) {
@@ -1241,9 +1244,12 @@ func TestHandleCommitAndFetchOffset_AllowsWildcardGroupTopic(t *testing.T) {
 	ch, tm, coord := newTestHandlerWithCoordinator(t)
 	require.NoError(t, tm.CreateTopic("wild-alpha", 1, false, false))
 	require.NoError(t, coord.RegisterGroup("wild-*", "wild-group", 1))
+	assignments, err := coord.AddConsumer("wild-group", "wild-member")
+	require.NoError(t, err)
+	require.Equal(t, []int{0}, assignments)
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("COMMIT_OFFSET topic=wild-alpha partition=0 group=wild-group offset=7", ctx)
+	resp := ch.HandleCommand(fmt.Sprintf("COMMIT_OFFSET topic=wild-alpha partition=0 group=wild-group offset=7 member=wild-member generation=%d", coord.GetGeneration("wild-group")), ctx)
 	assert.Equal(t, "OK", resp)
 
 	resp = ch.HandleCommand("FETCH_OFFSET topic=wild-alpha partition=0 group=wild-group", ctx)
@@ -1254,9 +1260,12 @@ func TestHandleCommitAndFetchOffset_AllowsQuestionMarkGroupTopic(t *testing.T) {
 	ch, tm, coord := newTestHandlerWithCoordinator(t)
 	require.NoError(t, tm.CreateTopic("q-1", 1, false, false))
 	require.NoError(t, coord.RegisterGroup("q-?", "question-group", 1))
+	assignments, err := coord.AddConsumer("question-group", "question-member")
+	require.NoError(t, err)
+	require.Equal(t, []int{0}, assignments)
 	ctx := NewClientContext("", 0)
 
-	resp := ch.HandleCommand("COMMIT_OFFSET topic=q-1 partition=0 group=question-group offset=3", ctx)
+	resp := ch.HandleCommand(fmt.Sprintf("COMMIT_OFFSET topic=q-1 partition=0 group=question-group offset=3 member=question-member generation=%d", coord.GetGeneration("question-group")), ctx)
 	assert.Equal(t, "OK", resp)
 
 	resp = ch.HandleCommand("FETCH_OFFSET topic=q-1 partition=0 group=question-group", ctx)
@@ -1682,4 +1691,12 @@ func TestRedactCommandSecrets(t *testing.T) {
 	assert.NotContains(t, redacted, "super-secret")
 	assert.Contains(t, redacted, "internal_token=<redacted>")
 	assert.Contains(t, redacted, "payload-value")
+}
+
+func TestFormatReplicatedGroupErrorPreservesWireCode(t *testing.T) {
+	err := fmt.Errorf("leader raft apply: ERROR: GEN_MISMATCH current=3 requested=2 group=g1")
+	assert.Equal(t, "ERROR: GEN_MISMATCH current=3 requested=2 group=g1", formatReplicatedGroupError(err, "offset_sync_failed"))
+
+	err = fmt.Errorf("raft apply failed: unavailable")
+	assert.Equal(t, `ERROR: offset_sync_failed reason="raft apply failed: unavailable"`, formatReplicatedGroupError(err, "offset_sync_failed"))
 }

--- a/pkg/controller/handler_group_test.go
+++ b/pkg/controller/handler_group_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type DummyPublisher struct{}
@@ -46,12 +47,14 @@ func TestCommandHandler_GroupOps(t *testing.T) {
 	})
 
 	t.Run("SYNC_GROUP", func(t *testing.T) {
-		resp := ch.HandleCommand("SYNC_GROUP topic=topic1 group=g1 member="+ctx.MemberID, ctx)
-		assert.Contains(t, resp, "OK assignments=")
+		cmd := fmt.Sprintf("SYNC_GROUP topic=topic1 group=g1 member=%s generation=%d", ctx.MemberID, ctx.Generation)
+		resp := ch.HandleCommand(cmd, ctx)
+		assert.Contains(t, resp, "OK generation=")
 	})
 
 	t.Run("HEARTBEAT", func(t *testing.T) {
-		resp := ch.HandleCommand("HEARTBEAT topic=topic1 group=g1 member="+ctx.MemberID, ctx)
+		cmd := fmt.Sprintf("HEARTBEAT topic=topic1 group=g1 member=%s generation=%d", ctx.MemberID, ctx.Generation)
+		resp := ch.HandleCommand(cmd, ctx)
 		assert.Contains(t, resp, "OK member=")
 	})
 
@@ -70,7 +73,8 @@ func TestCommandHandler_GroupOps(t *testing.T) {
 	})
 
 	t.Run("LEAVE_GROUP", func(t *testing.T) {
-		resp := ch.HandleCommand("LEAVE_GROUP topic=topic1 group=g1 member="+ctx.MemberID, ctx)
+		cmd := fmt.Sprintf("LEAVE_GROUP topic=topic1 group=g1 member=%s generation=%d", ctx.MemberID, ctx.Generation)
+		resp := ch.HandleCommand(cmd, ctx)
 		assert.Contains(t, resp, "left=true")
 	})
 }
@@ -86,10 +90,21 @@ func TestCommandHandler_OffsetOps(t *testing.T) {
 	ctx := controller.NewClientContext("g1", 0)
 
 	_ = coord.RegisterGroup("topic1", "g1", 4)
+	assignments, err := coord.AddConsumer("g1", "m1")
+	require.NoError(t, err)
+	require.Contains(t, assignments, 0)
+	generation := coord.GetGeneration("g1")
 
 	t.Run("COMMIT_OFFSET", func(t *testing.T) {
-		resp := ch.HandleCommand("COMMIT_OFFSET topic=topic1 partition=0 group=g1 offset=123", ctx)
+		resp := ch.HandleCommand(fmt.Sprintf("COMMIT_OFFSET topic=topic1 partition=0 group=g1 offset=123 member=m1 generation=%d", generation), ctx)
 		assert.Equal(t, "OK", resp)
+	})
+	t.Run("ownership-only validation ignores offset regression", func(t *testing.T) {
+		resp := ch.HandleCommand(fmt.Sprintf("COMMIT_OFFSET topic=topic1 partition=0 group=g1 offset=1 member=m1 generation=%d validate_only=true ownership_only=true", generation), ctx)
+		assert.Equal(t, "OK validated=true", resp)
+		offset, found := coord.GetOffset("g1", "topic1", 0)
+		require.True(t, found)
+		assert.Equal(t, uint64(123), offset)
 	})
 
 	t.Run("FETCH_OFFSET", func(t *testing.T) {
@@ -101,4 +116,126 @@ func TestCommandHandler_OffsetOps(t *testing.T) {
 		resp := ch.HandleCommand("FETCH_OFFSET topic=topic1 partition=1 group=g1", ctx)
 		assert.Equal(t, "OK offset=0", resp)
 	})
+}
+
+func TestCommandHandler_GroupCommandsRejectTopicMismatchAndPartialBatch(t *testing.T) {
+	cfg := config.DefaultConfig()
+	hp := &mockHandlerProvider{}
+	tm := topic.NewTopicManager(cfg, hp, nil)
+	require.NoError(t, tm.CreateTopic("topic1", 2, false, false))
+	require.NoError(t, tm.CreateTopic("topic2", 2, false, false))
+
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &DummyPublisher{})
+	ch := controller.NewCommandHandler(tm, cfg, coord, nil, nil)
+	t.Cleanup(func() { require.NoError(t, ch.Close()) })
+	ctx := controller.NewClientContext("g1", 0)
+
+	require.NoError(t, coord.RegisterGroup("topic1", "g1", 2))
+	assignments, err := coord.AddConsumer("g1", "m1")
+	require.NoError(t, err)
+	require.Contains(t, assignments, 0)
+	generation := coord.GetGeneration("g1")
+	require.NoError(t, coord.CommitOffset("g1", "topic1", 0, 123))
+
+	commands := []string{
+		"JOIN_GROUP topic=topic2 group=g1 member=intruder",
+		fmt.Sprintf("SYNC_GROUP topic=topic2 group=g1 member=m1 generation=%d", generation),
+		fmt.Sprintf("HEARTBEAT topic=topic2 group=g1 member=m1 generation=%d", generation),
+		fmt.Sprintf("LEAVE_GROUP topic=topic2 group=g1 member=m1 generation=%d", generation),
+	}
+	for _, command := range commands {
+		resp := ch.HandleCommand(command, ctx)
+		assert.Contains(t, resp, "ERROR: topic_not_assigned_to_group", command)
+	}
+
+	status, err := coord.GetGroupStatus("g1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, status.MemberCount)
+	assert.Equal(t, generation, status.Generation)
+
+	resp := ch.HandleCommand(
+		fmt.Sprintf("BATCH_COMMIT topic=topic1 group=g1 generation=%d member=m1 P0:150,invalid", generation),
+		ctx,
+	)
+	assert.Contains(t, resp, "ERROR: invalid_batch_commit_entry")
+	offset, found := coord.GetOffset("g1", "topic1", 0)
+	require.True(t, found)
+	assert.Equal(t, uint64(123), offset)
+
+	resp = ch.HandleCommand(
+		fmt.Sprintf("COMMIT_OFFSET topic=topic1 partition=-1 group=g1 offset=150 member=m1 generation=%d", generation),
+		ctx,
+	)
+	assert.Equal(t, "ERROR: invalid_partition", resp)
+
+	resp = ch.HandleCommand(
+		"BATCH_COMMIT topic=topic1 group=g1 member=m1 P0:150",
+		ctx,
+	)
+	assert.Equal(t, "ERROR: missing_generation command=BATCH_COMMIT", resp)
+}
+func TestCommandHandler_GroupResumeAndGenerationFencing(t *testing.T) {
+	cfg := config.DefaultConfig()
+	hp := &mockHandlerProvider{}
+	tm := topic.NewTopicManager(cfg, hp, nil)
+	require.NoError(t, tm.CreateTopic("resume-topic", 4, false, false))
+
+	coord := coordinator.NewCoordinator(context.Background(), cfg, &DummyPublisher{})
+	ch := controller.NewCommandHandler(tm, cfg, coord, nil, nil)
+	t.Cleanup(func() { require.NoError(t, ch.Close()) })
+	ctx := controller.NewClientContext("", 0)
+
+	registerResp := ch.HandleCommand("REGISTER_GROUP topic=resume-topic group=resume-group", ctx)
+	require.Contains(t, registerResp, "registered=true")
+	joinResp := ch.HandleCommand("JOIN_GROUP topic=resume-topic group=resume-group member=member", ctx)
+	require.Contains(t, joinResp, "OK generation=")
+
+	member := ctx.MemberID
+	generation := ctx.Generation
+	resumeResp := ch.HandleCommand(
+		fmt.Sprintf("JOIN_GROUP topic=resume-topic group=resume-group member=%s generation=%d", member, generation),
+		ctx,
+	)
+	assert.Contains(t, resumeResp, "resumed=true")
+	assert.Equal(t, member, ctx.MemberID)
+	assert.Equal(t, generation, ctx.Generation)
+
+	status, err := coord.GetGroupStatus("resume-group")
+	require.NoError(t, err)
+	assert.Equal(t, 1, status.MemberCount)
+	assert.Equal(t, generation, status.Generation)
+
+	otherCtx := controller.NewClientContext("", 0)
+	otherJoin := ch.HandleCommand("JOIN_GROUP topic=resume-topic group=resume-group member=other", otherCtx)
+	require.Contains(t, otherJoin, "OK generation=")
+	require.Greater(t, otherCtx.Generation, generation)
+
+	staleHeartbeat := ch.HandleCommand(
+		fmt.Sprintf("HEARTBEAT topic=resume-topic group=resume-group member=%s generation=%d", member, generation),
+		ctx,
+	)
+	assert.Contains(t, staleHeartbeat, "ERROR: GEN_MISMATCH")
+
+	staleSync := ch.HandleCommand(
+		fmt.Sprintf("SYNC_GROUP topic=resume-topic group=resume-group member=%s generation=%d", member, generation),
+		ctx,
+	)
+	assert.Contains(t, staleSync, "ERROR: GEN_MISMATCH")
+
+	staleCommit := ch.HandleCommand(
+		fmt.Sprintf("COMMIT_OFFSET topic=resume-topic partition=0 group=resume-group offset=7 member=%s generation=%d", member, generation),
+		ctx,
+	)
+	assert.Contains(t, staleCommit, "ERROR: GEN_MISMATCH")
+	_, committed := coord.GetOffset("resume-group", "resume-topic", 0)
+	assert.False(t, committed)
+
+	staleLeave := ch.HandleCommand(
+		fmt.Sprintf("LEAVE_GROUP topic=resume-topic group=resume-group member=%s generation=%d", member, generation),
+		ctx,
+	)
+	assert.Contains(t, staleLeave, "ERROR: GEN_MISMATCH")
+	status, err = coord.GetGroupStatus("resume-group")
+	require.NoError(t, err)
+	assert.Equal(t, 2, status.MemberCount)
 }

--- a/pkg/controller/handler_real_test.go
+++ b/pkg/controller/handler_real_test.go
@@ -134,7 +134,7 @@ func TestCommandHandler_GroupCommands(t *testing.T) {
 		{"REGISTER_GROUP topic=topic1 group=g1", "coordinator_not_available"},
 		{"JOIN_GROUP topic=topic1 group=g1 member=m1", "coordinator_not_available"},
 		{"HEARTBEAT topic=topic1 group=g1 member=m1", "coordinator_not_available"},
-		{"LEAVE_GROUP topic=topic1 group=g1 member=m1", "left=true"},
+		{"LEAVE_GROUP topic=topic1 group=g1 member=m1 generation=1", "coordinator_not_available"},
 		{"COMMIT_OFFSET topic=topic1 partition=0 group=g1 offset=10", "offset_manager_not_available"},
 		{"FETCH_OFFSET topic=topic1 partition=0 group=g1", "offset_manager_not_available"},
 	}

--- a/pkg/controller/response_contract_test.go
+++ b/pkg/controller/response_contract_test.go
@@ -19,9 +19,11 @@ func TestTextCommandResponseContract(t *testing.T) {
 		t.Fatalf("REGISTER_GROUP response missing registered=true: %s", registerResp)
 	}
 	assertContractSuccess(t, ch.HandleCommand("JOIN_GROUP topic=contract-topic group=contract-group member=contract-member", ctx), "JOIN_GROUP")
-	assertContractSuccess(t, ch.HandleCommand("SYNC_GROUP topic=contract-topic group=contract-group member="+ctx.MemberID, ctx), "SYNC_GROUP")
-	assertContractSuccess(t, ch.HandleCommand("HEARTBEAT topic=contract-topic group=contract-group member="+ctx.MemberID, ctx), "HEARTBEAT")
-	assertContractSuccess(t, ch.HandleCommand("COMMIT_OFFSET topic=contract-topic partition=0 group=contract-group offset=2", ctx), "COMMIT_OFFSET")
+	member := ctx.MemberID
+	generation := strconv.Itoa(ctx.Generation)
+	assertContractSuccess(t, ch.HandleCommand("SYNC_GROUP topic=contract-topic group=contract-group member="+member+" generation="+generation, ctx), "SYNC_GROUP")
+	assertContractSuccess(t, ch.HandleCommand("HEARTBEAT topic=contract-topic group=contract-group member="+member+" generation="+generation, ctx), "HEARTBEAT")
+	assertContractSuccess(t, ch.HandleCommand("COMMIT_OFFSET topic=contract-topic partition=0 group=contract-group offset=2 member="+member+" generation="+generation, ctx), "COMMIT_OFFSET")
 	assertContractSuccess(t, ch.HandleCommand("FETCH_OFFSET topic=contract-topic partition=0 group=contract-group", ctx), "FETCH_OFFSET")
 	initResp := ch.HandleCommand("INIT_PRODUCER_ID transactional_id=contract-tx", ctx)
 	assertContractSuccess(t, initResp, "INIT_PRODUCER_ID")

--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -23,8 +24,12 @@ type Coordinator struct {
 	offsetTopic               string
 	offsetTopicPartitionCount int
 
-	// ensure only the active GroupCoordinator handles session expiration.
-	leaderChecker func() bool
+	// Session expiration is decided by the broker that owns each group. In a
+	// cluster, the expiration callback serializes removals through the metadata
+	// log so every broker observes the same generation and assignments.
+	groupOwnerChecker func(groupName string) bool
+	expirationHandler func(groupName string, generation int, memberIDs []string) error
+	ownershipSince    map[string]time.Time
 }
 
 type TopicHandler interface {
@@ -36,6 +41,10 @@ type OffsetLogReader interface {
 	ReadTopicPartition(topic string, partitionID int, offset uint64, max int) ([]types.Message, error)
 }
 
+type offsetTopicPartitionProvider interface {
+	ExistingPartitionCount(topic string) (int, error)
+}
+
 type syncPublisher interface {
 	PublishWithAck(topic string, msg *types.Message) error
 }
@@ -45,7 +54,7 @@ type GroupMetadata struct {
 	mu            sync.RWMutex               // Per-group lock for offset operations
 	TopicName     string                     // Topic this group consumes
 	Members       map[string]*MemberMetadata // Active members
-	Generation    int                        // Current generation (unused but reserved)
+	Generation    int                        // Current membership generation
 	Partitions    []int                      // All partitions of the topic
 	LastRebalance time.Time                  // Timestamp of last rebalance
 	Offsets       map[string]map[int]uint64  // topic -> partition -> offset
@@ -60,10 +69,12 @@ type MemberMetadata struct {
 
 // GroupStateSnapshot is a serializable snapshot of a consumer group's state.
 type GroupStateSnapshot struct {
-	TopicName  string                    `json:"topic"`
-	Generation int                       `json:"generation"`
-	Members    map[string][]int          `json:"members"`
-	Offsets    map[string]map[int]uint64 `json:"offsets"`
+	TopicName     string                    `json:"topic"`
+	Generation    int                       `json:"generation"`
+	Members       map[string][]int          `json:"members"`
+	Partitions    []int                     `json:"partitions,omitempty"`
+	LastRebalance time.Time                 `json:"last_rebalance,omitempty"`
+	Offsets       map[string]map[int]uint64 `json:"offsets"`
 }
 
 // GroupStatus represents the status of a consumer group
@@ -122,6 +133,16 @@ func NewCoordinator(ctx context.Context, cfg *config.Config, handler TopicHandle
 		topicHandler:              handler,
 		offsetTopic:               "__consumer_offsets",
 		offsetTopicPartitionCount: 4, // init. dynamic
+		ownershipSince:            make(map[string]time.Time),
+	}
+
+	if provider, ok := handler.(offsetTopicPartitionProvider); ok {
+		partitionCount, err := provider.ExistingPartitionCount(c.offsetTopic)
+		if err != nil {
+			util.Warn("Coordinator: failed to discover offset topic partitions: %v", err)
+		} else if partitionCount > c.offsetTopicPartitionCount {
+			c.offsetTopicPartitionCount = partitionCount
+		}
 	}
 
 	if err := handler.CreateTopic(c.offsetTopic, c.offsetTopicPartitionCount, false, false); err != nil {
@@ -135,10 +156,15 @@ func NewCoordinator(ctx context.Context, cfg *config.Config, handler TopicHandle
 	return c
 }
 
-func (c *Coordinator) SetLeaderChecker(f func() bool) {
+func (c *Coordinator) SetGroupSessionCallbacks(
+	ownerChecker func(groupName string) bool,
+	expirationHandler func(groupName string, generation int, memberIDs []string) error,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.leaderChecker = f
+	c.groupOwnerChecker = ownerChecker
+	c.expirationHandler = expirationHandler
+	c.ownershipSince = make(map[string]time.Time)
 }
 
 // Start launches background monitoring processes (e.g., heartbeat monitor).
@@ -294,6 +320,20 @@ func (c *Coordinator) validateMemberGenerationLocked(groupName, memberID string,
 	return ""
 }
 
+// ResumeConsumer refreshes a known member session without changing membership,
+// generation, or assignments. It is used after a transient reconnect.
+func (c *Coordinator) ResumeConsumer(groupName, memberID string, generation int) ([]int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
+		return nil, fmt.Errorf("%s", errResp)
+	}
+	member := c.groups[groupName].Members[memberID]
+	member.LastHeartbeat = time.Now()
+	return append([]int(nil), member.Assignments...), nil
+}
+
 // ValidateOwnershipFailure returns a wire-ready error code when a member does
 // not own a partition in the supplied generation. Empty string means valid.
 func (c *Coordinator) ValidateOwnershipFailure(groupName, memberID string, generation int, partition int) string {
@@ -390,10 +430,12 @@ func (c *Coordinator) ExportState() map[string]*GroupStateSnapshot {
 	for name, group := range c.groups {
 		group.mu.RLock()
 		snap := &GroupStateSnapshot{
-			TopicName:  group.TopicName,
-			Generation: group.Generation,
-			Members:    make(map[string][]int, len(group.Members)),
-			Offsets:    make(map[string]map[int]uint64),
+			TopicName:     group.TopicName,
+			Generation:    group.Generation,
+			Members:       make(map[string][]int, len(group.Members)),
+			Partitions:    append([]int(nil), group.Partitions...),
+			LastRebalance: group.LastRebalance,
+			Offsets:       make(map[string]map[int]uint64),
 		}
 		for mid, member := range group.Members {
 			assignments := make([]int, len(member.Assignments))
@@ -417,20 +459,23 @@ func (c *Coordinator) ImportState(state map[string]*GroupStateSnapshot) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.groups = make(map[string]*GroupMetadata, len(state))
+	c.ownershipSince = make(map[string]time.Time)
 	for name, snap := range state {
 		group := &GroupMetadata{
-			TopicName:  snap.TopicName,
-			Generation: snap.Generation,
-			Members:    make(map[string]*MemberMetadata, len(snap.Members)),
-			Partitions: make([]int, 0),
-			Offsets:    make(map[string]map[int]uint64),
+			TopicName:     snap.TopicName,
+			Generation:    snap.Generation,
+			Members:       make(map[string]*MemberMetadata, len(snap.Members)),
+			Partitions:    append([]int(nil), snap.Partitions...),
+			LastRebalance: snap.LastRebalance,
+			Offsets:       make(map[string]map[int]uint64),
 		}
 
 		for mid, assignments := range snap.Members {
 			group.Members[mid] = &MemberMetadata{
 				ID:            mid,
 				LastHeartbeat: time.Now(),
-				Assignments:   assignments,
+				Assignments:   append([]int(nil), assignments...),
 			}
 		}
 
@@ -441,12 +486,30 @@ func (c *Coordinator) ImportState(state map[string]*GroupStateSnapshot) {
 			}
 		}
 
-		if topicOffsets, ok := snap.Offsets[snap.TopicName]; ok {
-			for pid := range topicOffsets {
-				group.Partitions = append(group.Partitions, pid)
-			}
+		if len(group.Partitions) == 0 {
+			group.Partitions = inferSnapshotPartitions(snap)
 		}
 
 		c.groups[name] = group
 	}
+}
+
+func inferSnapshotPartitions(snap *GroupStateSnapshot) []int {
+	seen := make(map[int]struct{})
+	for _, assignments := range snap.Members {
+		for _, partition := range assignments {
+			seen[partition] = struct{}{}
+		}
+	}
+	if topicOffsets := snap.Offsets[snap.TopicName]; topicOffsets != nil {
+		for partition := range topicOffsets {
+			seen[partition] = struct{}{}
+		}
+	}
+	partitions := make([]int, 0, len(seen))
+	for partition := range seen {
+		partitions = append(partitions, partition)
+	}
+	sort.Ints(partitions)
+	return partitions
 }

--- a/pkg/coordinator/coordinator_offset.go
+++ b/pkg/coordinator/coordinator_offset.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -22,12 +23,16 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 		return fmt.Errorf("group '%s' not found", groupName)
 	}
 
-	gm.mu.RLock()
+	return c.commitOffsetForGroup(gm, groupName, topic, partition, offset)
+}
+
+func (c *Coordinator) commitOffsetForGroup(gm *GroupMetadata, groupName, topic string, partition int, offset uint64) error {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
 	if current, ok := gm.getOffsetSafe(topic, partition); ok && offset < current {
-		gm.mu.RUnlock()
 		return fmt.Errorf("offset regression for group=%s topic=%s partition=%d: current=%d attempted=%d", groupName, topic, partition, current, offset)
 	}
-	gm.mu.RUnlock()
 
 	offsetMsg := OffsetCommitMessage{
 		Group:     groupName,
@@ -50,11 +55,7 @@ func (c *Coordinator) CommitOffset(groupName, topic string, partition int, offse
 		return err
 	}
 
-	gm.mu.Lock()
-	err = gm.storeOffsetMonotonic(groupName, topic, partition, offset)
-	gm.mu.Unlock()
-
-	return err
+	return gm.storeOffsetMonotonic(groupName, topic, partition, offset)
 }
 
 func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []OffsetItem) error {
@@ -67,14 +68,34 @@ func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []Offse
 		return fmt.Errorf("group '%s' not found", groupName)
 	}
 
-	gm.mu.RLock()
+	return c.commitOffsetsBulkForGroup(gm, groupName, topic, offsets)
+}
+
+// ValidateAndCommitOffsetsBulk keeps the membership generation stable until the
+// durable offset record and all in-memory offsets have been applied.
+func (c *Coordinator) ValidateAndCommitOffsetsBulk(groupName, topic, memberID string, generation int, offsets []OffsetItem) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
+		return fmt.Errorf("%s", errResp)
+	}
+	group := c.groups[groupName]
 	for _, item := range offsets {
-		if current, ok := gm.getOffsetSafe(topic, item.Partition); ok && item.Offset < current {
-			gm.mu.RUnlock()
-			return fmt.Errorf("offset regression for group=%s topic=%s partition=%d: current=%d attempted=%d", groupName, topic, item.Partition, current, item.Offset)
+		if !contains(group.Members[memberID].Assignments, item.Partition) {
+			return fmt.Errorf("ERROR: NOT_OWNER partition=%d member=%s group=%s generation=%d", item.Partition, memberID, groupName, generation)
 		}
 	}
-	gm.mu.RUnlock()
+	return c.commitOffsetsBulkForGroup(group, groupName, topic, offsets)
+}
+
+func (c *Coordinator) commitOffsetsBulkForGroup(gm *GroupMetadata, groupName, topic string, offsets []OffsetItem) error {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	if err := validateOffsetBatchLocked(gm, groupName, topic, offsets); err != nil {
+		return err
+	}
 
 	bulkMsg := BulkOffsetMsg{
 		Group:     groupName,
@@ -96,16 +117,10 @@ func (c *Coordinator) CommitOffsetsBulk(groupName, topic string, offsets []Offse
 		return err
 	}
 
-	gm.mu.Lock()
-	var firstErr error
 	for _, item := range offsets {
-		if err := gm.storeOffsetMonotonic(groupName, topic, item.Partition, item.Offset); err != nil && firstErr == nil {
-			firstErr = err
-		}
+		gm.storeOffset(topic, item.Partition, item.Offset)
 	}
-	gm.mu.Unlock()
-
-	return firstErr
+	return nil
 }
 
 func (c *Coordinator) ApplyOffsetUpdateFromFSM(groupName, topic string, offsets []OffsetItem) error {
@@ -132,18 +147,65 @@ func (c *Coordinator) ApplyOffsetUpdateFromFSM(groupName, topic string, offsets 
 	c.mu.Unlock()
 
 	gm.mu.Lock()
+	defer gm.mu.Unlock()
 	if gm.Offsets == nil {
 		gm.Offsets = make(map[string]map[int]uint64)
 	}
-	var firstErr error
+	if err := validateOffsetBatchLocked(gm, groupName, topic, offsets); err != nil {
+		return err
+	}
 	for _, item := range offsets {
-		if err := gm.storeOffsetMonotonic(groupName, topic, item.Partition, item.Offset); err != nil && firstErr == nil {
-			firstErr = err
+		gm.storeOffset(topic, item.Partition, item.Offset)
+	}
+	return nil
+}
+
+// ApplyFencedOffsetUpdateFromFSM validates ownership at metadata-log apply time,
+// closing the gap between command handling and the replicated state transition.
+func (c *Coordinator) ApplyFencedOffsetUpdateFromFSM(
+	groupName, topic, memberID string,
+	generation int,
+	offsets []OffsetItem,
+) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
+		return fmt.Errorf("%s", errResp)
+	}
+	group := c.groups[groupName]
+	for _, item := range offsets {
+		if !contains(group.Members[memberID].Assignments, item.Partition) {
+			return fmt.Errorf("ERROR: NOT_OWNER partition=%d member=%s group=%s generation=%d", item.Partition, memberID, groupName, generation)
 		}
 	}
-	gm.mu.Unlock()
 
-	return firstErr
+	group.mu.Lock()
+	defer group.mu.Unlock()
+	if err := validateOffsetBatchLocked(group, groupName, topic, offsets); err != nil {
+		return err
+	}
+	for _, item := range offsets {
+		group.storeOffset(topic, item.Partition, item.Offset)
+	}
+	return nil
+}
+
+func validateOffsetBatchLocked(group *GroupMetadata, groupName, topic string, offsets []OffsetItem) error {
+	seen := make(map[int]struct{}, len(offsets))
+	for _, item := range offsets {
+		if _, exists := seen[item.Partition]; exists {
+			return fmt.Errorf("ERROR: duplicate_partition partition=%d group=%s topic=%s", item.Partition, groupName, topic)
+		}
+		seen[item.Partition] = struct{}{}
+		if current, exists := group.getOffsetSafe(topic, item.Partition); exists && item.Offset < current {
+			return fmt.Errorf(
+				"offset regression for group=%s topic=%s partition=%d: current=%d attempted=%d",
+				groupName, topic, item.Partition, current, item.Offset,
+			)
+		}
+	}
+	return nil
 }
 
 func (c *Coordinator) publishOffsetMessage(msg *types.Message) error {
@@ -161,12 +223,16 @@ func (c *Coordinator) publishOffsetMessage(msg *types.Message) error {
 
 func (c *Coordinator) LoadOffsetsFromLog(reader OffsetLogReader) error {
 	const batchSize = 1024
+	skipped := 0
+	var firstParseErr error
 
 	applied := 0
+	recovered := make(map[string]map[string]map[int]uint64)
 	for partition := 0; partition < c.offsetTopicPartitionCount; partition++ {
 		next := uint64(0)
 		for {
 			messages, err := reader.ReadTopicPartition(c.offsetTopic, partition, next, batchSize)
+			readOffset := next
 			if err != nil {
 				util.Warn("Coordinator: error reading offset log partition=%d offset=%d: %v", partition, next, err)
 				break
@@ -176,15 +242,58 @@ func (c *Coordinator) LoadOffsetsFromLog(reader OffsetLogReader) error {
 			}
 
 			for _, msg := range messages {
-				if err := c.applyOffsetLogPayload(msg.Payload); err != nil {
-					util.Warn("Coordinator: skipping invalid offset log record at partition=%d offset=%d: %v", partition, msg.Offset, err)
+				candidate := msg.Offset + 1
+				if candidate > next {
+					next = candidate
+				}
+				group, topic, offsets, parseErr := parseOffsetLogPayload(msg.Payload)
+				if parseErr != nil {
+					skipped++
+					if firstParseErr == nil {
+						firstParseErr = parseErr
+					}
 					continue
 				}
+				if recovered[group] == nil {
+					recovered[group] = make(map[string]map[int]uint64)
+				}
+				if recovered[group][topic] == nil {
+					recovered[group][topic] = make(map[int]uint64)
+				}
+				for _, item := range offsets {
+					current, exists := recovered[group][topic][item.Partition]
+					if !exists || item.Offset > current {
+						recovered[group][topic][item.Partition] = item.Offset
+					}
+				}
 				applied++
-				next = msg.Offset + 1
 			}
 			if len(messages) < batchSize {
 				break
+			}
+			if next <= readOffset {
+				util.Warn("Coordinator: offset log reader made no progress at partition=%d offset=%d", partition, readOffset)
+				break
+			}
+		}
+	}
+
+	if skipped > 0 {
+		util.Warn("Coordinator: skipped %d invalid offset log records; first error: %v", skipped, firstParseErr)
+	}
+	for group, topics := range recovered {
+		for topic, partitionOffsets := range topics {
+			partitions := make([]int, 0, len(partitionOffsets))
+			for partition := range partitionOffsets {
+				partitions = append(partitions, partition)
+			}
+			sort.Ints(partitions)
+			offsets := make([]OffsetItem, 0, len(partitions))
+			for _, partition := range partitions {
+				offsets = append(offsets, OffsetItem{Partition: partition, Offset: partitionOffsets[partition]})
+			}
+			if err := c.ApplyOffsetUpdateFromFSM(group, topic, offsets); err != nil {
+				return fmt.Errorf("restore group=%s topic=%s offsets: %w", group, topic, err)
 			}
 		}
 	}
@@ -195,23 +304,23 @@ func (c *Coordinator) LoadOffsetsFromLog(reader OffsetLogReader) error {
 	return nil
 }
 
-func (c *Coordinator) applyOffsetLogPayload(payload string) error {
+func parseOffsetLogPayload(payload string) (string, string, []OffsetItem, error) {
 	var bulk BulkOffsetMsg
 	if err := json.Unmarshal([]byte(payload), &bulk); err == nil && bulk.Group != "" && bulk.Topic != "" && len(bulk.Offsets) > 0 {
-		return c.ApplyOffsetUpdateFromFSM(bulk.Group, bulk.Topic, bulk.Offsets)
+		return bulk.Group, bulk.Topic, bulk.Offsets, nil
 	}
 
 	var single OffsetCommitMessage
 	if err := json.Unmarshal([]byte(payload), &single); err != nil {
-		return err
+		return "", "", nil, err
 	}
 	if single.Group == "" || single.Topic == "" {
-		return fmt.Errorf("missing group or topic")
+		return "", "", nil, fmt.Errorf("missing group or topic")
 	}
-	return c.ApplyOffsetUpdateFromFSM(single.Group, single.Topic, []OffsetItem{{
+	return single.Group, single.Topic, []OffsetItem{{
 		Partition: single.Partition,
 		Offset:    single.Offset,
-	}})
+	}}, nil
 }
 
 func (c *Coordinator) GetOffset(groupName, topic string, partition int) (uint64, bool) {
@@ -253,62 +362,15 @@ func (c *Coordinator) updateOffsetPartitionCount() {
 
 func (c *Coordinator) ValidateAndCommit(groupName, topic string, partition int, offset uint64, generation int, memberID string) error {
 	c.mu.RLock()
+	defer c.mu.RUnlock()
 	group := c.groups[groupName]
 	if errResp := c.validateMemberGenerationLocked(groupName, memberID, generation); errResp != "" {
-		c.mu.RUnlock()
 		return fmt.Errorf("%s", errResp)
 	}
 	if !contains(group.Members[memberID].Assignments, partition) {
-		c.mu.RUnlock()
 		return fmt.Errorf("ERROR: NOT_OWNER partition=%d member=%s group=%s generation=%d", partition, memberID, groupName, generation)
 	}
-	c.mu.RUnlock()
-
-	// Store offset under per-group lock
-	group.mu.Lock()
-	prevOffset, hadPrev := group.getOffsetSafe(topic, partition)
-	if err := group.storeOffsetMonotonic(groupName, topic, partition, offset); err != nil {
-		group.mu.Unlock()
-		return err
-	}
-	group.mu.Unlock()
-
-	offsetMsg := OffsetCommitMessage{
-		Group:     groupName,
-		Topic:     topic,
-		Partition: partition,
-		Offset:    offset,
-		Timestamp: time.Now(),
-	}
-
-	payload, err := json.Marshal(offsetMsg)
-	if err != nil {
-		c.rollbackOffset(group, topic, partition, prevOffset, hadPrev)
-		return fmt.Errorf("failed to marshal offset: %w", err)
-	}
-
-	err = c.publishOffsetMessage(&types.Message{
-		ProducerID: "broker",
-		Payload:    string(payload),
-		Key:        groupName + "-" + topic + "-" + strconv.Itoa(partition),
-	})
-
-	if err != nil {
-		c.rollbackOffset(group, topic, partition, prevOffset, hadPrev)
-		return fmt.Errorf("failed to publish offset: %w", err)
-	}
-
-	return nil
-}
-
-func (c *Coordinator) rollbackOffset(gm *GroupMetadata, topic string, partition int, prevOffset uint64, hadPrev bool) {
-	gm.mu.Lock()
-	defer gm.mu.Unlock()
-	if hadPrev {
-		gm.storeOffset(topic, partition, prevOffset)
-	} else if partitions, ok := gm.Offsets[topic]; ok {
-		delete(partitions, partition)
-	}
+	return c.commitOffsetForGroup(group, groupName, topic, partition, offset)
 }
 
 func (c *Coordinator) getGroupUnsafe(name string) *GroupMetadata {

--- a/pkg/coordinator/group_contract_test.go
+++ b/pkg/coordinator/group_contract_test.go
@@ -1,0 +1,314 @@
+package coordinator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResumeConsumerPreservesGenerationAndAssignments(t *testing.T) {
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("events", "workers", 4))
+
+	assignments, err := c.AddConsumer("workers", "member-1")
+	require.NoError(t, err)
+	generation := c.GetGeneration("workers")
+	require.Positive(t, generation)
+
+	resumed, err := c.ResumeConsumer("workers", "member-1", generation)
+	require.NoError(t, err)
+	assert.Equal(t, assignments, resumed)
+	assert.Equal(t, generation, c.GetGeneration("workers"))
+
+	_, err = c.ResumeConsumer("workers", "member-1", generation+1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: GEN_MISMATCH")
+	assert.Equal(t, generation, c.GetGeneration("workers"))
+}
+
+func TestExpireConsumersAdvancesGenerationOnceAndTransfersOwnership(t *testing.T) {
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("events", "workers", 4))
+	_, err := c.AddConsumer("workers", "member-1")
+	require.NoError(t, err)
+	_, err = c.AddConsumer("workers", "member-2")
+	require.NoError(t, err)
+	generation := c.GetGeneration("workers")
+
+	require.NoError(t, c.ExpireConsumers("workers", generation, []string{"member-1"}))
+	assert.Equal(t, generation+1, c.GetGeneration("workers"))
+
+	status, err := c.GetGroupStatus("workers")
+	require.NoError(t, err)
+	require.Len(t, status.Members, 1)
+	assert.Equal(t, "member-2", status.Members[0].MemberID)
+	assert.ElementsMatch(t, []int{0, 1, 2, 3}, status.Members[0].Assignments)
+
+	err = c.ExpireConsumers("workers", generation, []string{"member-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: GEN_MISMATCH")
+	assert.Equal(t, generation+1, c.GetGeneration("workers"))
+}
+
+func TestGroupSnapshotRestoresPartitionsBeforeFirstOffsetCommit(t *testing.T) {
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("events", "workers", 4))
+	assignments, err := c.AddConsumer("workers", "member-1")
+	require.NoError(t, err)
+	require.Len(t, assignments, 4)
+
+	restored := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	restored.ImportState(c.ExportState())
+
+	status, err := restored.GetGroupStatus("workers")
+	require.NoError(t, err)
+	assert.Equal(t, 4, status.PartitionCount)
+	require.Len(t, status.Members, 1)
+	assert.ElementsMatch(t, []int{0, 1, 2, 3}, status.Members[0].Assignments)
+
+	_, err = restored.AddConsumer("workers", "member-2")
+	require.NoError(t, err)
+	status, err = restored.GetGroupStatus("workers")
+	require.NoError(t, err)
+	for _, member := range status.Members {
+		assert.Len(t, member.Assignments, 2)
+	}
+}
+
+func TestApplyFencedOffsetUpdateRejectsStaleAndPartialMutation(t *testing.T) {
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("events", "workers", 2))
+	_, err := c.AddConsumer("workers", "member-1")
+	require.NoError(t, err)
+	generation := c.GetGeneration("workers")
+
+	err = c.ApplyFencedOffsetUpdateFromFSM(
+		"workers",
+		"events",
+		"member-1",
+		generation+1,
+		[]OffsetItem{{Partition: 0, Offset: 5}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: GEN_MISMATCH")
+	_, ok := c.GetOffset("workers", "events", 0)
+	assert.False(t, ok)
+
+	require.NoError(t, c.ApplyFencedOffsetUpdateFromFSM(
+		"workers",
+		"events",
+		"member-1",
+		generation,
+		[]OffsetItem{{Partition: 0, Offset: 5}, {Partition: 1, Offset: 10}},
+	))
+
+	err = c.ApplyFencedOffsetUpdateFromFSM(
+		"workers",
+		"events",
+		"member-1",
+		generation,
+		[]OffsetItem{{Partition: 0, Offset: 6}, {Partition: 1, Offset: 9}},
+	)
+	require.ErrorContains(t, err, "offset regression")
+	offset, ok := c.GetOffset("workers", "events", 0)
+	require.True(t, ok)
+	assert.Equal(t, uint64(5), offset)
+	offset, ok = c.GetOffset("workers", "events", 1)
+	require.True(t, ok)
+	assert.Equal(t, uint64(10), offset)
+}
+
+func TestDistributedTimeoutRequiresOwnershipGraceAndReplicatedMutation(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnabledDistribution = true
+	c := NewCoordinator(context.Background(), cfg, &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("events", "workers", 2))
+	_, err := c.AddConsumer("workers", "member-1")
+	require.NoError(t, err)
+
+	timeout := time.Second
+	c.mu.Lock()
+	c.groups["workers"].Members["member-1"].LastHeartbeat = time.Now().Add(-2 * timeout)
+	c.mu.Unlock()
+
+	owner := false
+	var (
+		calls      int
+		generation int
+		members    []string
+	)
+	c.SetGroupSessionCallbacks(
+		func(string) bool { return owner },
+		func(_ string, gotGeneration int, gotMembers []string) error {
+			calls++
+			generation = gotGeneration
+			members = append([]string(nil), gotMembers...)
+			return nil
+		},
+	)
+
+	c.checkSingleGroupTimeout("workers", timeout)
+	assert.Zero(t, calls)
+
+	owner = true
+	c.checkSingleGroupTimeout("workers", timeout)
+	assert.Zero(t, calls, "new coordinator ownership must wait one full session timeout")
+
+	c.mu.Lock()
+	c.ownershipSince["workers"] = time.Now().Add(-2 * timeout)
+	wantGeneration := c.groups["workers"].Generation
+	c.mu.Unlock()
+
+	c.checkSingleGroupTimeout("workers", timeout)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, wantGeneration, generation)
+	assert.Equal(t, []string{"member-1"}, members)
+
+	status, err := c.GetGroupStatus("workers")
+	require.NoError(t, err)
+	assert.Equal(t, 1, status.MemberCount, "distributed timeout mutation must be applied through the replicated callback")
+}
+
+type partitionedOffsetReader struct {
+	records      map[int][]types.Message
+	lastOffset   map[int]uint64
+	offsetWasSet map[int]bool
+}
+
+func (r *partitionedOffsetReader) ReadTopicPartition(_ string, partitionID int, offset uint64, max int) ([]types.Message, error) {
+	if r.lastOffset == nil {
+		r.lastOffset = make(map[int]uint64)
+		r.offsetWasSet = make(map[int]bool)
+	}
+	if r.offsetWasSet[partitionID] && r.lastOffset[partitionID] == offset {
+		return nil, fmt.Errorf("repeated offset request: partition=%d offset=%d", partitionID, offset)
+	}
+	r.lastOffset[partitionID] = offset
+	r.offsetWasSet[partitionID] = true
+	records := r.records[partitionID]
+	if offset >= uint64(len(records)) {
+		return nil, nil
+	}
+	end := int(offset) + max
+	if end > len(records) {
+		end = len(records)
+	}
+	result := make([]types.Message, end-int(offset))
+	copy(result, records[int(offset):end])
+	return result, nil
+}
+
+func TestLoadOffsetsFromLogIsIndependentOfInternalPartitionOrder(t *testing.T) {
+	oldBulk, err := json.Marshal(BulkOffsetMsg{
+		Group: "workers",
+		Topic: "events",
+		Offsets: []OffsetItem{
+			{Partition: 0, Offset: 10},
+			{Partition: 1, Offset: 7},
+		},
+		Timestamp: time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	newSingle, err := json.Marshal(OffsetCommitMessage{
+		Group:     "workers",
+		Topic:     "events",
+		Partition: 0,
+		Offset:    12,
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, err)
+
+	reader := &partitionedOffsetReader{records: map[int][]types.Message{
+		0: {{Offset: 0, Payload: string(newSingle)}},
+		1: {{Offset: 0, Payload: string(oldBulk)}},
+	}}
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.LoadOffsetsFromLog(reader))
+
+	offset, ok := c.GetOffset("workers", "events", 0)
+	require.True(t, ok)
+	assert.Equal(t, uint64(12), offset)
+	offset, ok = c.GetOffset("workers", "events", 1)
+	require.True(t, ok)
+	assert.Equal(t, uint64(7), offset)
+}
+
+func TestLoadOffsetsFromLogAdvancesPastInvalidFullBatch(t *testing.T) {
+	records := make([]types.Message, 1025)
+	for i := 0; i < 1024; i++ {
+		records[i] = types.Message{Offset: uint64(i), Payload: "invalid"}
+	}
+	valid, err := json.Marshal(OffsetCommitMessage{
+		Group:     "workers",
+		Topic:     "events",
+		Partition: 2,
+		Offset:    19,
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, err)
+	records[1024] = types.Message{Offset: 1024, Payload: string(valid)}
+
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.LoadOffsetsFromLog(&partitionedOffsetReader{
+		records: map[int][]types.Message{0: records},
+	}))
+	offset, ok := c.GetOffset("workers", "events", 2)
+	require.True(t, ok)
+	assert.Equal(t, uint64(19), offset)
+}
+
+func TestCommitOffsetsBulkRejectsDuplicatePartitionAtomically(t *testing.T) {
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), &DummyPublisher{})
+	require.NoError(t, c.RegisterGroup("events", "workers", 1))
+	require.NoError(t, c.CommitOffset("workers", "events", 0, 5))
+
+	err := c.CommitOffsetsBulk("workers", "events", []OffsetItem{
+		{Partition: 0, Offset: 6},
+		{Partition: 0, Offset: 4},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR: duplicate_partition")
+	offset, ok := c.GetOffset("workers", "events", 0)
+	require.True(t, ok)
+	assert.Equal(t, uint64(5), offset)
+}
+
+type discoveringOffsetLog struct {
+	*partitionedOffsetReader
+	DummyPublisher
+	partitionCount int
+}
+
+func (l *discoveringOffsetLog) ExistingPartitionCount(string) (int, error) {
+	return l.partitionCount, nil
+}
+
+func TestCoordinatorDiscoversExpandedOffsetTopicBeforeReplay(t *testing.T) {
+	payload, err := json.Marshal(OffsetCommitMessage{
+		Group:     "workers",
+		Topic:     "events",
+		Partition: 3,
+		Offset:    27,
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, err)
+	log := &discoveringOffsetLog{
+		partitionedOffsetReader: &partitionedOffsetReader{records: map[int][]types.Message{
+			5: {{Offset: 0, Payload: string(payload)}},
+		}},
+		partitionCount: 6,
+	}
+
+	c := NewCoordinator(context.Background(), config.DefaultConfig(), log)
+	assert.Equal(t, 6, c.offsetTopicPartitionCount)
+	offset, ok := c.GetOffset("workers", "events", 3)
+	require.True(t, ok)
+	assert.Equal(t, uint64(27), offset)
+}

--- a/pkg/coordinator/heartbeat.go
+++ b/pkg/coordinator/heartbeat.go
@@ -16,11 +16,6 @@ func (c *Coordinator) monitorHeartbeats() {
 	for {
 		select {
 		case <-ticker.C:
-			if c.cfg.EnabledDistribution && c.leaderChecker != nil {
-				if !c.leaderChecker() {
-					continue
-				}
-			}
 			c.checkAllGroupsTimeout()
 		case <-c.ctx.Done():
 			return
@@ -43,6 +38,11 @@ func (c *Coordinator) checkAllGroupsTimeout() {
 }
 
 func (c *Coordinator) checkSingleGroupTimeout(groupName string, timeout time.Duration) {
+	now := time.Now()
+	if !c.ownsGroupSession(groupName, now, timeout) {
+		return
+	}
+
 	c.mu.Lock()
 	group, exists := c.groups[groupName]
 	if !exists || len(group.Members) == 0 {
@@ -51,44 +51,81 @@ func (c *Coordinator) checkSingleGroupTimeout(groupName string, timeout time.Dur
 	}
 
 	var timedOutMembers []string
-	now := time.Now()
-
 	for id, member := range group.Members {
 		if now.Sub(member.LastHeartbeat) > timeout {
 			timedOutMembers = append(timedOutMembers, id)
-			delete(group.Members, id)
 		}
 	}
+	generation := group.Generation
+	handler := c.expirationHandler
+	distributed := c.cfg.EnabledDistribution
+	c.mu.Unlock()
 
-	if len(timedOutMembers) > 0 {
-		group.Generation++
-		c.rebalanceRange(groupName)
+	if len(timedOutMembers) == 0 {
+		return
+	}
+
+	if distributed {
+		if handler == nil {
+			util.Warn("Group '%s': session expiration deferred because no cluster handler is configured", groupName)
+			return
+		}
+		if err := handler(groupName, generation, timedOutMembers); err != nil {
+			util.Warn("Group '%s': failed to replicate session expiration: %v", groupName, err)
+			return
+		}
+	} else if err := c.ExpireConsumers(groupName, generation, timedOutMembers); err != nil {
+		util.Warn("Group '%s': failed to expire members: %v", groupName, err)
+		return
+	}
+
+	util.Warn("Group '%s': %d members timed out; generation advanced", groupName, len(timedOutMembers))
+}
+
+func (c *Coordinator) ownsGroupSession(groupName string, now time.Time, timeout time.Duration) bool {
+	if !c.cfg.EnabledDistribution {
+		return true
+	}
+
+	c.mu.RLock()
+	checker := c.groupOwnerChecker
+	c.mu.RUnlock()
+	if checker == nil || !checker(groupName) {
+		c.mu.Lock()
+		delete(c.ownershipSince, groupName)
+		c.mu.Unlock()
+		return false
+	}
+
+	c.mu.Lock()
+	since, observed := c.ownershipSince[groupName]
+	if !observed {
+		c.ownershipSince[groupName] = now
+		c.mu.Unlock()
+		return false
 	}
 	c.mu.Unlock()
 
-	if len(timedOutMembers) > 0 {
-		util.Warn("⚠️ Group '%s': %d members timed out. Triggered rebalance.", groupName, len(timedOutMembers))
-	}
+	// A new group coordinator waits one full session timeout before expiring
+	// members, giving healthy clients time to redirect and heartbeat.
+	return now.Sub(since) >= timeout
 }
 
 // RecordHeartbeat updates the consumer's last heartbeat timestamp.
 func (c *Coordinator) RecordHeartbeat(groupName, consumerID string) error {
+	return c.RecordHeartbeatForGeneration(groupName, consumerID, -1)
+}
+
+// RecordHeartbeatForGeneration atomically fences and refreshes a member session.
+func (c *Coordinator) RecordHeartbeatForGeneration(groupName, consumerID string, generation int) error {
 	c.mu.Lock()
-	group := c.groups[groupName]
-	if group == nil {
-		c.mu.Unlock()
-		return fmt.Errorf("group '%s' not found", groupName)
+	defer c.mu.Unlock()
+	if errResp := c.validateMemberGenerationLocked(groupName, consumerID, generation); errResp != "" {
+		return fmt.Errorf("%s", errResp)
 	}
 
-	member := group.Members[consumerID]
-	if member == nil {
-		c.mu.Unlock()
-		return fmt.Errorf("consumer '%s' not found", consumerID)
-	}
-
+	member := c.groups[groupName].Members[consumerID]
 	member.LastHeartbeat = time.Now()
-	c.mu.Unlock()
-
-	util.Info("💓 Heartbeat from %s/%s", groupName, consumerID)
+	util.Debug("Heartbeat from %s/%s generation=%d", groupName, consumerID, generation)
 	return nil
 }

--- a/pkg/coordinator/rebalancer.go
+++ b/pkg/coordinator/rebalancer.go
@@ -83,23 +83,78 @@ func (c *Coordinator) AddConsumer(groupName, consumerID string) ([]int, error) {
 // RemoveConsumer unregisters a consumer and triggers a rebalance.
 func (c *Coordinator) RemoveConsumer(groupName, consumerID string) error {
 	c.mu.Lock()
-	group := c.groups[groupName]
-	if group == nil {
-		c.mu.Unlock()
-		return fmt.Errorf("group not found")
+	memberCount, generation, err := c.removeConsumerLocked(groupName, consumerID)
+	c.mu.Unlock()
+	if err != nil {
+		return err
 	}
 
+	c.updateOffsetPartitionCount()
+	util.Info("Consumer '%s' left group '%s' (generation=%d remaining=%d)", consumerID, groupName, generation, memberCount)
+	return nil
+}
+
+// RemoveConsumerForGeneration prevents a stale session from removing a current
+// group member after ownership has moved to a newer generation.
+func (c *Coordinator) RemoveConsumerForGeneration(groupName, consumerID string, generation int) error {
+	c.mu.Lock()
+	if errResp := c.validateMemberGenerationLocked(groupName, consumerID, generation); errResp != "" {
+		c.mu.Unlock()
+		return fmt.Errorf("%s", errResp)
+	}
+	memberCount, newGeneration, err := c.removeConsumerLocked(groupName, consumerID)
+	c.mu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	c.updateOffsetPartitionCount()
+	util.Info("Consumer '%s' left group '%s' (generation=%d remaining=%d)", consumerID, groupName, newGeneration, memberCount)
+	return nil
+}
+
+// ExpireConsumers removes all members that crossed the same timeout boundary in
+// one generation change. expectedGeneration makes metadata-log replay and retries
+// harmless after a concurrent membership change.
+func (c *Coordinator) ExpireConsumers(groupName string, expectedGeneration int, consumerIDs []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	group := c.groups[groupName]
+	if group == nil {
+		return fmt.Errorf("ERROR: group_not_found group=%s", groupName)
+	}
+	if group.Generation != expectedGeneration {
+		return fmt.Errorf("ERROR: GEN_MISMATCH current=%d requested=%d group=%s", group.Generation, expectedGeneration, groupName)
+	}
+
+	removed := 0
+	for _, consumerID := range consumerIDs {
+		if _, exists := group.Members[consumerID]; exists {
+			delete(group.Members, consumerID)
+			removed++
+		}
+	}
+	if removed == 0 {
+		return nil
+	}
+	group.Generation++
+	c.rebalanceRange(groupName)
+	return nil
+}
+
+func (c *Coordinator) removeConsumerLocked(groupName, consumerID string) (int, int, error) {
+	group := c.groups[groupName]
+	if group == nil {
+		return 0, 0, fmt.Errorf("group not found")
+	}
+	if _, exists := group.Members[consumerID]; !exists {
+		return len(group.Members), group.Generation, fmt.Errorf("ERROR: member_not_found member=%s group=%s", consumerID, groupName)
+	}
 	delete(group.Members, consumerID)
 	group.Generation++
 	c.rebalanceRange(groupName)
-
-	memberCount := len(group.Members)
-	gen := group.Generation
-	c.mu.Unlock()
-
-	c.updateOffsetPartitionCount()
-	util.Info("👋 Consumer '%s' left group '%s' (New Gen: %d, Remaining: %d)", consumerID, groupName, gen, memberCount)
-	return nil
+	return len(group.Members), group.Generation, nil
 }
 
 // Rebalance forces a rebalance for a consumer group.

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,6 +47,45 @@ func (dm *DiskManager) GetHandler(topic string, partitionID int) (types.StorageH
 
 	dm.handlers[key] = dh
 	return dh, nil
+}
+
+// ExistingPartitionCount discovers the highest persisted partition for a topic
+// without creating handlers or files.
+func (dm *DiskManager) ExistingPartitionCount(topic string) (int, error) {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	entries, err := os.ReadDir(filepath.Join(dm.cfg.LogDir, topic))
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read topic directory: %w", err)
+	}
+
+	maxPartition := -1
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "partition_") {
+			continue
+		}
+		remainder := strings.TrimPrefix(name, "partition_")
+		separator := strings.Index(remainder, "_segment_")
+		if separator <= 0 || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		partition, parseErr := strconv.Atoi(remainder[:separator])
+		if parseErr != nil || partition < 0 {
+			continue
+		}
+		if partition > maxPartition {
+			maxPartition = partition
+		}
+	}
+	return maxPartition + 1, nil
 }
 
 // CloseAllHandlers should be implemented to ensure all DiskHandlers are closed properly

--- a/pkg/disk/manager_test.go
+++ b/pkg/disk/manager_test.go
@@ -131,3 +131,21 @@ func TestDiskManager_CloseTopicHandlers_DoesNotCloseTopicPrefix(t *testing.T) {
 		t.Fatalf("expected orders_v2 handler to remain open when closing orders")
 	}
 }
+
+func TestDiskManagerExistingPartitionCount(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	dm := disk.NewDiskManager(cfg)
+	defer dm.CloseAllHandlers()
+
+	if _, err := dm.GetHandler("__consumer_offsets", 7); err != nil {
+		t.Fatalf("create persisted partition: %v", err)
+	}
+	count, err := dm.ExistingPartitionCount("__consumer_offsets")
+	if err != nil {
+		t.Fatalf("discover persisted partitions: %v", err)
+	}
+	if count != 8 {
+		t.Fatalf("unexpected partition count: got %d want 8", count)
+	}
+}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -105,10 +105,6 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 
 		cc = clusterController.NewClusterController(ctx, cfg, rm, sd, brokerID, localAddr)
 
-		if cd != nil {
-			cd.SetLeaderChecker(cc.IsLeader)
-		}
-
 		// Start background heartbeats to all cluster members
 		clusterClient.StartHeartbeat(ctx, cfg.StaticClusterMembers, brokerID, localAddr, cfg.DiscoveryPort)
 
@@ -176,6 +172,9 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 	startHealthCheckServer(healthPort, brokerReady)
 
 	globalCH := controller.NewCommandHandler(tm, cfg, cd, sm, cc)
+	if cd != nil {
+		cd.SetGroupSessionCallbacks(globalCH.IsGroupCoordinator, globalCH.ExpireGroupMembers)
+	}
 	if cc != nil {
 		cc.SetLocalProcessor(globalCH)
 	}

--- a/pkg/stream/connection.go
+++ b/pkg/stream/connection.go
@@ -21,8 +21,8 @@ const (
 	StreamControlReasonOffsetOutOfRange = "offset_out_of_range"
 )
 
-// OffsetCommitter abstracts offset commit operations to break the
-// circular dependency between stream and coordinator packages.
+// OffsetCommitter is retained for source compatibility.
+// Deprecated: stream delivery never commits consumer offsets.
 type OffsetCommitter interface {
 	CommitOffset(group, topic string, partition int, offset uint64) error
 }
@@ -50,7 +50,6 @@ type StreamConnection struct {
 	keepaliveInterval time.Duration
 	newMessageCh      <-chan struct{} // signal from partition when new messages arrive
 
-	committer OffsetCommitter
 }
 
 // NewStreamConnection creates a new stream connection
@@ -82,11 +81,9 @@ func (sc *StreamConnection) SetInterval(interval time.Duration) {
 	sc.interval = interval
 }
 
-func (sc *StreamConnection) SetCommitter(c OffsetCommitter) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	sc.committer = c
-}
+// SetCommitter is retained for source compatibility.
+// Deprecated: stream delivery never commits consumer offsets.
+func (sc *StreamConnection) SetCommitter(OffsetCommitter) {}
 
 func (sc *StreamConnection) SetKeepaliveInterval(d time.Duration) {
 	sc.mu.Lock()
@@ -100,23 +97,19 @@ func (sc *StreamConnection) SetNewMessageCh(ch <-chan struct{}) {
 	sc.newMessageCh = ch
 }
 
+// Run accepts the legacy commit interval for source compatibility but ignores
+// it because delivery is not a processing acknowledgement.
 func (sc *StreamConnection) Run(
-	readFn func(offset uint64, max int) ([]types.Message, error),
-	commitInterval time.Duration,
+	readFn func(offset uint64, max int) ([]types.Message, error), _ time.Duration,
 ) {
 	defer func() {
-		if sc.committer != nil {
-			_ = sc.committer.CommitOffset(sc.group, sc.topic, sc.partition, sc.Offset())
-		}
 		sc.sendCloseControlFrame()
 		sc.closeConn()
 	}()
 
 	pollTicker := time.NewTicker(sc.interval)
-	commitTicker := time.NewTicker(commitInterval)
 	keepaliveTicker := time.NewTicker(sc.keepaliveInterval)
 	defer pollTicker.Stop()
-	defer commitTicker.Stop()
 	defer keepaliveTicker.Stop()
 
 	// sendMessages reads and sends available messages. Returns false on fatal error.
@@ -177,11 +170,6 @@ func (sc *StreamConnection) Run(
 		select {
 		case <-sc.stopCh:
 			return
-
-		case <-commitTicker.C:
-			if sc.committer != nil {
-				_ = sc.committer.CommitOffset(sc.group, sc.topic, sc.partition, sc.Offset())
-			}
 
 		case <-sc.newMessageCh:
 			if !sendMessages() {

--- a/pkg/stream/connection_test.go
+++ b/pkg/stream/connection_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type countingOffsetCommitter struct {
+	commits int
+}
+
+func (c *countingOffsetCommitter) CommitOffset(string, string, int, uint64) error {
+	c.commits++
+	return nil
+}
+
 func TestStreamConnection_Basic(t *testing.T) {
 	c1, c2 := net.Pipe()
 	defer func() { _ = c1.Close() }()
@@ -89,6 +98,8 @@ func TestStreamConnection_StopSendsCloseControlFrame(t *testing.T) {
 	sc := NewStreamConnection(c1, "t1", 0, "g1", 42)
 	sc.SetInterval(10 * time.Second)
 	sc.SetKeepaliveInterval(10 * time.Second)
+	committer := &countingOffsetCommitter{}
+	sc.SetCommitter(committer)
 
 	readFn := func(offset uint64, max int) ([]types.Message, error) {
 		return []types.Message{}, nil
@@ -118,4 +129,5 @@ func TestStreamConnection_StopSendsCloseControlFrame(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("stream did not stop")
 	}
+	assert.Zero(t, committer.commits, "delivery and close must not commit consumer offsets")
 }

--- a/pkg/stream/manager.go
+++ b/pkg/stream/manager.go
@@ -26,9 +26,10 @@ func NewStreamManager(maxConn int, timeout, heartbeat time.Duration) *StreamMana
 	}
 }
 
+// AddStream accepts a legacy commit interval that is intentionally ignored.
 func (sm *StreamManager) AddStream(key string, stream *StreamConnection,
 	readFn func(offset uint64, max int) ([]types.Message, error),
-	commitInterval time.Duration,
+	legacyCommitInterval time.Duration,
 ) error {
 
 	sm.mu.Lock()
@@ -39,7 +40,7 @@ func (sm *StreamManager) AddStream(key string, stream *StreamConnection,
 	}
 
 	sm.streams[key] = stream
-	go stream.Run(readFn, commitInterval)
+	go stream.Run(readFn, legacyCommitInterval)
 	go sm.monitorConnection(key, stream)
 
 	return nil

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -17,7 +17,7 @@ import (
 )
 
 type StreamManager interface {
-	AddStream(key string, streamConn *stream.StreamConnection, readFn func(offset uint64, max int) ([]types.Message, error), commitInterval time.Duration) error
+	AddStream(key string, streamConn *stream.StreamConnection, readFn func(offset uint64, max int) ([]types.Message, error), legacyCommitInterval time.Duration) error
 	RemoveStream(key string)
 	GetStreamsForPartition(topic string, partition int) []*stream.StreamConnection
 	StopStream(key string)
@@ -36,6 +36,10 @@ type TopicManager struct {
 // HandlerProvider defines an interface to provide disk handlers.
 type HandlerProvider interface {
 	GetHandler(topic string, partitionID int) (types.StorageHandler, error)
+}
+
+type existingPartitionProvider interface {
+	ExistingPartitionCount(topic string) (int, error)
 }
 
 type topicHandlerCloser interface {
@@ -103,6 +107,23 @@ func (tm *TopicManager) GetTopic(name string) *Topic {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
 	return tm.topics[name]
+}
+
+// ExistingPartitionCount reports the partition count already known in memory or
+// persisted by the storage provider without creating new partitions.
+func (tm *TopicManager) ExistingPartitionCount(name string) (int, error) {
+	tm.mu.RLock()
+	if existing := tm.topics[name]; existing != nil {
+		count := len(existing.Partitions)
+		tm.mu.RUnlock()
+		return count, nil
+	}
+	provider := tm.hp
+	tm.mu.RUnlock()
+	if discovery, ok := provider.(existingPartitionProvider); ok {
+		return discovery.ExistingPartitionCount(name)
+	}
+	return 0, nil
 }
 
 func (tm *TopicManager) GetLastOffset(topicName string, partitionID int) uint64 {

--- a/pkg/topic/stream_adapter.go
+++ b/pkg/topic/stream_adapter.go
@@ -19,8 +19,13 @@ func NewStreamManagerAdapter(sm *stream.StreamManager) (*StreamManagerAdapter, e
 	return &StreamManagerAdapter{sm: sm}, nil
 }
 
-func (a *StreamManagerAdapter) AddStream(key string, streamConn *stream.StreamConnection, readFn func(offset uint64, max int) ([]types.Message, error), commitInterval time.Duration) error {
-	return a.sm.AddStream(key, streamConn, readFn, commitInterval)
+func (a *StreamManagerAdapter) AddStream(
+	key string,
+	streamConn *stream.StreamConnection,
+	readFn func(offset uint64, max int) ([]types.Message, error),
+	legacyCommitInterval time.Duration,
+) error {
+	return a.sm.AddStream(key, streamConn, readFn, legacyCommitInterval)
 }
 
 func (a *StreamManagerAdapter) RemoveStream(key string) {

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -585,12 +585,19 @@ func (c *Consumer) joinGroup() (int64, string, []int, error) {
 
 	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
 
+	c.mu.RLock()
 	mID := c.memberID
+	generation := c.generation
+	c.mu.RUnlock()
+	resuming := mID != "" && generation > 0
 	if mID == "" {
 		mID = c.config.ConsumerID
 	}
 
 	joinCmd := fmt.Sprintf("JOIN_GROUP topic=%s group=%s member=%s", c.config.Topic, c.config.GroupID, mID)
+	if resuming {
+		joinCmd += fmt.Sprintf(" generation=%d", generation)
+	}
 	if err := WriteWithLength(conn, EncodeMessage("", joinCmd)); err != nil {
 		return 0, "", nil, fmt.Errorf("send join: %w", err)
 	}
@@ -606,12 +613,30 @@ func (c *Consumer) joinGroup() (int64, string, []int, error) {
 		return 0, "", nil, fmt.Errorf("coordinator moved, retry")
 	}
 	if !strings.HasPrefix(respStr, "OK") {
+		if resuming && strings.Contains(respStr, "GEN_MISMATCH") {
+			currentText := parseOKFields(respStr)["current"]
+			current, parseErr := strconv.ParseInt(currentText, 10, 64)
+			if parseErr == nil {
+				assignments, syncErr := c.syncGroup(current, mID)
+				if syncErr == nil {
+					return current, mID, assignments, nil
+				}
+			}
+		}
+		if resuming && strings.Contains(respStr, "member_not_found") {
+			c.mu.Lock()
+			if c.memberID == mID {
+				c.memberID = ""
+				c.generation = 0
+			}
+			c.mu.Unlock()
+			return c.joinGroup()
+		}
 		return 0, "", nil, fmt.Errorf("join rejected: %s", respStr)
 	}
 
 	var gen int64
 	var mid string
-	var assigned []int
 
 	for _, part := range strings.Fields(respStr) {
 		if strings.HasPrefix(part, "generation=") {
@@ -621,21 +646,7 @@ func (c *Consumer) joinGroup() (int64, string, []int, error) {
 		}
 	}
 
-	if strings.Contains(respStr, "assignments=") {
-		start := strings.Index(respStr, "[")
-		end := strings.Index(respStr, "]")
-		if start != -1 && end != -1 {
-			partStr := strings.ReplaceAll(respStr[start+1:end], ",", " ")
-			for _, p := range strings.Fields(partStr) {
-				pid, err := strconv.Atoi(strings.TrimSpace(p))
-				if err == nil {
-					assigned = append(assigned, pid)
-				}
-			}
-		}
-	}
-
-	return gen, mid, assigned, nil
+	return gen, mid, parseGroupAssignments(respStr), nil
 }
 
 func (c *Consumer) syncGroup(generation int64, memberID string) ([]int, error) {
@@ -666,18 +677,25 @@ func (c *Consumer) syncGroup(generation int64, memberID string) ([]int, error) {
 	c.memberID = memberID
 	c.mu.Unlock()
 
-	var assigned []int
-	if strings.Contains(respStr, "[") && strings.Contains(respStr, "]") {
-		start := strings.Index(respStr, "[")
-		end := strings.Index(respStr, "]")
-		for _, p := range strings.Fields(respStr[start+1 : end]) {
-			var pid int
-			if _, err := fmt.Sscanf(p, "%d", &pid); err == nil {
-				assigned = append(assigned, pid)
-			}
+	return parseGroupAssignments(respStr), nil
+}
+
+func parseGroupAssignments(resp string) []int {
+	start := strings.Index(resp, "[")
+	end := strings.Index(resp, "]")
+	if start == -1 || end <= start {
+		return nil
+	}
+
+	partitionText := strings.ReplaceAll(resp[start+1:end], ",", " ")
+	assignments := make([]int, 0)
+	for _, field := range strings.Fields(partitionText) {
+		partition, err := strconv.Atoi(field)
+		if err == nil {
+			assignments = append(assignments, partition)
 		}
 	}
-	return assigned, nil
+	return assignments
 }
 
 func (c *Consumer) fetchOffsetWithRetry(partition int) (uint64, error) {
@@ -780,10 +798,14 @@ func (c *Consumer) Close() error {
 	close(c.commitCh)
 	c.commitWg.Wait()
 
-	if c.memberID != "" {
+	c.mu.RLock()
+	memberID := c.memberID
+	generation := c.generation
+	c.mu.RUnlock()
+	if memberID != "" && generation > 0 {
 		if conn, err := c.getCoordinatorConn(); err == nil {
-			leaveCmd := fmt.Sprintf("LEAVE_GROUP topic=%s group=%s member=%s",
-				c.config.Topic, c.config.GroupID, c.memberID)
+			leaveCmd := fmt.Sprintf("LEAVE_GROUP topic=%s group=%s member=%s generation=%d",
+				c.config.Topic, c.config.GroupID, memberID, generation)
 			_ = WriteWithLength(conn, EncodeMessage("", leaveCmd))
 			_ = conn.Close()
 		}

--- a/sdk/consumer_group.go
+++ b/sdk/consumer_group.go
@@ -26,8 +26,12 @@ func (c *Consumer) heartbeatLoop() {
 			}
 
 			_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+			c.mu.RLock()
+			memberID := c.memberID
+			generation := c.generation
+			c.mu.RUnlock()
 			hb := fmt.Sprintf("HEARTBEAT topic=%s group=%s member=%s generation=%d",
-				c.config.Topic, c.config.GroupID, c.memberID, c.generation)
+				c.config.Topic, c.config.GroupID, memberID, generation)
 			if err := WriteWithLength(conn, EncodeMessage("", hb)); err != nil {
 				LogError("Heartbeat send failed: %v", err)
 				c.cleanupHbConn(conn)
@@ -195,6 +199,27 @@ func (c *Consumer) rebalanceMonitorLoop() {
 	}
 }
 
+func (c *Consumer) scheduleRebalanceRetry() {
+	delay := time.Duration(c.config.ConnectRetryBackoffMS) * time.Millisecond
+	if delay < 100*time.Millisecond {
+		delay = 100 * time.Millisecond
+	}
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-c.doneCh:
+			return
+		case <-timer.C:
+		}
+		select {
+		case <-c.doneCh:
+		case c.rebalanceSig <- struct{}{}:
+		default:
+		}
+	}()
+}
+
 func (c *Consumer) handleRebalanceSignal() {
 	if !atomic.CompareAndSwapInt32(&c.rebalancing, 0, 1) {
 		return
@@ -251,25 +276,34 @@ drainDone:
 	gen, mid, assignments, err := c.joinGroupWithRetry()
 	if err != nil {
 		LogError("Rebalance join failed: %v", err)
+		c.scheduleRebalanceRetry()
 		return
 	}
 	if len(assignments) == 0 {
 		assignments, err = c.syncGroup(gen, mid)
 		if err != nil {
 			LogError("Rebalance sync failed: %v", err)
+			c.scheduleRebalanceRetry()
 			return
 		}
+	}
+
+	offsetMap := make(map[int]uint64, len(assignments))
+	for _, pid := range assignments {
+		offset, err := c.fetchOffsetWithRetry(pid)
+		if err != nil {
+			LogError("Rebalance: offset fetch failed for P%d: %v", pid, err)
+			c.scheduleRebalanceRetry()
+			return
+		}
+		offsetMap[pid] = offset
 	}
 
 	c.mu.Lock()
 	c.generation = gen
 	c.memberID = mid
 	for _, pid := range assignments {
-		offset, err := c.fetchOffset(pid)
-		if err != nil {
-			LogError("Rebalance: offset fetch failed for P%d: %v", pid, err)
-			return
-		}
+		offset := offsetMap[pid]
 		c.partitionConsumers[pid] = &PartitionConsumer{
 			partitionID:  pid,
 			consumer:     c,
@@ -277,9 +311,11 @@ drainDone:
 			commitOffset: offset,
 		}
 		c.offsets[pid] = offset
-		LogInfo("Rebalance: P%d assigned at offset %d (gen=%d)", pid, offset, gen)
 	}
 	c.mu.Unlock()
+	for _, pid := range assignments {
+		LogInfo("Rebalance: P%d assigned at offset %d (gen=%d)", pid, offsetMap[pid], gen)
+	}
 
 	if err := c.fetchMetadata(); err != nil {
 		LogWarn("Rebalance: failed to fetch metadata: %v", err)

--- a/sdk/consumer_group_contract_test.go
+++ b/sdk/consumer_group_contract_test.go
@@ -1,0 +1,208 @@
+package sdk
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type scriptedSDKCommand struct {
+	command string
+	err     error
+}
+
+func startSDKCommandServer(t *testing.T, responses ...string) (string, <-chan scriptedSDKCommand) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	results := make(chan scriptedSDKCommand, len(responses))
+	go func() {
+		defer close(results)
+		for _, response := range responses {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				results <- scriptedSDKCommand{err: acceptErr}
+				return
+			}
+
+			request, readErr := ReadWithLength(conn)
+			if readErr != nil {
+				_ = conn.Close()
+				results <- scriptedSDKCommand{err: readErr}
+				return
+			}
+			if len(request) < 2 {
+				_ = conn.Close()
+				results <- scriptedSDKCommand{err: fmt.Errorf("short encoded command: %d bytes", len(request))}
+				return
+			}
+
+			topicLength := int(binary.BigEndian.Uint16(request[:2]))
+			commandStart := 2 + topicLength
+			if commandStart > len(request) {
+				_ = conn.Close()
+				results <- scriptedSDKCommand{err: fmt.Errorf("invalid topic length %d for %d-byte command", topicLength, len(request))}
+				return
+			}
+
+			results <- scriptedSDKCommand{command: string(request[commandStart:])}
+			if response != "" {
+				if writeErr := WriteWithLength(conn, []byte(response)); writeErr != nil {
+					_ = conn.Close()
+					results <- scriptedSDKCommand{err: writeErr}
+					return
+				}
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	return listener.Addr().String(), results
+}
+
+func requireSDKCommand(t *testing.T, results <-chan scriptedSDKCommand) string {
+	t.Helper()
+
+	select {
+	case result, ok := <-results:
+		require.True(t, ok, "scripted SDK command server closed early")
+		require.NoError(t, result.err)
+		return result.command
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for SDK command")
+		return ""
+	}
+}
+
+func newGroupContractConsumer(t *testing.T, addr string) *Consumer {
+	t.Helper()
+
+	cfg := NewDefaultConsumerConfig()
+	cfg.BrokerAddrs = []string{addr}
+	cfg.Topic = "events"
+	cfg.GroupID = "workers"
+	cfg.ConsumerID = "worker"
+	consumer, err := NewConsumer(cfg)
+	require.NoError(t, err)
+	consumer.coordinatorAddr = addr
+	t.Cleanup(consumer.mainCancel)
+	return consumer
+}
+
+func TestConsumerJoinGroupResumesExistingMember(t *testing.T) {
+	addr, commands := startSDKCommandServer(
+		t,
+		"OK generation=7 member=worker-1234 assignments=[0,1] resumed=true",
+	)
+	consumer := newGroupContractConsumer(t, addr)
+	consumer.memberID = "worker-1234"
+	consumer.generation = 7
+
+	generation, member, assignments, err := consumer.joinGroup()
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), generation)
+	assert.Equal(t, "worker-1234", member)
+	assert.Equal(t, []int{0, 1}, assignments)
+	assert.Equal(t, "JOIN_GROUP topic=events group=workers member=worker-1234 generation=7", requireSDKCommand(t, commands))
+}
+
+func TestConsumerJoinGroupSynchronizesExistingMemberAfterGenerationMismatch(t *testing.T) {
+	addr, commands := startSDKCommandServer(
+		t,
+		"ERROR: GEN_MISMATCH current=8 requested=7 group=workers member=worker-1234",
+		"OK generation=8 member=worker-1234 assignments=[1,2]",
+	)
+	consumer := newGroupContractConsumer(t, addr)
+	consumer.memberID = "worker-1234"
+	consumer.generation = 7
+
+	generation, member, assignments, err := consumer.joinGroup()
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), generation)
+	assert.Equal(t, "worker-1234", member)
+	assert.Equal(t, []int{1, 2}, assignments)
+	assert.Equal(t, "JOIN_GROUP topic=events group=workers member=worker-1234 generation=7", requireSDKCommand(t, commands))
+	assert.Equal(t, "SYNC_GROUP topic=events group=workers member=worker-1234 generation=8", requireSDKCommand(t, commands))
+}
+
+func TestConsumerJoinGroupCreatesFreshMemberAfterExpiration(t *testing.T) {
+	addr, commands := startSDKCommandServer(
+		t,
+		"ERROR: member_not_found member=worker-1234 group=workers",
+		"OK generation=9 member=worker-9876 assignments=[0,1,2]",
+	)
+	consumer := newGroupContractConsumer(t, addr)
+	consumer.memberID = "worker-1234"
+	consumer.generation = 7
+
+	generation, member, assignments, err := consumer.joinGroup()
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), generation)
+	assert.Equal(t, "worker-9876", member)
+	assert.Equal(t, []int{0, 1, 2}, assignments)
+	assert.Equal(t, "JOIN_GROUP topic=events group=workers member=worker-1234 generation=7", requireSDKCommand(t, commands))
+	assert.Equal(t, "JOIN_GROUP topic=events group=workers member=worker", requireSDKCommand(t, commands))
+}
+func TestConsumerHeartbeatIncludesMemberAndGeneration(t *testing.T) {
+	addr, commands := startSDKCommandServer(
+		t,
+		"OK member=worker-1234 generation=7",
+	)
+	consumer := newGroupContractConsumer(t, addr)
+	consumer.memberID = "worker-1234"
+	consumer.generation = 7
+	consumer.config.HeartbeatIntervalMS = 5
+
+	finished := make(chan struct{})
+	go func() {
+		consumer.heartbeatLoop()
+		close(finished)
+	}()
+
+	assert.Equal(t, "HEARTBEAT topic=events group=workers member=worker-1234 generation=7", requireSDKCommand(t, commands))
+	close(consumer.doneCh)
+
+	select {
+	case <-finished:
+	case <-time.After(3 * time.Second):
+		t.Fatal("heartbeat loop did not stop")
+	}
+}
+
+func TestConsumerCloseLeavesCurrentGeneration(t *testing.T) {
+	addr, commands := startSDKCommandServer(t, "")
+	consumer := newGroupContractConsumer(t, addr)
+	consumer.memberID = "worker-1234"
+	consumer.generation = 7
+
+	require.NoError(t, consumer.Close())
+	assert.Equal(t, "LEAVE_GROUP topic=events group=workers member=worker-1234 generation=7", requireSDKCommand(t, commands))
+}
+
+func TestConsumerSchedulesRebalanceRetryUntilClosed(t *testing.T) {
+	c := newTestConsumer(t)
+	c.config.ConnectRetryBackoffMS = 1
+	c.scheduleRebalanceRetry()
+
+	select {
+	case <-c.rebalanceSig:
+	case <-time.After(time.Second):
+		t.Fatal("rebalance retry was not scheduled")
+	}
+
+	require.NoError(t, c.Close())
+	c.scheduleRebalanceRetry()
+	select {
+	case <-c.rebalanceSig:
+		t.Fatal("closed consumer scheduled another rebalance")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -85,12 +85,27 @@ func (pc *PartitionConsumer) runWorker() {
 
 		// Deliver messages to user handler.
 		handler := pc.consumer.MessageHandler
+		processingFailed := false
 		if handler != nil {
 			for _, msg := range batch.messages {
 				if err := handler(msg); err != nil {
 					LogError("Partition [%d] handler error at offset %d: %v", pc.partitionID, msg.Offset, err)
+					processingFailed = true
+					break
 				}
 			}
+		}
+		if processingFailed {
+			pc.consumer.mu.RLock()
+			committed := pc.consumer.offsets[pc.partitionID]
+			pc.consumer.mu.RUnlock()
+			atomic.StoreUint64(&pc.fetchOffset, committed)
+			pc.closeConnection()
+			select {
+			case pc.consumer.rebalanceSig <- struct{}{}:
+			default:
+			}
+			return
 		}
 
 		if pc.consumer.mainCtx.Err() != nil {

--- a/sdk/partition_test.go
+++ b/sdk/partition_test.go
@@ -657,3 +657,43 @@ func TestPartitionConsumer_HandleStreamControl_OffsetOutOfRange(t *testing.T) {
 	assert.True(t, result)
 	assert.Equal(t, uint64(5), atomic.LoadUint64(&pc.fetchOffset))
 }
+
+func TestPartitionConsumer_HandlerFailureDoesNotCommitAndRequestsRedelivery(t *testing.T) {
+	c := newTestConsumer(t)
+	c.mu.Lock()
+	c.offsets[0] = 3
+	c.mu.Unlock()
+	c.MessageHandler = func(Message) error {
+		return assert.AnError
+	}
+
+	pc := &PartitionConsumer{
+		partitionID: 0,
+		consumer:    c,
+		fetchOffset: 6,
+		dataCh:      make(chan *messageBatch, 1),
+	}
+	c.wg.Add(1)
+	go pc.runWorker()
+	pc.dataCh <- &messageBatch{
+		topic: "test-topic",
+		messages: []Message{
+			{Offset: 3, Payload: "first"},
+			{Offset: 4, Payload: "second"},
+		},
+	}
+
+	select {
+	case <-c.rebalanceSig:
+	case <-time.After(time.Second):
+		t.Fatal("handler failure did not request a rebalance")
+	}
+	c.wg.Wait()
+
+	assert.Equal(t, uint64(3), atomic.LoadUint64(&pc.fetchOffset))
+	select {
+	case commit := <-c.commitCh:
+		t.Fatalf("handler failure unexpectedly queued commit: %+v", commit)
+	default:
+	}
+}

--- a/test/consumer/subscriber/consumer.go
+++ b/test/consumer/subscriber/consumer.go
@@ -1130,9 +1130,13 @@ func (c *Consumer) Close() error {
 	close(c.commitCh)
 	c.resetHeartbeatConn()
 
-	if c.memberID != "" {
+	c.mu.RLock()
+	memberID, generation := c.memberID, c.generation
+	c.mu.RUnlock()
+	if memberID != "" {
 		if conn, err := c.getCoordinatorConn(); err == nil {
-			leaveCmd := fmt.Sprintf("LEAVE_GROUP topic=%s group=%s member=%s", c.config.Topic, c.config.GroupID, c.memberID)
+			leaveCmd := fmt.Sprintf("LEAVE_GROUP topic=%s group=%s member=%s generation=%d",
+				c.config.Topic, c.config.GroupID, memberID, generation)
 			_ = util.WriteWithLength(conn, util.EncodeMessage("", leaveCmd))
 			_ = conn.Close()
 		}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off.
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes

## Summary

This PR strengthens the consumer group lifecycle across coordinator failover, reconnect, generation fencing, assignment recovery, and durable offset resume.

## Changes

- Preserve member identity and assignment across transient reconnects.
- Add coordinator handoff grace and stale generation recovery semantics.
- Keep committed offsets monotonic and validate partition ownership.
- Align streaming and pull consumers with the same group lifecycle contract.
- Update the Go SDK to rediscover coordinators and resume broker-owned offsets.
- Document the complete lifecycle and add broker/SDK contract tests.

## Dependency

Depends on #87. This is a stacked draft; the current diff includes the transaction base until #87 is merged and this branch is rebased onto `main`.

## Validation

- `go test ./pkg/... ./sdk/... -count=1`

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.
