### PR TITLE
feat: add broker health and runtime observability

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,8 +87,8 @@ cursus exposes three network ports, each serving a distinct purpose:
 | Port | Protocol | Handler | Purpose |
 |------|----------|---------|---------|
 | 9000 | TCP      | `server.RunServer()` | Main broker operations (`PUBLISH`, `CONSUME`, `CREATE`, etc.) |
-| 9080 | HTTP     | `startHealthCheckServer()` | Health check endpoint for load balancers |
-| 9100 | HTTP     | `metrics.StartMetricsServer()` | Prometheus metrics exporter |
+| 9080 | HTTP     | `startHealthCheckServer()` | `/live`, `/ready`, and compatible `/health` probes |
+| 9100 | HTTP     | `metrics.StartMetricsServer()` | Prometheus exporter with scrape-time broker state |
 
 
 ## Core Data Flow

--- a/docs/core/server.md
+++ b/docs/core/server.md
@@ -132,23 +132,20 @@ This ensures clients can read responses using the same protocol as sending reque
 
 ## Health Check System
 
-The health check server runs on a separate HTTP port and provides endpoints for load balancers and orchestration systems.
+The health server binds synchronously on a separate HTTP port. A bind failure aborts broker startup.
 
 ### Endpoints
 
-- `/health`: Primary health check endpoint
-- `/`: Root path also serves health check (convenience)
+| Endpoint | Meaning | Success |
+|---|---|---|
+| `/live` | The broker process and health handler are running | `200` JSON |
+| `/ready` | Startup completed and dynamic dependency checks pass | `200` JSON |
+| `/health` | Backward-compatible readiness check | `200 OK` plain text |
+| `/` | Alias of `/health` | `200 OK` plain text |
 
-### Health Check Logic
+Readiness becomes true only after the TCP listener, command handler, worker pool, and enabled HTTP services are initialized. Distributed brokers also require a resolvable cluster leader. Leader election can therefore produce `/live = 200` and `/ready = 503`, which keeps the process alive while removing it from client traffic.
 
-The health handler in `pkg/server/main.go` checks the `brokerReady` atomic boolean.
-
-| Condition | HTTP Status | Response Body |
-|-----------|-------------|----------------|
-| `brokerReady.Load() == false` | 503 Service Unavailable | `"Broker not ready: Main listener not active"` |
-| `brokerReady.Load() == true` | 200 OK | `"OK"` |
-
-The `brokerReady` flag is set to `true` immediately after the TCP listener starts successfully, ensuring that health checks pass only when the server can accept connections.
+See [Broker Observability](../reference/observability.md) for response bodies, metrics, and probe examples.
 
 ## Integration with Other Systems
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -457,7 +457,7 @@ and every partition.
 
 **COMMIT_OFFSET**
 ```
-COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N> [member=<actual-id> generation=<N>]
+COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N> member=<actual-id> generation=<N>
 ```
 Response: `OK`
 
@@ -465,7 +465,9 @@ The `offset` value is the next offset to read after the client has processed
 records. Commits are durable and monotonic per `(topic, group, partition)`.
 Committing the same offset is idempotent. Committing an offset lower than the
 current committed offset returns an error and does not move the stored offset
-backward.
+backward. `member` and `generation` are required and must identify the current
+partition owner; missing values are validation errors and stale values are fencing
+errors.
 
 **BATCH_COMMIT**
 ```
@@ -482,6 +484,8 @@ included partition. The broker validates `member` and `generation` before applyi
 the batch. If any partition is not owned by that member in that generation, the
 entire batch is rejected with `ERROR: NOT_OWNER ...`. Stale generations return
 `ERROR: GEN_MISMATCH ...`, and unknown members return `ERROR: member_not_found ...`.
+The whole batch is also rejected before any offset changes when `generation` is
+missing, an entry is malformed, or the same partition appears more than once.
 
 
 #### Transaction Coordinator
@@ -828,7 +832,16 @@ SDKs should parse the code and fields first, use `class` for broad handling, and
 | `offset_regression reason="..."` | Commit lower than current stored offset | Treat commit as failed; refetch offset |
 | `stale_producer_epoch producer=<id> current=<N> got=<N>` | Idempotent producer request uses an older fenced epoch | Treat as fatal for that producer instance; create a new producer session |
 | `OFFSET_OUT_OF_RANGE requested=N earliest=N latest=N` | Requested offset is older than retained log or beyond available range | Treat as data loss or reset according to policy |
-| `no_valid_offsets` | BATCH_COMMIT parse failure | Check format: `P<N>:<offset>` |
+| `no_valid_offsets` | BATCH_COMMIT contains no usable offsets | Supply at least one `P<N>:<offset>` entry |
+| `missing_generation command=<command>` | Group command omitted its generation | Rejoin if needed and send the current generation |
+| `invalid_batch_commit_entry entry=<entry>` | BATCH_COMMIT entry is not `P<N>:<offset>` | Correct the malformed entry and retry |
+| `duplicate_partition partition=N group=<G> topic=<T>` | BATCH_COMMIT repeats a partition | Send one next offset per partition; no offsets were committed |
+| `NOT_PARTITION_LEADER leader=<id> requested_leader=<id>` | Replication reached a broker that is not the current partition leader | Refresh partition metadata and retry against the leader |
+| `STALE_LEADER_EPOCH current=N requested=N` | Replication request carries a fenced leader epoch | Discard the stale leader session and refresh metadata |
+| `cluster_metadata_unavailable command=REPLICATE_MESSAGE` | Cluster metadata subsystem is temporarily unavailable | Back off and retry |
+| `partition_metadata_not_found topic=<T> partition=N` | Partition metadata does not exist | Refresh metadata and verify topic/partition |
+| `missing_leader_fence command=REPLICATE_MESSAGE` | Internal replication omitted leader ID or epoch | Correct the broker request; do not retry unchanged |
+| `invalid_commit_watermark reason="..."` | Commit watermark is ahead of local durable data or otherwise invalid | Repair/catch up the replica before retrying |
 | invalid_control_batch_bytes field=<key|value> | Broker-internal transaction control bytes are not valid base64 | Reject the internal publish and inspect broker compatibility |
 | `version_conflict current=N expected=N` | Optimistic concurrency failure | Reload aggregate and retry |
 | `event_sourcing_not_enabled topic=<X>` | ES command on non-ES topic | CREATE topic with `event_sourcing=true` |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -194,6 +194,12 @@ ERROR: missing_payload command=REPLICATE_MESSAGE
 ERROR: unmarshal_failed reason="..."
 ERROR: topic_not_found topic=<name>
 ERROR: partition_not_found partition=<N>
+ERROR: cluster_metadata_unavailable command=REPLICATE_MESSAGE
+ERROR: partition_metadata_not_found topic=<name> partition=<N>
+ERROR: missing_leader_fence command=REPLICATE_MESSAGE
+ERROR: NOT_PARTITION_LEADER leader=<broker-id> requested_leader=<broker-id>
+ERROR: STALE_LEADER_EPOCH current=<N> requested=<N>
+ERROR: invalid_commit_watermark reason="..."
 ERROR: replica_append_failed reason="..."
 ```
 
@@ -357,10 +363,10 @@ When no offset has been committed, the broker returns `OK offset=0`.
 ### COMMIT_OFFSET
 
 ```text
-COMMIT_OFFSET topic=<name> group=<group> partition=<N> offset=<nextOffset> [member=<member-id> generation=<N>]
+COMMIT_OFFSET topic=<name> group=<group> partition=<N> offset=<nextOffset> member=<member-id> generation=<N>
 ```
 
-The offset is the next offset to read after successful processing. Commits are monotonic per `(topic, group, partition)`: a commit lower than the current offset fails and does not rewind the group. When `member` or `generation` is supplied, both must be present and the member must own the partition in that generation. Legacy clients may omit both fields, but group-aware SDKs should send them.
+The offset is the next offset to read after successful processing. Commits are monotonic per `(topic, group, partition)`: a commit lower than the current offset fails and does not rewind the group. `member` and `generation` are required, and the member must own the partition in that generation.
 
 Success:
 
@@ -372,6 +378,7 @@ Common errors:
 
 ```text
 ERROR: invalid_offset
+ERROR: missing_generation command=COMMIT_OFFSET
 ERROR: invalid_generation command=COMMIT_OFFSET
 ERROR: offset_regression reason="..."
 ERROR: GEN_MISMATCH current=<N> requested=<N> group=<group> member=<member-id>
@@ -398,7 +405,10 @@ Common errors:
 
 ```text
 ERROR: invalid_batch_commit_format
+ERROR: invalid_batch_commit_entry entry=<entry>
+ERROR: missing_generation command=BATCH_COMMIT
 ERROR: invalid_generation command=BATCH_COMMIT
+ERROR: duplicate_partition partition=<N> group=<group> topic=<topic>
 ERROR: no_valid_offsets
 ERROR: offset_regression reason="..."
 ERROR: GEN_MISMATCH current=<N> requested=<N> group=<group> member=<member-id>

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -1,486 +1,234 @@
-# Monitoring and Observability
+# Broker Observability
 
-## Purpose and Scope
+## Contract
 
-This document describes the monitoring and observability capabilities built into cursus, including health check endpoints, Prometheus metrics, and structured logging. 
+Cursus exposes health and Prometheus endpoints on HTTP listeners separate from
+the client protocol listener.
 
-These features enable operators to monitor broker health, track performance metrics, and diagnose issues in production environments.
+| Default port | Endpoint | Response | Purpose |
+|---|---|---|---|
+| `9080` | `GET /live` | JSON | Process liveness |
+| `9080` | `GET /ready` | JSON | Broker and dependency readiness |
+| `9080` | `GET /health` | Plain text | Backward-compatible readiness check |
+| `9080` | `GET /` | Plain text | Alias of `/health` |
+| `9100` | `GET /metrics` | Prometheus/OpenMetrics | Broker metrics when the exporter is enabled |
 
-## Overview
+Only `GET` and `HEAD` are accepted by health endpoints. Other methods return
+`405 Method Not Allowed`.
 
-```mermaid
-graph LR
-    B[Broker :9000] -->|expose| M[Metrics :9100]
-    B -->|expose| H[Health :9080]
-    B -->|write| L[stdout/stderr]
-    M -->|scrape| P[Prometheus]
-    P --> G[Grafana]
-    H -->|poll| LB[Load Balancer]
-    L -->|collect| ELK[Log Aggregator]
+The HTTP listeners bind before broker readiness is published. A health or
+metrics bind failure fails broker startup instead of being logged as a
+background-only failure.
 
-    SDK[SDK Client] -->|expose| SM[SDK Metrics :2112]
-    SM -->|scrape| P
+## Liveness And Readiness
+
+`/live` returns `200` while the health HTTP server can execute requests. It does
+not check topic storage, consumer groups, or cluster quorum.
+
+```json
+{"status":"live"}
 ```
 
-cursus provides three primary observability mechanisms:
+`/ready` returns `200` only after the client listener, command handler, worker
+pool, and enabled HTTP services have initialized and all dynamic checks pass.
 
-| Component            | Port       | Protocol          | Purpose                                                      |
-|---------------------|-----------|-----------------|--------------------------------------------------------------|
-| Health Check Server  | 9080      | HTTP             | Load balancer health checks, liveness probes                |
-| Metrics Exporter     | 9100      | HTTP (Prometheus)| Performance metrics, resource utilization                   |
-| Structured Logging   | N/A       | stdout/stderr    | Request tracing, command auditing, error diagnostics        |
+Standalone response:
 
-**Note:** All components can be independently configured and integrate with standard monitoring infrastructure (Prometheus, Grafana, ELK stack, etc.).
-
-## Health Check System
-
-### Implementation
-
-The health check system is implemented as a lightweight HTTP server running on a separate port from the main broker listener. This separation ensures health checks don't compete with broker traffic.
-
-### Key Components:
-
-- **`startHealthCheckServer()`**: Initializes HTTP server
-- **brokerReady** : Atomic boolean flag tracking broker readiness
-- **Health Handler** : HTTP request handler
-
-## Readiness Flow
-
-### Endpoints
-
-| Endpoint | Method | Response Codes | Response Body                                               |
-|----------|--------|----------------|-------------------------------------------------------------|
-| /health  | GET    | 200, 503        | "OK" or "Broker not ready: Main listener not active"       |
-| /        | GET    | 200, 503        | Same as /health                                            |
-
-**Note:** Both endpoints return the same health status. The root endpoint(`/`) allows simple `curl` commands without specifying a path.
-
-### HTTP Status Codes:
-
-- **200 OK**: Broker is ready and accepting connections on port 9000
-- **503 Service Unavailable**: Main TCP listener has not started successfully
-
-### Configuration
-
-
-# manifests/config.yaml
-```
-broker:
-  port: 9000
-  # Health check configuration
-  # Defaults to 9080 if not specified
+```json
+{"status":"ready","checks":{"storage":"ok"}}
 ```
 
-The health check port is configured via:
-- **YAML/JSON config file**: `health_check_port` field
-- **Command-line flag**: --health-port 
-- **Default value**: 9080 
+In distributed mode, readiness also requires a resolvable cluster leader. A
+broker process can therefore remain live while returning `503` from `/ready`
+during election or loss of cluster leadership.
 
-## Prometheus Metrics System
-
-### Architecture
-
-The Prometheus metrics exporter runs as a separate HTTP server on port 9100, exposing metrics in the standard Prometheus text format. The exporter can be toggled via configuration.
-
-### Metric Categories
-
-The `pkg/metrics` package exposes the following Prometheus metrics:
-
-**Broker Metrics** (`pkg/metrics/broker.go`):
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `broker_messages_processed_total` | Counter | Total messages processed |
-| `broker_messages_per_second` | Gauge | Current throughput |
-| `broker_message_latency_seconds` | Histogram | Message processing latency |
-| `broker_queue_size` | Gauge | Current topic manager queue size |
-| `broker_cleanup_count_total` | Counter | Deduped message IDs cleaned up |
-| `broker_seqnum_gap_total` | Counter | SeqNum gaps detected (labels: topic, partition, producer_id) |
-| `broker_seqnum_duplicate_total` | Counter | Duplicate seqNums detected (labels: topic, partition) |
-| `broker_consumer_lag` | Gauge | Consumer lag per partition (labels: topic, partition, group) |
-
-**Cluster Metrics** (`pkg/metrics/cluster.go`):
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `cluster_brokers_total` | Gauge | Total brokers in cluster |
-| `cluster_partition_leaders_total` | Gauge | Partition leaders per broker |
-| `cluster_replication_lag_seconds` | Histogram | Replication lag (labels: topic, partition, broker) |
-| `cluster_leader_elections_total` | Counter | Leader elections |
-| `cluster_isr_size` | Gauge | ISR size per partition |
-| `cluster_replication_lag_bytes` | Gauge | Replication lag in bytes |
-| `cluster_isr_changes_total` | Counter | ISR membership changes |
-| `cluster_leader_election_failures_total` | Counter | Failed leader elections |
-| `cluster_broker_health_status` | Gauge | Broker health (1=healthy, 0=unhealthy) |
-| `cluster_quorum_operations_total` | Counter | Quorum operations |
-| `cluster_partition_reassignments_total` | Counter | Partition reassignments |
-
-### Configuration
-
-manifests/config.yaml
-```
-broker:
-  enable_exporter: true
-  exporter_port: 9100
-
-prometheus:
-  scrape_interval: "5s"
-  scrape_timeout: "3s"
+```json
+{
+  "status": "not_ready",
+  "checks": {
+    "cluster_leader": "no cluster leader available",
+    "storage": "ok"
+  }
+}
 ```
 
-### Configuration Options:
+`/health` remains compatible with existing container checks:
 
-| Parameter       | Type    | Default | Description                             |
-|-----------------|--------|---------|-----------------------------------------|
-| enable_exporter | boolean | true    | Enable/disable Prometheus exporter      |
-| exporter_port   | integer | 9100    | Port for metrics HTTP server            |
-
-**Command-line Flags:**
-
-- `--exporter`: Enable exporter (boolean)
-- `--exporter-port`: Port number (integer)
-
-### Prometheus Integration
-
-To scrape cursus metrics, configure Prometheus with:
-
-
-prometheus.yml
-```
-scrape_configs:
-  - job_name: 'cursus'
-    scrape_interval: 5s
-    scrape_timeout: 3s
-    static_configs:
-      - targets: ['localhost:9100']
+```text
+HTTP 200: OK
+HTTP 503: Broker not ready: <failed-check>=<reason>
 ```
 
-For Docker deployments, use the service name:
+Recommended Kubernetes probes:
 
-```
-static_configs:
-  - targets: ['cursus:9100']
-```
-
-## Structured Logging
-
-### Logging Strategy
-
-cursus implements structured logging throughout the codebase using Go's standard log package with prefixed message categories. All logs are written to `stdout/stderr` for compatibility with container log aggregation systems.
-
-### Log Format Examples
-
-Request Logging 
-```
-[REQ] [192.168.1.10:52341] Received request. Topic: 'orders', Payload: 'CREATE orders 4'
-```
-
-Command Result Logging 
-
-```
-[CMD] SUCCESS | Command: [CREATE topic=orders partitions=4] | Response: OK topic=orders partitions=4
-[CMD] FAILURE | Command: [DELETE topic=nonexistent] | Response: ERROR: topic_not_found topic=nonexistent
-```
-
-Streaming Logging 
-
-```
-[STREAM] Completed streaming 342 messages for command [CONSUME orders 0 0]
-```
-
-Error Logging 
-
-```
-[CONSUME_ERR] Error streaming data for command [CONSUME orders 0 0]: failed to read messages from disk
-```
-
-Operational Logging 
-
-```
-📈 Prometheus exporter started on port 9100
-🧩 Broker listening on :9000 (TLS=false, Gzip=false)
-🩺 Health check endpoint started on port 9080
-```
-
-Log Categories Detail
-
-| Prefix         | Source                  | Level | Description                           |
-|----------------|------------------------|-------|---------------------------------------|
-| `[REQ]`        | HandleConnection        | INFO  | Incoming request metadata             |
-| `[INPUT_WARN]` | HandleConnection        | WARN  | Malformed input                        |
-| `[CMD]`        | CommandHandler          | INFO  | Command execution results (SUCCESS/FAILURE) |
-| `[STREAM]`     | HandleConsumeCommand    | INFO  | Message streaming completion status    |
-| `[CONSUME_ERR]`| HandleConsumeCommand    | ERROR | Errors during message consumption      |
-
-## Client Address Tracking
-
-All connection-related logs include the remote client address for request tracing:
-
-```
-clientAddr := conn.RemoteAddr().String()
-log.Printf("[%s] Received request. Topic: '%s', Payload: '%s'", 
-    clientAddr, topicName, payload)
-```
-
-This enables:
-- Correlating multiple requests from the same client
-- Identifying problematic clients
-- Request-level tracing for debugging
-
-## Configuration Reference
-
-Complete Configuration Example
-
-manifests/config.yaml
-```
-broker:
-  # Network Ports
-  port: 9000                    # Main broker TCP port
-  health_check_port: 9080       # Health check HTTP port (optional, defaults to 9080)
-  
-  # Observability
-  enable_exporter: true         # Enable Prometheus metrics
-  exporter_port: 9100          # Prometheus exporter port
-  
-  # System Configuration
-  cleanup_interval: 60         # Deduplication cleanup interval (seconds)
-  use_tls: false               # TLS encryption
-  enable_gzip: false           # Message compression
-  
-  # Performance Tuning
-  channel_buffer_size: 10000   # Partition channel buffer
-  disk_flush_batch_size: 500   # Messages per disk flush
-  linger_ms: 100               # Max wait before flush (ms)
-
-# Prometheus Scrape Configuration
-prometheus:
-  scrape_interval: "5s"
-  scrape_timeout: "3s"
-```
-
-## Configuration Loading Priority
-
-Priority Order (highest to lowest):
-- Command-line flags (--exporter-port=9100)
-- Config file values (via CONFIG_PATH env var or --config flag)
-- Built-in defaults
-
-### Docker Deployment Configuration
-
-manifests/docker-compose.yml
-```
-services:
-  broker:
-    ports:
-      - "9000:9000"   # Main broker port
-      - "9100:9100"   # Metrics exporter
-      - "9080:9080"   # Health check
-    environment:
-      - CONFIG_PATH=/root/config.yaml
-    volumes:
-      - ./config.yaml:/root/config.yaml
-```
-
-All three ports must be exposed for full observability:
-
-- 9000: Client connections (publishers/consumers)
-- 9080: Health checks (load balancers, Kubernetes probes)
-- 9100: Metrics (Prometheus scraping)
-
-## Monitoring Best Practices
-
-### Health Check Integration
-
-Load Balancer Configuration:
-
-Configure load balancers to use the health endpoint for backend health checks:
-
-```
-Health Check URL: http://broker:9080/health
-Expected Status: 200
-Check Interval: 10s
-Timeout: 3s
-Unhealthy Threshold: 3
-Kubernetes Liveness Probe:
-
+```yaml
 livenessProbe:
   httpGet:
-    path: /health
+    path: /live
     port: 9080
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  timeoutSeconds: 3
-  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 9080
 ```
 
-### Metrics Collection
+Do not use `/live` for traffic admission. It intentionally remains successful
+when the broker cannot safely serve client work.
 
-Recommended Prometheus Alerts:
+## Metrics Semantics
 
-| Alert           | Condition                                | Severity  | Description                     |
-|-----------------|------------------------------------------|-----------|---------------------------------|
-| BrokerDown      | `up{job="cursus"} == 0`                 | Critical  | Broker unreachable             |
-| HighDiskUsage   | Disk segment count growing rapidly       | Warning   | May need compaction            |
-| ConsumerLag     | Consumer offset far behind latest        | Warning   | Processing bottleneck          |
-| HighErrorRate   | Command failure rate > 5%                | Warning   | Application issues             |
+Runtime gauges are generated from a point-in-time broker snapshot on every
+scrape. They do not retain labels for deleted topics, departed groups, or old
+partition leaders.
 
-### Log Aggregation
+### Broker Traffic
 
-Recommended Setup:
+| Metric | Type | Meaning |
+|---|---|---|
+| `cursus_broker_client_connections_total` | Counter | Accepted client TCP connections |
+| `cursus_broker_client_connections_active` | Gauge | Connections currently handled |
+| `cursus_broker_commands_total{command,result}` | Counter | Completed text command dispatches |
+| `cursus_broker_command_duration_seconds{command}` | Histogram | Command dispatch latency |
+| `cursus_broker_command_errors_total{command,code}` | Counter | Wire errors by bounded command and error code |
+| `broker_messages_processed_total` | Counter | Messages accepted by the topic manager |
+| `broker_message_latency_seconds` | Histogram | Topic manager publish latency |
+| `broker_seqnum_gap_total{topic,partition,producer_id}` | Counter | Detected producer sequence gaps |
+| `broker_seqnum_duplicate_total{topic,partition}` | Counter | Detected duplicate producer sequences |
 
-- **Docker Logs**: Use `docker logs -f cursus` for development
-- **Production**: Ship logs to centralized system (ELK, Splunk, Datadog)
-- **Retention**: Keep at least 7 days of logs for incident investigation
-- **Parsing**: Index logs by category prefix ([CMD], [REQ], etc.)
+Command duration ends when a streaming command is accepted. It does not include
+the lifetime or payload transfer time of a stream.
 
-### Example Filebeat Configuration:
+### Topic And Storage State
 
-```
-filebeat.inputs:
-  - type: container
-    paths:
-      - '/var/lib/docker/containers/*/*.log'
-    processors:
-      - add_docker_metadata: ~
-      - decode_json_fields:
-          fields: ["message"]
-          target: "json"
+| Metric | Meaning |
+|---|---|
+| `cursus_broker_ready` | Current readiness result (`1` or `0`) |
+| `cursus_broker_topics` | Topics loaded on this broker |
+| `cursus_broker_partitions` | Partitions loaded on this broker |
+| `cursus_partition_log_start_offset{topic,partition}` | Earliest retained offset |
+| `cursus_partition_log_end_offset{topic,partition}` | Next allocated offset |
+| `cursus_partition_high_watermark{topic,partition}` | Next offset visible to committed readers |
+| `cursus_streams_active` | Registered streaming consumers |
+| `cursus_storage_handlers` | Open partition storage handlers |
+| `cursus_storage_segments` | Segment files represented by open handlers |
+| `cursus_storage_bytes` | Segment and offset-index bytes represented by open handlers |
+| `cursus_storage_pending_writes` | Messages queued for disk writes |
+| `cursus_storage_active_readers` | Current segment readers |
+| `cursus_storage_stat_failures` | Files that could not be inspected during the scrape |
 
-output.elasticsearch:
-  hosts: ["elasticsearch:9200"]
-  index: "cursus-logs-%{+yyyy.MM.dd}"
-```
+`cursus_storage_bytes` covers open topic handlers. It is not filesystem capacity
+or free-space telemetry; collect those values with the node or container
+runtime exporter.
 
-## Troubleshooting
+### Consumer Groups
 
-### Health Check Issues
+| Metric | Meaning |
+|---|---|
+| `cursus_consumer_group_members{group,topic}` | Active group members |
+| `cursus_consumer_group_generation{group,topic}` | Current group generation |
+| `cursus_consumer_group_assigned_partitions{group,topic}` | Assignments held by active members |
+| `cursus_consumer_group_committed_offset{group,topic,partition}` | Durable next offset |
+| `cursus_consumer_group_lag{group,topic,partition}` | `max(HWM - committedNextOffset, 0)` |
+| `cursus_consumer_group_offset_out_of_range{group,topic,partition}` | Commit is below log start or above the high watermark |
 
-Symptom: Health check returns 503
+Lag uses the high watermark rather than the local log end so uncommitted replica
+tail data is not reported as consumable work. For an exact-topic group with no
+stored offset, the collector applies the broker's earliest default of `0`.
+Wildcard groups expose partitions for which broker offset state exists.
 
-Diagnosis:
+`broker_consumer_lag{topic,partition,group}` remains as a deprecated alias with
+the same scrape-time HWM semantics. New dashboards should use
+`cursus_consumer_group_lag`.
 
-```
-curl http://localhost:9080/health
-# Response: "Broker not ready: Main listener not active"
-```
+### Cluster State
 
-Possible Causes:
-- Main listener failed to bind to port 9000 (port already in use)
-- Network configuration issues
-- Broker crashed after health server started
+| Metric | Meaning |
+|---|---|
+| `cursus_distribution_enabled` | Distributed mode is enabled |
+| `cursus_cluster_brokers` | Brokers in replicated metadata |
+| `cursus_cluster_has_leader` | This broker resolves a cluster leader |
+| `cursus_cluster_is_leader` | This broker is the current cluster leader |
+| `cursus_cluster_offline_partitions` | Partitions without a leader assignment |
+| `cursus_cluster_under_replicated_partitions` | Partitions where ISR size is below replica count |
+| `cursus_cluster_partition_replicas{topic,partition}` | Configured replicas |
+| `cursus_cluster_partition_in_sync_replicas{topic,partition}` | Current ISR size |
+| `cursus_cluster_partition_leader_epoch{topic,partition}` | Current leader epoch |
+| `cursus_cluster_partition_leader{topic,partition,broker_id}` | Current leader identity (`1`) |
+| `cluster_replication_lag_seconds{topic,partition,broker}` | Successful follower acknowledgement latency |
+| `cluster_quorum_operations_total{operation,result}` | Instrumented quorum operation results |
 
-Resolution:
+The historical `cluster_*` vectors that are not listed above are compatibility
+surfaces and may have no series unless their corresponding operation occurs.
+Use the `cursus_cluster_*` scrape-time metrics for current topology and health.
 
-- Check broker logs for TCP listener errors
-- Verify port 9000 is available: `netstat -an | grep 9000`
-- Check firewall rules
+## Configuration
 
-### Metrics Not Available
-
-Symptom: Prometheus cannot scrape metrics
-
-Diagnosis:
-
-```
-curl http://localhost:9100/metrics
-# Connection refused or timeout
-```
-
-Possible Causes:
-
-- Exporter disabled in configuration
-- Port 9100 not accessible
-- Metrics server failed to start
-
-Resolution:
-
-- Verify enable_exporter: true in config
-- Check Docker port mapping: `docker ps`
-- Verify metrics server startup in logs: `📈 Prometheus exporter started`
-
-### Missing Logs
-
-Symptom: Expected log messages not appearing
-
-Possible Causes:
-
-- Log verbosity insufficient
-- Docker logging driver not configured
-- Log aggregator not collecting from container
-
-Resolution:
-
-```
-# View container logs directly
-docker logs -f cursus
-
-# Check Docker logging driver
-docker inspect cursus | grep LogConfig
-
-# Verify log output
-docker exec cursus ls -la /proc/1/fd/1
+```yaml
+health_check_port: 9080
+enable_exporter: true
+exporter_port: 9100
 ```
 
-## SDK Client Metrics
+Equivalent environment variables are `HEALTH_CHECK_PORT`, `ENABLE_EXPORTER`,
+and `EXPORTER_PORT`.
 
-In addition to broker-side metrics, the Go SDK provides built-in Prometheus metrics for producer and consumer clients. These are opt-in via the `enable_metrics` configuration field.
-
-### Enabling SDK Metrics
-
-```go
-cfg := sdk.NewDefaultPublisherConfig()
-cfg.EnableMetrics = true
-
-// Expose metrics endpoint
-http.Handle("/metrics", sdk.MetricsHandler())
-go log.Fatal(http.ListenAndServe(":2112", nil))
-```
-
-### Available SDK Metrics
-
-**Producer:**
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `cursus_producer_messages_sent_total` | Counter | Total messages successfully acknowledged |
-| `cursus_producer_send_errors_total` | Counter | Total send failures (network errors, partial failures) |
-| `cursus_producer_batch_latency_seconds` | Histogram | End-to-end batch send latency |
-
-**Consumer:**
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `cursus_consumer_messages_received_total` | Counter | Total messages received (polling + streaming) |
-| `cursus_consumer_commit_total` | Counter | Successful offset commits |
-| `cursus_consumer_commit_errors_total` | Counter | Failed offset commit attempts |
-| `cursus_consumer_poll_latency_seconds` | Histogram | Poll round-trip latency |
-| `cursus_consumer_rebalance_total` | Counter | Consumer group rebalance events |
-
-### Prometheus Scrape Configuration for SDK
+Prometheus example:
 
 ```yaml
 scrape_configs:
-  - job_name: 'cursus-sdk'
-    scrape_interval: 10s
+  - job_name: cursus
+    scrape_interval: 15s
     static_configs:
-      - targets: ['app-host:2112']
+      - targets: ["broker-1:9100", "broker-2:9100", "broker-3:9100"]
 ```
 
-### Recommended Alerts for SDK Metrics
+## Alert Baseline
 
-| Alert | Condition | Severity |
-|-------|-----------|----------|
-| HighSendErrorRate | `rate(cursus_producer_send_errors_total[5m]) > 0.1` | Warning |
-| ConsumerLag | `rate(cursus_consumer_messages_received_total[5m]) == 0` | Warning |
-| FrequentRebalances | `rate(cursus_consumer_rebalance_total[5m]) > 0.5` | Warning |
-| HighCommitFailure | `rate(cursus_consumer_commit_errors_total[5m]) > 0.05` | Warning |
+```promql
+# Scrape target unavailable
+up{job="cursus"} == 0
 
-# Summary
+# Process is reachable but cannot serve client work
+cursus_broker_ready == 0
 
-cursus provides comprehensive observability through three independent systems:
+# No cluster leader
+cursus_distribution_enabled == 1 and cursus_cluster_has_leader == 0
 
-- **Health Checks** (:9080): Binary ready/not-ready status for load balancers
-- **Prometheus Metrics** (:9100): Time-series performance data for monitoring
-- **Structured Logs** (stdout): Request tracing and diagnostic information
+# Replication safety degraded
+cursus_cluster_under_replicated_partitions > 0
 
-All three systems are production-ready, configurable, and integrate with standard monitoring infrastructure. The separation of concerns (different ports, different protocols) ensures that monitoring operations don't interfere with broker functionality.
+# Group commit no longer points into retained data
+cursus_consumer_group_offset_out_of_range == 1
+
+# Sustained consumer backlog
+max_over_time(cursus_consumer_group_lag[10m]) > 10000
+
+# Storage writer backlog
+cursus_storage_pending_writes > 0
+```
+
+Tune lag and pending-write thresholds to topic throughput and retention. A
+single non-zero sample can be normal during bursts.
+
+## Security Boundary
+
+Health and metrics endpoints do not perform client authentication. Bind and
+publish these ports only on a trusted operations network, or place them behind
+an authenticated reverse proxy. Metrics include topic, consumer group, and
+broker identifiers.
+
+Do not expose the metrics listener as a public application endpoint.
+
+## Validation
+
+```bash
+curl -fsS http://localhost:9080/live
+curl -fsS http://localhost:9080/ready
+curl -fsS http://localhost:9100/metrics | grep '^cursus_'
+```
+
+The compatibility probe remains:
+
+```bash
+curl -fsS http://localhost:9080/health
+```

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -107,13 +107,14 @@ The configuration is represented by the Config struct in the codebase, which org
 | Parameter           | Type       | Default        | Description                                      |
 |--------------------|------------|----------------|--------------------------------------------------|
 | `broker_port`        | int        | 9000           | Main broker TCP port for client connections     |
-| `health_check_port`  | int        | 9080           | HTTP port for health check endpoint             |
+| `health_check_port`  | int        | 9080           | HTTP port for `/live`, `/ready`, and `/health`             |
 | `log_dir`            | string     | "broker-logs"  | Directory path for persistent log segments      |
 | `enable_exporter`    | bool       | true           | Enable Prometheus metrics exporter              |
-| `exporter_port`      | int        | 9100           | HTTP port for Prometheus metrics endpoint       |
+| `exporter_port`      | int        | 9100           | HTTP port for the Prometheus `/metrics` endpoint       |
 | `enable_benchmark`   | bool       | false          | Enable benchmark mode for testing               |
 | `cleanup_interval`   | int        | 300            | Log cleanup interval (seconds)                 |
 
+The health and metrics listeners are unauthenticated operations endpoints. Restrict both ports to a trusted network. `/live` reports process liveness, while `/ready` and the compatible `/health` endpoint include storage and distributed leader checks. See [Broker Observability](../reference/observability.md).
 
 # Security and Compression
 

--- a/manifests/helm/templates/deployment.yaml
+++ b/manifests/helm/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             {{- end }}  
           livenessProbe:  
             httpGet:  
-              path: /health  
+              path: /live
               port: health  
             initialDelaySeconds: 30  
             periodSeconds: 10  
@@ -67,7 +67,7 @@ spec:
             failureThreshold: 3  
           readinessProbe:  
             httpGet:  
-              path: /health  
+              path: /ready
               port: health  
             initialDelaySeconds: 5  
             periodSeconds: 5  

--- a/pkg/cluster/controller/runtime.go
+++ b/pkg/cluster/controller/runtime.go
@@ -1,0 +1,83 @@
+package controller
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// PartitionRuntimeSnapshot describes replicated partition placement.
+type PartitionRuntimeSnapshot struct {
+	Topic       string
+	Partition   int
+	Leader      string
+	LeaderEpoch int
+	Replicas    int
+	InSync      int
+}
+
+// RuntimeSnapshot is a point-in-time view of cluster control state.
+type RuntimeSnapshot struct {
+	Enabled          bool
+	BrokerID         string
+	BrokerCount      int
+	HasLeader        bool
+	IsLeader         bool
+	Offline          int
+	UnderReplicated  int
+	PartitionDetails []PartitionRuntimeSnapshot
+}
+
+// RuntimeSnapshot returns cluster metadata without exposing mutable FSM state.
+func (cc *ClusterController) RuntimeSnapshot() RuntimeSnapshot {
+	if cc == nil || cc.RaftManager == nil {
+		return RuntimeSnapshot{}
+	}
+
+	snapshot := RuntimeSnapshot{
+		Enabled:   true,
+		BrokerID:  cc.brokerID,
+		HasLeader: cc.RaftManager.GetLeaderAddress() != "",
+		IsLeader:  cc.RaftManager.IsLeader(),
+	}
+	fsmState := cc.RaftManager.GetFSM()
+	if fsmState == nil {
+		return snapshot
+	}
+
+	snapshot.BrokerCount = len(fsmState.GetBrokers())
+	keys := fsmState.GetAllPartitionKeys()
+	sort.Strings(keys)
+	for _, key := range keys {
+		separator := strings.LastIndexByte(key, '-')
+		if separator <= 0 || separator == len(key)-1 {
+			continue
+		}
+		partition, err := strconv.Atoi(key[separator+1:])
+		if err != nil {
+			continue
+		}
+		metadata := fsmState.GetPartitionMetadata(key)
+		if metadata == nil {
+			continue
+		}
+
+		detail := PartitionRuntimeSnapshot{
+			Topic:       key[:separator],
+			Partition:   partition,
+			Leader:      metadata.Leader,
+			LeaderEpoch: metadata.LeaderEpoch,
+			Replicas:    len(metadata.Replicas),
+			InSync:      len(metadata.ISR),
+		}
+		if detail.Leader == "" {
+			snapshot.Offline++
+		}
+		if detail.InSync < detail.Replicas {
+			snapshot.UnderReplicated++
+		}
+		snapshot.PartitionDetails = append(snapshot.PartitionDetails, detail)
+	}
+
+	return snapshot
+}

--- a/pkg/cluster/controller/runtime_test.go
+++ b/pkg/cluster/controller/runtime_test.go
@@ -1,0 +1,24 @@
+package controller
+
+import "testing"
+
+func TestRuntimeSnapshotReportsLeadershipWithoutFSM(t *testing.T) {
+	manager := &ComprehensiveMockRaftManager{isLeader: true}
+	manager.On("GetLeaderAddress").Return("broker-1:9001").Once()
+	controller := &ClusterController{RaftManager: manager, brokerID: "broker-1"}
+
+	snapshot := controller.RuntimeSnapshot()
+	if !snapshot.Enabled || !snapshot.HasLeader || !snapshot.IsLeader {
+		t.Fatalf("unexpected cluster snapshot: %+v", snapshot)
+	}
+	if snapshot.BrokerID != "broker-1" || snapshot.BrokerCount != 0 {
+		t.Fatalf("unexpected cluster identity snapshot: %+v", snapshot)
+	}
+}
+
+func TestRuntimeSnapshotHandlesDisabledController(t *testing.T) {
+	var controller *ClusterController
+	if snapshot := controller.RuntimeSnapshot(); snapshot.Enabled {
+		t.Fatalf("nil controller reported enabled: %+v", snapshot)
+	}
+}

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cursus-io/cursus/pkg/coordinator"
-	"github.com/cursus-io/cursus/pkg/metrics"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/util"
 )
@@ -744,7 +743,6 @@ func (ch *CommandHandler) handleCommitOffset(cmd string) string {
 	if err != nil {
 		return formatCoordinatorError(err)
 	}
-	ch.recordConsumerLag(offsetTopic, partition, offset, groupID)
 	return "OK"
 }
 
@@ -849,10 +847,6 @@ func (ch *CommandHandler) handleBatchCommit(cmd string) string {
 		return "ERROR: offset_manager_not_available"
 	}
 
-	for _, item := range offsetList {
-		ch.recordConsumerLag(offsetTopic, item.Partition, item.Offset, groupID)
-	}
-
 	return fmt.Sprintf("OK batched=%d", len(offsetList))
 }
 func (ch *CommandHandler) resolveGroupOffsetTopic(groupName, topicName string) (string, string) {
@@ -906,22 +900,6 @@ func formatCoordinatorError(err error) string {
 		return fmt.Sprintf("ERROR: group_not_found reason=%q", msg)
 	}
 	return fmt.Sprintf("ERROR: coordinator_error reason=%q", msg)
-}
-func (ch *CommandHandler) recordConsumerLag(topicName string, partition int, committedOffset uint64, groupID string) {
-	t := ch.TopicManager.GetTopic(topicName)
-	if t == nil {
-		return
-	}
-	p, err := t.GetPartition(partition)
-	if err != nil {
-		return
-	}
-	leo := p.NextOffset()
-	lag := float64(0)
-	if leo > committedOffset {
-		lag = float64(leo - committedOffset)
-	}
-	metrics.ConsumerLag.WithLabelValues(topicName, fmt.Sprintf("%d", partition), groupID).Set(lag)
 }
 
 // resolveOffset determines the starting offset for a consumer

--- a/pkg/controller/command_metrics_test.go
+++ b/pkg/controller/command_metrics_test.go
@@ -1,0 +1,19 @@
+package controller
+
+import "testing"
+
+func TestMetricCommandNameBoundsLabels(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	tests := map[string]string{
+		"CREATE topic=orders":   "CREATE",
+		"consume topic=orders":  "CONSUME",
+		"STREAM topic=orders":   "STREAM",
+		"user-controlled-value": "UNKNOWN",
+		"":                      "EMPTY",
+	}
+	for command, want := range tests {
+		if got := handler.metricCommandName(command); got != want {
+			t.Fatalf("metricCommandName(%q) = %q, want %q", command, got, want)
+		}
+	}
+}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/eventsource"
+	"github.com/cursus-io/cursus/pkg/metrics"
 	"github.com/cursus-io/cursus/pkg/stream"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/transaction"
@@ -184,8 +185,14 @@ func redactOneCommandSecret(s, key string) string {
 }
 
 // HandleCommand processes non-streaming commands and returns a signal for streaming commands.
-func (ch *CommandHandler) HandleCommand(rawCmd string, ctx *ClientContext) string {
+func (ch *CommandHandler) HandleCommand(rawCmd string, ctx *ClientContext) (response string) {
+	started := time.Now()
 	cmd := strings.TrimSpace(rawCmd)
+	commandName := ch.metricCommandName(cmd)
+	defer func() {
+		metrics.RecordCommand(commandName, response, time.Since(started))
+	}()
+
 	if cmd == "" {
 		resp := decorateProtocolResponse("ERROR: empty_command", ctx)
 		ch.logCommandResult(rawCmd, resp)
@@ -218,9 +225,26 @@ func (ch *CommandHandler) HandleCommand(rawCmd string, ctx *ClientContext) strin
 		return ch.fail(rawCmd, resp)
 	}
 
-	resp := decorateProtocolResponse(ch.handleCommandByType(cmd, upper, ctx), ctx)
-	ch.logCommandResult(rawCmd, resp)
-	return resp
+	response = decorateProtocolResponse(ch.handleCommandByType(cmd, upper, ctx), ctx)
+	ch.logCommandResult(rawCmd, response)
+	return response
+}
+
+func (ch *CommandHandler) metricCommandName(cmd string) string {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return "EMPTY"
+	}
+	name := strings.ToUpper(fields[0])
+	if name == "STREAM" || name == "CONSUME" {
+		return name
+	}
+	for _, entry := range ch.commands {
+		if name == strings.TrimSpace(entry.prefix) {
+			return name
+		}
+	}
+	return "UNKNOWN"
 }
 
 // handleCommandByType dispatches to the matching command handler from the registry.

--- a/pkg/controller/transaction_handler.go
+++ b/pkg/controller/transaction_handler.go
@@ -656,7 +656,6 @@ func (ch *CommandHandler) commitTransactionOffset(op transaction.OffsetOperation
 	if err := ch.Coordinator.ValidateAndCommit(op.Group, op.Topic, op.Partition, op.Offset, op.Generation, op.Member); err != nil {
 		return err
 	}
-	ch.recordConsumerLag(op.Topic, op.Partition, op.Offset, op.Group)
 	return nil
 }
 

--- a/pkg/disk/readiness_test.go
+++ b/pkg/disk/readiness_test.go
@@ -1,0 +1,41 @@
+package disk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+)
+
+func TestDiskManagerReadyChecksLogDirectory(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = filepath.Join(t.TempDir(), "missing")
+	manager := NewDiskManager(cfg)
+	if err := manager.Ready(); err == nil {
+		t.Fatal("Ready accepted a missing log directory")
+	}
+	if err := os.MkdirAll(cfg.LogDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Ready(); err != nil {
+		t.Fatalf("Ready rejected an available log directory: %v", err)
+	}
+}
+
+func TestDiskManagerReadyRejectsClosedRegisteredHandler(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	manager := NewDiskManager(cfg)
+	handler, err := manager.GetHandler("orders", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handler.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Ready(); err == nil {
+		t.Fatal("Ready accepted a closed registered handler")
+	}
+	manager.CloseAllHandlers()
+}

--- a/pkg/disk/runtime.go
+++ b/pkg/disk/runtime.go
@@ -1,0 +1,99 @@
+package disk
+
+import (
+	"fmt"
+	"os"
+)
+
+// RuntimeSnapshot is an aggregate view of open broker storage handlers.
+type RuntimeSnapshot struct {
+	Handlers      int
+	Segments      int
+	Bytes         int64
+	PendingWrites int
+	ActiveReaders int
+	StatFailures  int
+}
+
+// RuntimeSnapshot returns storage state without retaining manager locks during I/O.
+func (dm *DiskManager) RuntimeSnapshot() RuntimeSnapshot {
+	if dm == nil {
+		return RuntimeSnapshot{}
+	}
+
+	dm.mu.Lock()
+	handlers := make([]*DiskHandler, 0, len(dm.handlers))
+	for _, handler := range dm.handlers {
+		handlers = append(handlers, handler)
+	}
+	dm.mu.Unlock()
+
+	snapshot := RuntimeSnapshot{Handlers: len(handlers)}
+	for _, handler := range handlers {
+		if handler == nil {
+			continue
+		}
+
+		handler.mu.Lock()
+		segments := append([]uint64(nil), handler.segments...)
+		current := handler.CurrentSegment
+		pending := len(handler.writeCh)
+		handler.mu.Unlock()
+
+		seen := make(map[uint64]struct{}, len(segments)+1)
+		segments = append(segments, current)
+		for _, baseOffset := range segments {
+			if _, exists := seen[baseOffset]; exists {
+				continue
+			}
+			seen[baseOffset] = struct{}{}
+			snapshot.Segments++
+			for _, path := range []string{handler.GetSegmentPath(baseOffset), handler.GetIndexPath(baseOffset)} {
+				info, err := os.Stat(path)
+				if err != nil {
+					if !os.IsNotExist(err) {
+						snapshot.StatFailures++
+					}
+					continue
+				}
+				snapshot.Bytes += info.Size()
+			}
+		}
+
+		snapshot.PendingWrites += pending
+		snapshot.ActiveReaders += int(handler.GetActiveReaders())
+	}
+
+	return snapshot
+}
+
+// Ready verifies that the configured log directory and active handlers are available.
+func (dm *DiskManager) Ready() error {
+	if dm == nil || dm.cfg == nil {
+		return fmt.Errorf("disk manager unavailable")
+	}
+	if dm.cfg.LogDir == "" {
+		return fmt.Errorf("log directory is not configured")
+	}
+	info, err := os.Stat(dm.cfg.LogDir)
+	if err != nil {
+		return fmt.Errorf("inspect log directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("log path is not a directory")
+	}
+
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	for key, handler := range dm.handlers {
+		if handler == nil {
+			return fmt.Errorf("storage handler %s is unavailable", key)
+		}
+		select {
+		case <-handler.done:
+			return fmt.Errorf("storage handler %s is closed", key)
+		default:
+		}
+	}
+	return nil
+}

--- a/pkg/disk/runtime_test.go
+++ b/pkg/disk/runtime_test.go
@@ -1,0 +1,25 @@
+package disk
+
+import (
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+)
+
+func TestDiskManagerRuntimeSnapshot(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	manager := NewDiskManager(cfg)
+	if _, err := manager.GetHandler("orders", 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(manager.CloseAllHandlers)
+
+	snapshot := manager.RuntimeSnapshot()
+	if snapshot.Handlers != 1 || snapshot.Segments != 1 {
+		t.Fatalf("runtime snapshot = %+v", snapshot)
+	}
+	if snapshot.Bytes < 0 || snapshot.StatFailures != 0 {
+		t.Fatalf("unexpected storage accounting: %+v", snapshot)
+	}
+}

--- a/pkg/metrics/broker.go
+++ b/pkg/metrics/broker.go
@@ -39,8 +39,37 @@ var (
 		Help: "Total number of duplicate sequence numbers detected",
 	}, []string{"topic", "partition"})
 
+	// ConsumerLag is retained for Go API compatibility. The broker exporter
+	// serves this name from its scrape-time runtime collector.
+	// Deprecated: use cursus_consumer_group_lag from the broker exporter.
 	ConsumerLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "broker_consumer_lag",
-		Help: "Consumer lag per partition (LEO - committed offset)",
+		Help: "Deprecated consumer lag compatibility gauge",
 	}, []string{"topic", "partition", "group"})
+
+	ClientConnectionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cursus_broker_client_connections_total",
+		Help: "Total client TCP connections accepted by the broker",
+	})
+
+	ClientConnectionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cursus_broker_client_connections_active",
+		Help: "Client TCP connections currently handled by the broker",
+	})
+
+	CommandsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cursus_broker_commands_total",
+		Help: "Broker text commands completed by command and result",
+	}, []string{"command", "result"})
+
+	CommandDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "cursus_broker_command_duration_seconds",
+		Help:    "Broker text command handling latency before streamed payload transfer",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"command"})
+
+	CommandErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cursus_broker_command_errors_total",
+		Help: "Broker text command errors by bounded command and wire error code",
+	}, []string{"command", "code"})
 )

--- a/pkg/metrics/command.go
+++ b/pkg/metrics/command.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"strings"
+	"time"
+)
+
+// RecordCommand records a bounded command name and its wire response.
+func RecordCommand(command, response string, elapsed time.Duration) {
+	result := "ok"
+	if strings.HasPrefix(strings.TrimSpace(response), "ERROR:") {
+		result = "error"
+		CommandErrors.WithLabelValues(command, errorCode(response)).Inc()
+	}
+	CommandsTotal.WithLabelValues(command, result).Inc()
+	CommandDuration.WithLabelValues(command).Observe(elapsed.Seconds())
+}
+
+func errorCode(response string) string {
+	trimmed := strings.TrimSpace(response)
+	trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "ERROR:"))
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return "unknown"
+	}
+	return fields[0]
+}

--- a/pkg/metrics/command_test.go
+++ b/pkg/metrics/command_test.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestRecordCommandTracksResultLatencyAndErrorCode(t *testing.T) {
+	command := "TEST_COMMAND"
+	okCounter := CommandsTotal.WithLabelValues(command, "ok")
+	errorCounter := CommandsTotal.WithLabelValues(command, "error")
+	codeCounter := CommandErrors.WithLabelValues(command, "invalid_request")
+	okBefore := counterMetricValue(t, okCounter)
+	errorBefore := counterMetricValue(t, errorCounter)
+	codeBefore := counterMetricValue(t, codeCounter)
+	duration := CommandDuration.WithLabelValues(command)
+	durationBefore := histogramMetricCount(t, duration)
+
+	RecordCommand(command, "OK", 5*time.Millisecond)
+	RecordCommand(command, "ERROR: invalid_request reason=bad", 10*time.Millisecond)
+
+	if got := counterMetricValue(t, okCounter); got != okBefore+1 {
+		t.Fatalf("ok command count = %v, want %v", got, okBefore+1)
+	}
+	if got := counterMetricValue(t, errorCounter); got != errorBefore+1 {
+		t.Fatalf("error command count = %v, want %v", got, errorBefore+1)
+	}
+	if got := counterMetricValue(t, codeCounter); got != codeBefore+1 {
+		t.Fatalf("error code count = %v, want %v", got, codeBefore+1)
+	}
+	if got := histogramMetricCount(t, duration); got != durationBefore+2 {
+		t.Fatalf("duration sample count = %v, want %v", got, durationBefore+2)
+	}
+}
+
+func counterMetricValue(t *testing.T, counter prometheus.Counter) float64 {
+	t.Helper()
+	metric := &dto.Metric{}
+	if err := counter.Write(metric); err != nil {
+		t.Fatal(err)
+	}
+	return metric.GetCounter().GetValue()
+}
+
+func histogramMetricCount(t *testing.T, observer prometheus.Observer) uint64 {
+	t.Helper()
+	metricWriter, ok := observer.(prometheus.Metric)
+	if !ok {
+		t.Fatal("histogram observer does not implement prometheus.Metric")
+	}
+	metric := &dto.Metric{}
+	if err := metricWriter.Write(metric); err != nil {
+		t.Fatal(err)
+	}
+	return metric.GetHistogram().GetSampleCount()
+}

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -1,28 +1,71 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func init() {
-	prometheus.MustRegister(MessagesProcessed, MessagesPerSec, LatencyHist, QueueSize, CleanupCount, SeqNumGapTotal, SeqNumDuplicateTotal, ConsumerLag)
+	prometheus.MustRegister(MessagesProcessed, MessagesPerSec, LatencyHist, QueueSize, CleanupCount, SeqNumGapTotal, SeqNumDuplicateTotal)
+	prometheus.MustRegister(ClientConnectionsTotal, ClientConnectionsActive, CommandsTotal, CommandDuration, CommandErrors)
 	prometheus.MustRegister(ClusterBrokersTotal, PartitionLeadersTotal, ClusterReplicationLag, LeaderElectionTotal, ISRSize)
 	prometheus.MustRegister(ReplicationLagBytes, ISRChangesTotal, LeaderElectionFailures, BrokerHealthStatus, QuorumOperations, PartitionReassignments)
 }
 
-func StartMetricsServer(port int) {
+// Handler returns an isolated metrics handler containing process and runtime collectors.
+func Handler(collectors ...prometheus.Collector) (http.Handler, error) {
+	runtimeRegistry := prometheus.NewRegistry()
+	for _, collector := range collectors {
+		if collector == nil {
+			continue
+		}
+		if err := runtimeRegistry.Register(collector); err != nil {
+			return nil, fmt.Errorf("register runtime collector: %w", err)
+		}
+	}
+	gatherer := prometheus.Gatherers{prometheus.DefaultGatherer, runtimeRegistry}
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{EnableOpenMetrics: true}), nil
+}
+
+// StartMetricsServer starts the exporter and reports bind failures synchronously.
+func StartMetricsServer(port int, collectors ...prometheus.Collector) (*http.Server, error) {
+	return StartMetricsServerAddress(fmt.Sprintf(":%d", port), collectors...)
+}
+
+// StartMetricsServerAddress starts the exporter on an explicit listen address.
+func StartMetricsServerAddress(addr string, collectors ...prometheus.Collector) (*http.Server, error) {
+	handler, err := Handler(collectors...)
+	if err != nil {
+		return nil, err
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", handler)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen for metrics on %s: %w", addr, err)
+	}
+	server.Addr = listener.Addr().String()
 	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		addr := fmt.Sprintf(":%d", port)
-		fmt.Println("[METRICS] Prometheus exporter listening on", addr)
-		if err := http.ListenAndServe(addr, nil); err != nil {
-			fmt.Printf("[METRICS] Failed to start metrics server: %v\n", err)
+		if serveErr := server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			fmt.Printf("[METRICS] exporter stopped: %v\n", serveErr)
 		}
 	}()
+	fmt.Println("[METRICS] Prometheus exporter listening on", listener.Addr())
+	return server, nil
 }
 
 // PushMetric updates Prometheus metrics for each processed message.

--- a/pkg/metrics/metrics_ext_test.go
+++ b/pkg/metrics/metrics_ext_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAllMetricsRegistered(t *testing.T) {
-	// If any of these are not nil, it means they were initialized.
-	// Since init() calls MustRegister, they should be valid.
+func TestAllMetricsInitialized(t *testing.T) {
+	// Exported metric handles remain initialized even when a runtime collector
+	// owns the corresponding scrape-time metric name.
 	assert.NotNil(t, MessagesProcessed)
 	assert.NotNil(t, MessagesPerSec)
 	assert.NotNil(t, LatencyHist)
@@ -17,7 +17,11 @@ func TestAllMetricsRegistered(t *testing.T) {
 	assert.NotNil(t, SeqNumGapTotal)
 	assert.NotNil(t, SeqNumDuplicateTotal)
 	assert.NotNil(t, ConsumerLag)
-
+	assert.NotNil(t, ClientConnectionsTotal)
+	assert.NotNil(t, ClientConnectionsActive)
+	assert.NotNil(t, CommandsTotal)
+	assert.NotNil(t, CommandDuration)
+	assert.NotNil(t, CommandErrors)
 	assert.NotNil(t, ClusterBrokersTotal)
 	assert.NotNil(t, PartitionLeadersTotal)
 	assert.NotNil(t, ClusterReplicationLag)

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type fixedCollector struct {
+	desc *prometheus.Desc
+}
+
+func (collector fixedCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.desc
+}
+
+func (collector fixedCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(collector.desc, prometheus.GaugeValue, 7)
+}
+
+func TestStartMetricsServerServesRuntimeCollector(t *testing.T) {
+	collector := fixedCollector{desc: prometheus.NewDesc("cursus_test_runtime_value", "test", nil, nil)}
+	server, err := StartMetricsServerAddress("127.0.0.1:0", collector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	})
+
+	response, err := http.Get("http://" + server.Addr + "/metrics") // #nosec G107 -- test server address is loopback-only.
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status = %d", response.StatusCode)
+	}
+	if !strings.Contains(string(body), "cursus_test_runtime_value 7") {
+		t.Fatalf("runtime metric missing from response: %s", body)
+	}
+}
+
+func TestStartMetricsServerReportsBindFailure(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	server, err := StartMetricsServerAddress(listener.Addr().String())
+	if err == nil || server != nil {
+		t.Fatalf("StartMetricsServerAddress() = (%v, %v), want bind error", server, err)
+	}
+}

--- a/pkg/observability/collector.go
+++ b/pkg/observability/collector.go
@@ -1,0 +1,285 @@
+package observability
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	clustercontroller "github.com/cursus-io/cursus/pkg/cluster/controller"
+	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type topicSource interface {
+	RuntimeSnapshot() topic.RuntimeSnapshot
+}
+
+type groupSource interface {
+	ExportState() map[string]*coordinator.GroupStateSnapshot
+}
+
+type diskSource interface {
+	RuntimeSnapshot() disk.RuntimeSnapshot
+}
+
+type streamSource interface {
+	ActiveCount() int
+}
+
+type clusterSource interface {
+	RuntimeSnapshot() clustercontroller.RuntimeSnapshot
+}
+
+// ReadinessSource reports whether the broker is ready to accept client work.
+type ReadinessSource interface {
+	IsReady() bool
+}
+
+// Collector exports scrape-time state rather than retaining stale gauge labels.
+type Collector struct {
+	topics      topicSource
+	groups      groupSource
+	disk        diskSource
+	streams     streamSource
+	cluster     clusterSource
+	readiness   ReadinessSource
+	descriptors []*prometheus.Desc
+
+	ready                  *prometheus.Desc
+	topicCount             *prometheus.Desc
+	partitionCount         *prometheus.Desc
+	logStart               *prometheus.Desc
+	logEnd                 *prometheus.Desc
+	highWatermark          *prometheus.Desc
+	groupMembers           *prometheus.Desc
+	groupGeneration        *prometheus.Desc
+	groupAssignments       *prometheus.Desc
+	groupCommittedOffset   *prometheus.Desc
+	groupLag               *prometheus.Desc
+	legacyGroupLag         *prometheus.Desc
+	groupOffsetOutOfRange  *prometheus.Desc
+	activeStreams          *prometheus.Desc
+	storageHandlers        *prometheus.Desc
+	storageSegments        *prometheus.Desc
+	storageBytes           *prometheus.Desc
+	storagePendingWrites   *prometheus.Desc
+	storageActiveReaders   *prometheus.Desc
+	storageStatFailures    *prometheus.Desc
+	distributionEnabled    *prometheus.Desc
+	clusterBrokers         *prometheus.Desc
+	clusterHasLeader       *prometheus.Desc
+	clusterIsLeader        *prometheus.Desc
+	clusterOffline         *prometheus.Desc
+	clusterUnderReplicated *prometheus.Desc
+	partitionReplicas      *prometheus.Desc
+	partitionInSync        *prometheus.Desc
+	partitionLeaderEpoch   *prometheus.Desc
+	partitionLeader        *prometheus.Desc
+}
+
+// NewCollector creates a broker runtime collector. Nil sources are supported.
+func NewCollector(topics topicSource, groups groupSource, diskState diskSource, streams streamSource, cluster clusterSource, readiness ReadinessSource) *Collector {
+	c := &Collector{
+		topics:                 topics,
+		groups:                 groups,
+		disk:                   diskState,
+		streams:                streams,
+		cluster:                cluster,
+		readiness:              readiness,
+		ready:                  prometheus.NewDesc("cursus_broker_ready", "Whether the broker is ready to accept client work.", nil, nil),
+		topicCount:             prometheus.NewDesc("cursus_broker_topics", "Number of topics loaded by this broker.", nil, nil),
+		partitionCount:         prometheus.NewDesc("cursus_broker_partitions", "Number of topic partitions loaded by this broker.", nil, nil),
+		logStart:               prometheus.NewDesc("cursus_partition_log_start_offset", "Earliest retained offset for a partition.", []string{"topic", "partition"}, nil),
+		logEnd:                 prometheus.NewDesc("cursus_partition_log_end_offset", "Next offset allocated in a partition.", []string{"topic", "partition"}, nil),
+		highWatermark:          prometheus.NewDesc("cursus_partition_high_watermark", "Next offset visible to committed readers.", []string{"topic", "partition"}, nil),
+		groupMembers:           prometheus.NewDesc("cursus_consumer_group_members", "Active members in a consumer group.", []string{"group", "topic"}, nil),
+		groupGeneration:        prometheus.NewDesc("cursus_consumer_group_generation", "Current consumer group generation.", []string{"group", "topic"}, nil),
+		groupAssignments:       prometheus.NewDesc("cursus_consumer_group_assigned_partitions", "Partitions assigned to active group members.", []string{"group", "topic"}, nil),
+		groupCommittedOffset:   prometheus.NewDesc("cursus_consumer_group_committed_offset", "Committed next offset for a consumer group partition.", []string{"group", "topic", "partition"}, nil),
+		groupLag:               prometheus.NewDesc("cursus_consumer_group_lag", "Committed-reader lag, max(high watermark - committed next offset, 0).", []string{"group", "topic", "partition"}, nil),
+		legacyGroupLag:         prometheus.NewDesc("broker_consumer_lag", "Deprecated alias of cursus_consumer_group_lag.", []string{"topic", "partition", "group"}, nil),
+		groupOffsetOutOfRange:  prometheus.NewDesc("cursus_consumer_group_offset_out_of_range", "Whether a committed offset is outside the retained committed-readable range.", []string{"group", "topic", "partition"}, nil),
+		activeStreams:          prometheus.NewDesc("cursus_streams_active", "Currently registered streaming consumers.", nil, nil),
+		storageHandlers:        prometheus.NewDesc("cursus_storage_handlers", "Open partition storage handlers.", nil, nil),
+		storageSegments:        prometheus.NewDesc("cursus_storage_segments", "Open storage segments including active segments.", nil, nil),
+		storageBytes:           prometheus.NewDesc("cursus_storage_bytes", "Bytes used by segment and offset index files for open handlers.", nil, nil),
+		storagePendingWrites:   prometheus.NewDesc("cursus_storage_pending_writes", "Messages waiting in storage write queues.", nil, nil),
+		storageActiveReaders:   prometheus.NewDesc("cursus_storage_active_readers", "Readers currently accessing storage segments.", nil, nil),
+		storageStatFailures:    prometheus.NewDesc("cursus_storage_stat_failures", "Storage files that could not be inspected during this scrape.", nil, nil),
+		distributionEnabled:    prometheus.NewDesc("cursus_distribution_enabled", "Whether distributed cluster mode is enabled.", nil, nil),
+		clusterBrokers:         prometheus.NewDesc("cursus_cluster_brokers", "Brokers present in replicated cluster metadata.", nil, nil),
+		clusterHasLeader:       prometheus.NewDesc("cursus_cluster_has_leader", "Whether this broker can resolve the cluster leader.", nil, nil),
+		clusterIsLeader:        prometheus.NewDesc("cursus_cluster_is_leader", "Whether this broker is the current cluster leader.", nil, nil),
+		clusterOffline:         prometheus.NewDesc("cursus_cluster_offline_partitions", "Partitions without an assigned leader.", nil, nil),
+		clusterUnderReplicated: prometheus.NewDesc("cursus_cluster_under_replicated_partitions", "Partitions whose in-sync replica count is below their replica count.", nil, nil),
+		partitionReplicas:      prometheus.NewDesc("cursus_cluster_partition_replicas", "Configured replica count for a partition.", []string{"topic", "partition"}, nil),
+		partitionInSync:        prometheus.NewDesc("cursus_cluster_partition_in_sync_replicas", "In-sync replica count for a partition.", []string{"topic", "partition"}, nil),
+		partitionLeaderEpoch:   prometheus.NewDesc("cursus_cluster_partition_leader_epoch", "Current partition leader epoch.", []string{"topic", "partition"}, nil),
+		partitionLeader:        prometheus.NewDesc("cursus_cluster_partition_leader", "Current partition leader identity.", []string{"topic", "partition", "broker_id"}, nil),
+	}
+	c.descriptors = []*prometheus.Desc{
+		c.ready, c.topicCount, c.partitionCount, c.logStart, c.logEnd, c.highWatermark,
+		c.groupMembers, c.groupGeneration, c.groupAssignments, c.groupCommittedOffset,
+		c.groupLag, c.legacyGroupLag, c.groupOffsetOutOfRange, c.activeStreams, c.storageHandlers,
+		c.storageSegments, c.storageBytes, c.storagePendingWrites, c.storageActiveReaders,
+		c.storageStatFailures, c.distributionEnabled, c.clusterBrokers, c.clusterHasLeader,
+		c.clusterIsLeader, c.clusterOffline, c.clusterUnderReplicated, c.partitionReplicas,
+		c.partitionInSync, c.partitionLeaderEpoch, c.partitionLeader,
+	}
+	return c
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	for _, descriptor := range c.descriptors {
+		ch <- descriptor
+	}
+}
+
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	ready := false
+	if c.readiness != nil {
+		ready = c.readiness.IsReady()
+	}
+	ch <- gauge(c.ready, boolValue(ready))
+
+	topicState := topic.RuntimeSnapshot{}
+	if c.topics != nil {
+		topicState = c.topics.RuntimeSnapshot()
+	}
+	ch <- gauge(c.topicCount, float64(topicState.TopicCount))
+	ch <- gauge(c.partitionCount, float64(len(topicState.Partitions)))
+	partitionState := make(map[string]topic.PartitionRuntimeSnapshot, len(topicState.Partitions))
+	for _, partition := range topicState.Partitions {
+		partitionLabel := strconv.Itoa(partition.Partition)
+		partitionState[partitionKey(partition.Topic, partition.Partition)] = partition
+		ch <- gauge(c.logStart, float64(partition.LogStart), partition.Topic, partitionLabel)
+		ch <- gauge(c.logEnd, float64(partition.LogEnd), partition.Topic, partitionLabel)
+		ch <- gauge(c.highWatermark, float64(partition.HighWatermark), partition.Topic, partitionLabel)
+	}
+	c.collectGroups(ch, partitionState)
+
+	activeStreams := 0
+	if c.streams != nil {
+		activeStreams = c.streams.ActiveCount()
+	}
+	ch <- gauge(c.activeStreams, float64(activeStreams))
+	c.collectStorage(ch)
+	c.collectCluster(ch)
+}
+
+func (c *Collector) collectGroups(ch chan<- prometheus.Metric, partitions map[string]topic.PartitionRuntimeSnapshot) {
+	if c.groups == nil {
+		return
+	}
+	groups := c.groups.ExportState()
+	names := make([]string, 0, len(groups))
+	for name := range groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		state := groups[name]
+		if state == nil {
+			continue
+		}
+		assignments := 0
+		for _, memberAssignments := range state.Members {
+			assignments += len(memberAssignments)
+		}
+		ch <- gauge(c.groupMembers, float64(len(state.Members)), name, state.TopicName)
+		ch <- gauge(c.groupGeneration, float64(state.Generation), name, state.TopicName)
+		ch <- gauge(c.groupAssignments, float64(assignments), name, state.TopicName)
+
+		positions := make(map[string]uint64)
+		if !strings.ContainsAny(state.TopicName, "*?") {
+			prefix := state.TopicName + "\x00"
+			for key := range partitions {
+				if strings.HasPrefix(key, prefix) {
+					positions[key] = 0
+				}
+			}
+		}
+		for topicName, offsets := range state.Offsets {
+			for partition, offset := range offsets {
+				positions[partitionKey(topicName, partition)] = offset
+			}
+		}
+
+		keys := make([]string, 0, len(positions))
+		for key := range positions {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			partition, exists := partitions[key]
+			if !exists {
+				continue
+			}
+			committed := positions[key]
+			lag := uint64(0)
+			if partition.HighWatermark > committed {
+				lag = partition.HighWatermark - committed
+			}
+			outOfRange := committed < partition.LogStart || committed > partition.HighWatermark
+			partitionLabel := strconv.Itoa(partition.Partition)
+			ch <- gauge(c.groupCommittedOffset, float64(committed), name, partition.Topic, partitionLabel)
+			ch <- gauge(c.groupLag, float64(lag), name, partition.Topic, partitionLabel)
+			ch <- gauge(c.legacyGroupLag, float64(lag), partition.Topic, partitionLabel, name)
+			ch <- gauge(c.groupOffsetOutOfRange, boolValue(outOfRange), name, partition.Topic, partitionLabel)
+		}
+	}
+}
+
+func (c *Collector) collectStorage(ch chan<- prometheus.Metric) {
+	state := disk.RuntimeSnapshot{}
+	if c.disk != nil {
+		state = c.disk.RuntimeSnapshot()
+	}
+	ch <- gauge(c.storageHandlers, float64(state.Handlers))
+	ch <- gauge(c.storageSegments, float64(state.Segments))
+	ch <- gauge(c.storageBytes, float64(state.Bytes))
+	ch <- gauge(c.storagePendingWrites, float64(state.PendingWrites))
+	ch <- gauge(c.storageActiveReaders, float64(state.ActiveReaders))
+	ch <- gauge(c.storageStatFailures, float64(state.StatFailures))
+}
+
+func (c *Collector) collectCluster(ch chan<- prometheus.Metric) {
+	state := clustercontroller.RuntimeSnapshot{}
+	if c.cluster != nil {
+		state = c.cluster.RuntimeSnapshot()
+	}
+	ch <- gauge(c.distributionEnabled, boolValue(state.Enabled))
+	ch <- gauge(c.clusterBrokers, float64(state.BrokerCount))
+	ch <- gauge(c.clusterHasLeader, boolValue(state.HasLeader))
+	ch <- gauge(c.clusterIsLeader, boolValue(state.IsLeader))
+	ch <- gauge(c.clusterOffline, float64(state.Offline))
+	ch <- gauge(c.clusterUnderReplicated, float64(state.UnderReplicated))
+	for _, partition := range state.PartitionDetails {
+		partitionLabel := strconv.Itoa(partition.Partition)
+		ch <- gauge(c.partitionReplicas, float64(partition.Replicas), partition.Topic, partitionLabel)
+		ch <- gauge(c.partitionInSync, float64(partition.InSync), partition.Topic, partitionLabel)
+		ch <- gauge(c.partitionLeaderEpoch, float64(partition.LeaderEpoch), partition.Topic, partitionLabel)
+		if partition.Leader != "" {
+			ch <- gauge(c.partitionLeader, 1, partition.Topic, partitionLabel, partition.Leader)
+		}
+	}
+}
+
+func partitionKey(topicName string, partition int) string {
+	return fmt.Sprintf("%s\x00%d", topicName, partition)
+}
+
+func boolValue(value bool) float64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func gauge(desc *prometheus.Desc, value float64, labels ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, value, labels...)
+}

--- a/pkg/observability/collector_test.go
+++ b/pkg/observability/collector_test.go
@@ -1,0 +1,124 @@
+package observability
+
+import (
+	"testing"
+
+	clustercontroller "github.com/cursus-io/cursus/pkg/cluster/controller"
+	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type fixedTopics struct{ snapshot topic.RuntimeSnapshot }
+
+func (source fixedTopics) RuntimeSnapshot() topic.RuntimeSnapshot { return source.snapshot }
+
+type fixedGroups struct {
+	snapshot map[string]*coordinator.GroupStateSnapshot
+}
+
+func (source fixedGroups) ExportState() map[string]*coordinator.GroupStateSnapshot {
+	return source.snapshot
+}
+
+type fixedDisk struct{ snapshot disk.RuntimeSnapshot }
+
+func (source fixedDisk) RuntimeSnapshot() disk.RuntimeSnapshot { return source.snapshot }
+
+type fixedStreams int
+
+func (source fixedStreams) ActiveCount() int { return int(source) }
+
+type fixedCluster struct {
+	snapshot clustercontroller.RuntimeSnapshot
+}
+
+func (source fixedCluster) RuntimeSnapshot() clustercontroller.RuntimeSnapshot {
+	return source.snapshot
+}
+
+type fixedReadiness bool
+
+func (source fixedReadiness) IsReady() bool { return bool(source) }
+
+func TestCollectorExportsScrapeTimeBrokerState(t *testing.T) {
+	collector := NewCollector(
+		fixedTopics{snapshot: topic.RuntimeSnapshot{
+			TopicCount: 1,
+			Partitions: []topic.PartitionRuntimeSnapshot{{
+				Topic: "orders", Partition: 0, LogStart: 2, LogEnd: 10, HighWatermark: 8,
+			}},
+		}},
+		fixedGroups{snapshot: map[string]*coordinator.GroupStateSnapshot{
+			"workers": {
+				TopicName: "orders", Generation: 3,
+				Members: map[string][]int{"member-1": {0}},
+				Offsets: map[string]map[int]uint64{"orders": {0: 5}},
+			},
+			"new-workers": {TopicName: "orders", Members: map[string][]int{}, Offsets: map[string]map[int]uint64{}},
+			"ahead-workers": {
+				TopicName: "orders", Members: map[string][]int{},
+				Offsets: map[string]map[int]uint64{"orders": {0: 9}},
+			},
+		}},
+		fixedDisk{snapshot: disk.RuntimeSnapshot{Handlers: 1, Segments: 2, Bytes: 4096, PendingWrites: 4, ActiveReaders: 2}},
+		fixedStreams(2),
+		fixedCluster{snapshot: clustercontroller.RuntimeSnapshot{
+			Enabled: true, BrokerCount: 3, HasLeader: true, IsLeader: true, UnderReplicated: 1,
+			PartitionDetails: []clustercontroller.PartitionRuntimeSnapshot{{
+				Topic: "orders", Partition: 0, Leader: "broker-1", LeaderEpoch: 4, Replicas: 3, InSync: 2,
+			}},
+		}},
+		fixedReadiness(true),
+	)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertGauge(t, families, "cursus_broker_ready", nil, 1)
+	assertGauge(t, families, "cursus_partition_high_watermark", map[string]string{"topic": "orders", "partition": "0"}, 8)
+	assertGauge(t, families, "cursus_consumer_group_committed_offset", map[string]string{"group": "workers", "topic": "orders", "partition": "0"}, 5)
+	assertGauge(t, families, "cursus_consumer_group_lag", map[string]string{"group": "workers", "topic": "orders", "partition": "0"}, 3)
+	assertGauge(t, families, "cursus_consumer_group_lag", map[string]string{"group": "new-workers", "topic": "orders", "partition": "0"}, 8)
+	assertGauge(t, families, "cursus_consumer_group_offset_out_of_range", map[string]string{"group": "new-workers", "topic": "orders", "partition": "0"}, 1)
+	assertGauge(t, families, "cursus_consumer_group_offset_out_of_range", map[string]string{"group": "ahead-workers", "topic": "orders", "partition": "0"}, 1)
+	assertGauge(t, families, "cursus_storage_bytes", nil, 4096)
+	assertGauge(t, families, "cursus_streams_active", nil, 2)
+	assertGauge(t, families, "cursus_cluster_under_replicated_partitions", nil, 1)
+	assertGauge(t, families, "cursus_cluster_partition_leader", map[string]string{"topic": "orders", "partition": "0", "broker_id": "broker-1"}, 1)
+}
+
+func assertGauge(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string, want float64) {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if labelsMatch(metric.Label, labels) {
+				if got := metric.GetGauge().GetValue(); got != want {
+					t.Fatalf("%s%v = %v, want %v", name, labels, got, want)
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("metric %s%v not found", name, labels)
+}
+
+func labelsMatch(pairs []*dto.LabelPair, want map[string]string) bool {
+	if len(pairs) != len(want) {
+		return false
+	}
+	for _, pair := range pairs {
+		if want[pair.GetName()] != pair.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/protocol/errors.go
+++ b/pkg/protocol/errors.go
@@ -58,15 +58,15 @@ func buildErrorRegistry() map[string]ErrorClassification {
 	}
 
 	register(ErrorClassRouting, true,
-		"NOT_COORDINATOR", "NOT_LEADER",
+		"NOT_COORDINATOR", "NOT_LEADER", "NOT_PARTITION_LEADER",
 	)
 	register(ErrorClassAvailability, true,
-		"cluster_not_available", "coordinator_not_available", "fsm_not_available",
+		"cluster_metadata_unavailable", "cluster_not_available", "coordinator_not_available", "fsm_not_available",
 		"leader_not_found", "no_raft_leader", "offset_manager_not_available", "router_not_available",
 		"transaction_abort_marker_failed", "transaction_commit_failed", "transaction_manager_not_available", "transaction_sync_failed",
 	)
 	register(ErrorClassFencing, false,
-		"GEN_MISMATCH", "NOT_OWNER", "member_not_found", "producer_fenced", "stale_producer_epoch",
+		"GEN_MISMATCH", "NOT_OWNER", "STALE_LEADER_EPOCH", "member_not_found", "producer_fenced", "stale_producer_epoch",
 	)
 	register(ErrorClassConflict, false,
 		"OFFSET_OUT_OF_RANGE", "offset_regression", "snapshot_version_exceeds_stream",
@@ -80,14 +80,14 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"internal_txn_publish_forbidden", "transaction_metadata_forbidden",
 	)
 	register(ErrorClassNotFound, false,
-		"group_not_found", "partition_not_found", "topic_not_found", "transaction_not_found",
+		"group_not_found", "partition_metadata_not_found", "partition_not_found", "topic_not_found", "transaction_not_found",
 	)
 	register(ErrorClassValidation, false,
 		"UNSUPPORTED_FEATURE", "UNSUPPORTED_PROTOCOL_VERSION", "batch_decode_failed", "decode_failed",
-		"distribution_not_enabled", "distribution_required", "empty_command", "empty_messages",
-		"empty_required_params", "event_sourcing_not_enabled", "invalid_acks", "invalid_batch_commit_format",
+		"distribution_not_enabled", "distribution_required", "duplicate_partition", "empty_command", "empty_messages",
+		"empty_required_params", "event_sourcing_not_enabled", "invalid_acks", "invalid_batch_commit_entry", "invalid_batch_commit_format",
 		"invalid_auth", "invalid_consume_syntax", "invalid_control_batch_bytes", "invalid_control_batch_coordinator_epoch",
-		"invalid_control_batch_version", "invalid_epoch", "invalid_generation", "invalid_is_idempotent",
+		"invalid_control_batch_version", "invalid_commit_watermark", "invalid_epoch", "invalid_generation", "invalid_is_idempotent",
 		"invalid_offset", "invalid_partition", "invalid_partitions", "invalid_payload", "invalid_payload_json",
 		"invalid_protocol_features", "invalid_protocol_version", "invalid_replication_factor", "invalid_require_features",
 		"invalid_transaction_control_batch", "invalid_transaction_control_epoch", "invalid_transaction_control_record",
@@ -95,8 +95,8 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"invalid_transaction_state", "invalid_txn_offsets",
 		"invalid_retention_bytes", "invalid_retention_hours", "invalid_schema_version", "invalid_seq_num",
 		"invalid_snapshot_catchup_response", "invalid_snapshot_payload", "invalid_stream_syntax",
-		"invalid_topic_policy", "invalid_version", "malformed_input", "missing_group", "missing_key",
-		"missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
+		"invalid_topic_policy", "invalid_version", "malformed_input", "missing_generation", "missing_group", "missing_key",
+		"missing_leader_fence", "missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
 		"missing_coordinator_key", "missing_ownership_params", "missing_producer_id", "missing_protocol_version",
 		"missing_required_params", "missing_topic", "missing_transactional_id",
 		"missing_version", "no_valid_offsets", "unknown_command", "unmarshal_failed",

--- a/pkg/protocol/errors_test.go
+++ b/pkg/protocol/errors_test.go
@@ -45,7 +45,16 @@ func TestClassifyFencingAndAvailability(t *testing.T) {
 		{"transaction_manager_not_available", ErrorClassAvailability, true},
 		{"authentication_failed", ErrorClassAuthorization, false},
 		{"coordinator_not_available", ErrorClassAvailability, true},
+		{"cluster_metadata_unavailable", ErrorClassAvailability, true},
+		{"NOT_PARTITION_LEADER", ErrorClassRouting, true},
+		{"STALE_LEADER_EPOCH", ErrorClassFencing, false},
+		{"partition_metadata_not_found", ErrorClassNotFound, false},
+		{"invalid_commit_watermark", ErrorClassValidation, false},
+		{"missing_leader_fence", ErrorClassValidation, false},
+		{"duplicate_partition", ErrorClassValidation, false},
+		{"invalid_batch_commit_entry", ErrorClassValidation, false},
 		{"invalid_partition", ErrorClassValidation, false},
+		{"missing_generation", ErrorClassValidation, false},
 	}
 	for _, test := range tests {
 		got := ClassifyErrorCode(test.code)

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -1,0 +1,203 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cursus-io/cursus/util"
+)
+
+const healthCheckTimeout = 2 * time.Second
+
+type readinessCheck func(context.Context) error
+
+// HealthState tracks startup readiness and dynamic dependency checks.
+type HealthState struct {
+	ready  atomic.Bool
+	mu     sync.RWMutex
+	checks map[string]readinessCheck
+}
+
+func NewHealthState() *HealthState {
+	return &HealthState{checks: make(map[string]readinessCheck)}
+}
+
+func (state *HealthState) SetReady(ready bool) {
+	if state != nil {
+		state.ready.Store(ready)
+	}
+}
+
+func (state *HealthState) AddCheck(name string, check readinessCheck) {
+	if state == nil || strings.TrimSpace(name) == "" || check == nil {
+		return
+	}
+	state.mu.Lock()
+	state.checks[name] = check
+	state.mu.Unlock()
+}
+
+// IsReady reports startup state plus all current dependency checks.
+func (state *HealthState) IsReady() bool {
+	ready, _ := state.report()
+	return ready
+}
+
+func (state *HealthState) report() (bool, map[string]string) {
+	if state == nil || !state.ready.Load() {
+		return false, map[string]string{"broker": "starting"}
+	}
+
+	state.mu.RLock()
+	names := make([]string, 0, len(state.checks))
+	checks := make(map[string]readinessCheck, len(state.checks))
+	for name, check := range state.checks {
+		names = append(names, name)
+		checks[name] = check
+	}
+	state.mu.RUnlock()
+	sort.Strings(names)
+
+	result := make(map[string]string, len(names))
+	ready := true
+	for _, name := range names {
+		ctx, cancel := context.WithTimeout(context.Background(), healthCheckTimeout)
+		err := checks[name](ctx)
+		cancel()
+		if err != nil {
+			ready = false
+			result[name] = err.Error()
+			continue
+		}
+		result[name] = "ok"
+	}
+	return ready, result
+}
+
+type healthResponse struct {
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks,omitempty"`
+}
+
+func newHealthHandler(state *HealthState) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/live", func(w http.ResponseWriter, r *http.Request) {
+		if !allowHealthMethod(w, r) {
+			return
+		}
+		writeHealthJSON(w, http.StatusOK, healthResponse{Status: "live"})
+	})
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		if !allowHealthMethod(w, r) {
+			return
+		}
+		ready, checks := state.report()
+		status := http.StatusOK
+		label := "ready"
+		if !ready {
+			status = http.StatusServiceUnavailable
+			label = "not_ready"
+		}
+		writeHealthJSON(w, status, healthResponse{Status: label, Checks: checks})
+	})
+	compatibilityHandler := func(w http.ResponseWriter, r *http.Request) {
+		if !allowHealthMethod(w, r) {
+			return
+		}
+		ready, checks := state.report()
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if !ready {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if _, err := fmt.Fprintf(w, "Broker not ready: %s", failedChecks(checks)); err != nil {
+				util.Error("health check response write error: %v", err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("OK")); err != nil {
+			util.Error("health check response write error: %v", err)
+		}
+	}
+	mux.HandleFunc("/health", compatibilityHandler)
+	mux.HandleFunc("/", compatibilityHandler)
+	return mux
+}
+
+func allowHealthMethod(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return true
+	}
+	w.Header().Set("Allow", "GET, HEAD")
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return false
+}
+
+func writeHealthJSON(w http.ResponseWriter, status int, response healthResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		util.Error("health check JSON write error: %v", err)
+	}
+}
+
+func failedChecks(checks map[string]string) string {
+	names := make([]string, 0, len(checks))
+	for name, result := range checks {
+		if result != "ok" {
+			names = append(names, name+"="+result)
+		}
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return "unknown"
+	}
+	return strings.Join(names, ",")
+}
+
+// startHealthCheckServer binds synchronously so startup cannot report ready on bind failure.
+func startHealthCheckServer(port int, state *HealthState) (*http.Server, error) {
+	return startHealthCheckServerAddress(fmt.Sprintf(":%d", port), state)
+}
+
+func startHealthCheckServerAddress(addr string, state *HealthState) (*http.Server, error) {
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           newHealthHandler(state),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen for health checks on %s: %w", addr, err)
+	}
+	server.Addr = listener.Addr().String()
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			util.Error("health check server stopped: %v", serveErr)
+		}
+	}()
+	util.Info("Health check endpoint started on %s", listener.Addr())
+	return server, nil
+}
+
+func shutdownHTTPServer(server *http.Server) {
+	if server == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		util.Warn("HTTP server shutdown failed: %v", err)
+	}
+}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -10,9 +10,8 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/cursus-io/cursus/pkg/cluster"
@@ -24,6 +23,7 @@ import (
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/disk"
 	"github.com/cursus-io/cursus/pkg/metrics"
+	"github.com/cursus-io/cursus/pkg/observability"
 	wireprotocol "github.com/cursus-io/cursus/pkg/protocol"
 	"github.com/cursus-io/cursus/pkg/stream"
 	"github.com/cursus-io/cursus/pkg/topic"
@@ -35,19 +35,10 @@ const (
 	DefaultHealthCheckPort = 9080
 )
 
-var brokerReady = &atomic.Bool{}
-
 // RunServer starts the broker with optional TLS and gzip
 func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager, cd *coordinator.Coordinator, sm *stream.StreamManager) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	if cfg.EnableExporter {
-		metrics.StartMetricsServer(cfg.ExporterPort)
-		util.Info("📈 Prometheus exporter started on port %d", cfg.ExporterPort)
-	} else {
-		util.Info("📉 Exporter disabled")
-	}
 
 	addr := fmt.Sprintf(":%d", cfg.BrokerPort)
 	var ln net.Listener
@@ -65,6 +56,7 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 		return err
 	}
 
+	defer func() { _ = ln.Close() }()
 	util.Info("🧩 Broker listening on %s (TLS=%v, Compression=%v)", addr, cfg.UseTLS, cfg.CompressionType)
 
 	if cd != nil {
@@ -166,12 +158,6 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 		util.Info("🌐 Distributed clustering enabled (brokerID=%s, localAddr=%s)", brokerID, localAddr)
 	}
 
-	healthPort := cfg.HealthCheckPort
-	if healthPort == 0 {
-		healthPort = DefaultHealthCheckPort
-	}
-	startHealthCheckServer(healthPort, brokerReady)
-
 	globalCH := controller.NewCommandHandler(tm, cfg, cd, sm, cc)
 	if cd != nil {
 		cd.SetGroupSessionCallbacks(globalCH.IsGroupCoordinator, globalCH.ExpireGroupMembers)
@@ -187,30 +173,89 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 	if err := globalCH.RecoverPreparedTransactions(); err != nil {
 		return fmt.Errorf("failed to recover prepared transactions: %w", err)
 	}
-	brokerReady.Store(true)
 
-	go func() {
-		<-ctx.Done()
-		if err := globalCH.Close(); err != nil {
-			util.Error("Failed to close command handler: %v", err)
+	healthState := NewHealthState()
+	healthState.AddCheck("storage", func(context.Context) error {
+		if tm == nil || dm == nil {
+			return fmt.Errorf("storage subsystem unavailable")
 		}
-	}()
+		return dm.Ready()
+	})
+	if cfg.EnabledDistribution {
+		healthState.AddCheck("cluster_leader", func(context.Context) error {
+			if cc == nil {
+				return fmt.Errorf("cluster controller unavailable")
+			}
+			_, leaderErr := cc.GetClusterLeader()
+			return leaderErr
+		})
+	}
+
+	runtimeCollector := observability.NewCollector(tm, cd, dm, sm, cc, healthState)
+	if cfg.EnableExporter {
+		metricsServer, startErr := metrics.StartMetricsServer(cfg.ExporterPort, runtimeCollector)
+		if startErr != nil {
+			return fmt.Errorf("start metrics exporter: %w", startErr)
+		}
+		defer shutdownHTTPServer(metricsServer)
+		util.Info("📈 Prometheus exporter started on port %d", cfg.ExporterPort)
+	} else {
+		util.Info("📉 Exporter disabled")
+	}
+
+	healthPort := cfg.HealthCheckPort
+	if healthPort == 0 {
+		healthPort = DefaultHealthCheckPort
+	}
+	healthServer, healthErr := startHealthCheckServer(healthPort, healthState)
+	if healthErr != nil {
+		return fmt.Errorf("start health server: %w", healthErr)
+	}
+	defer shutdownHTTPServer(healthServer)
 
 	workerCh := make(chan net.Conn, maxWorkers)
+	var workerWG sync.WaitGroup
 	for i := 0; i < maxWorkers; i++ {
+		workerWG.Add(1)
 		go func() {
+			defer workerWG.Done()
 			for conn := range workerCh {
 				handleConn(ctx, conn, globalCH)
 			}
 		}()
 	}
+	defer func() {
+		healthState.SetReady(false)
+		cancel()
+		close(workerCh)
+		workerWG.Wait()
+		if err := globalCH.Close(); err != nil {
+			util.Error("Failed to close command handler: %v", err)
+		}
+	}()
 
+	var temporaryDelay time.Duration
 	for {
+		healthState.SetReady(true)
 		conn, err := ln.Accept()
 		if err != nil {
-			util.Error("⚠️ Accept error: %v", err)
+			if errors.Is(err, net.ErrClosed) {
+				return fmt.Errorf("broker listener closed: %w", err)
+			}
+			healthState.SetReady(false)
+			if temporaryDelay == 0 {
+				temporaryDelay = 5 * time.Millisecond
+			} else {
+				temporaryDelay *= 2
+			}
+			if maximum := time.Second; temporaryDelay > maximum {
+				temporaryDelay = maximum
+			}
+			util.Warn("accept error; retrying in %s: %v", temporaryDelay, err)
+			time.Sleep(temporaryDelay)
 			continue
 		}
+		temporaryDelay = 0
 		workerCh <- conn
 	}
 }
@@ -269,8 +314,15 @@ func handleInternalConn(ctx context.Context, conn net.Conn, cmdHandler *controll
 	handleConnWithContext(ctx, conn, cmdHandler, controller.NewInternalClientContext("default-group", 0))
 }
 
+func observeClientConnection() func() {
+	metrics.ClientConnectionsTotal.Inc()
+	metrics.ClientConnectionsActive.Inc()
+	return metrics.ClientConnectionsActive.Dec
+}
+
 // handleConn processes a connection using a shared CommandHandler.
 func handleConn(ctx context.Context, conn net.Conn, cmdHandler *controller.CommandHandler) {
+	defer observeClientConnection()()
 	handleConnWithContext(ctx, conn, cmdHandler, controller.NewClientContext("default-group", 0))
 }
 
@@ -286,6 +338,11 @@ func handleConnWithContext(ctx context.Context, conn net.Conn, cmdHandler *contr
 	defer cancel()
 
 	for {
+		select {
+		case <-clientCtx.Done():
+			return
+		default:
+		}
 		if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 			util.Error("⚠️ SetReadDeadline error: %v", err)
 			return
@@ -328,6 +385,7 @@ func handleConnWithContext(ctx context.Context, conn net.Conn, cmdHandler *contr
 // HandleConnection processes a single client connection (creates a new CommandHandler per call).
 // Deprecated: prefer handleConn with a shared CommandHandler to avoid file descriptor leaks.
 func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager, cfg *config.Config, cd *coordinator.Coordinator, sm *stream.StreamManager, cc *clusterController.ClusterController) {
+	defer observeClientConnection()()
 	isStreamed := false
 	defer func() {
 		if !isStreamed {
@@ -342,6 +400,11 @@ func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager
 	defer func() { _ = cmdHandler.Close() }()
 
 	for {
+		select {
+		case <-clientCtx.Done():
+			return
+		default:
+		}
 		if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 			util.Error("⚠️ SetReadDeadline error: %v", err)
 			return
@@ -405,6 +468,9 @@ func readMessage(conn net.Conn, compressionType string) ([]byte, error) {
 	}
 
 	msgLen := binary.BigEndian.Uint32(lenBuf)
+	if msgLen > uint32(util.MaxMessageSize) {
+		return nil, fmt.Errorf("message size %d exceeds maximum %d", msgLen, util.MaxMessageSize)
+	}
 	msgBuf := make([]byte, msgLen)
 	if _, err := io.ReadFull(conn, msgBuf); err != nil {
 		if err != io.EOF {
@@ -652,35 +718,4 @@ func writeResponse(conn net.Conn, msg string) {
 		util.Error("⚠️ Write response error: %v", err)
 		return
 	}
-}
-
-// startHealthCheckServer starts a simple HTTP server for health checks
-func startHealthCheckServer(port int, brokerReady *atomic.Bool) {
-	mux := http.NewServeMux()
-	healthHandler := func(w http.ResponseWriter, r *http.Request) {
-		if !brokerReady.Load() {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			if _, err := w.Write([]byte("Broker not ready: Main listener not active")); err != nil {
-				util.Error("⚠️ Health check response write error: %v", err)
-			}
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("OK")); err != nil {
-			util.Error("⚠️ Health check response write error: %v", err)
-		}
-	}
-
-	mux.HandleFunc("/health", healthHandler)
-	mux.HandleFunc("/", healthHandler)
-
-	addr := fmt.Sprintf(":%d", port)
-
-	go func() {
-		if err := http.ListenAndServe(addr, mux); err != nil {
-			util.Error("❌ Health check server failed: %v", err)
-		}
-	}()
-	util.Info("🩺 Health check endpoint started on port %d", port)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,11 +3,11 @@ package server
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"io"
 	"net"
 	"net/http"
-	"sync/atomic"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -141,64 +141,59 @@ func TestIsCommand_CaseInsensitive(t *testing.T) {
 	assert.True(t, isCommand("stream t"))
 }
 
-func TestHealthCheckServer(t *testing.T) {
-	ready := &atomic.Bool{}
-	ready.Store(false)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	assert.NoError(t, err)
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
-	startHealthCheckServer(port, ready)
-
-	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
-	var resp *http.Response
-	for i := 0; i < 20; i++ {
-		resp, err = http.Get(url)
-		if err == nil {
-			break
+func TestHealthHandlerSeparatesLivenessAndReadiness(t *testing.T) {
+	state := NewHealthState()
+	dependencyReady := false
+	state.AddCheck("cluster_leader", func(context.Context) error {
+		if !dependencyReady {
+			return errors.New("no leader")
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-	body, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, string(body), "Broker not ready")
-	_ = resp.Body.Close()
+		return nil
+	})
+	handler := newHealthHandler(state)
 
-	ready.Store(true)
-	resp, err = http.Get(url)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	body, _ = io.ReadAll(resp.Body)
-	assert.Equal(t, "OK", string(body))
-	_ = resp.Body.Close()
+	live := httptest.NewRecorder()
+	handler.ServeHTTP(live, httptest.NewRequest(http.MethodGet, "/live", nil))
+	assert.Equal(t, http.StatusOK, live.Code)
+
+	legacy := httptest.NewRecorder()
+	handler.ServeHTTP(legacy, httptest.NewRequest(http.MethodGet, "/health", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, legacy.Code)
+	assert.Contains(t, legacy.Body.String(), "broker=starting")
+
+	state.SetReady(true)
+	ready := httptest.NewRecorder()
+	handler.ServeHTTP(ready, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, ready.Code)
+	assert.Contains(t, ready.Body.String(), `"cluster_leader":"no leader"`)
+
+	dependencyReady = true
+	ready = httptest.NewRecorder()
+	handler.ServeHTTP(ready, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	assert.Equal(t, http.StatusOK, ready.Code)
+	assert.Contains(t, ready.Body.String(), `"status":"ready"`)
+
+	legacy = httptest.NewRecorder()
+	handler.ServeHTTP(legacy, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, legacy.Code)
+	assert.Equal(t, "OK", legacy.Body.String())
 }
 
-func TestHealthCheckServer_RootEndpoint(t *testing.T) {
-	ready := &atomic.Bool{}
-	ready.Store(true)
+func TestHealthHandlerRejectsMutationMethods(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	newHealthHandler(NewHealthState()).ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/ready", nil))
+	assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+	assert.Equal(t, "GET, HEAD", recorder.Header().Get("Allow"))
+}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+func TestHealthCheckServerReportsBindFailure(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
+	defer func() { _ = listener.Close() }()
 
-	startHealthCheckServer(port, ready)
-
-	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
-	var resp *http.Response
-	for i := 0; i < 20; i++ {
-		resp, err = http.Get(url)
-		if err == nil {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	_ = resp.Body.Close()
+	server, err := startHealthCheckServerAddress(listener.Addr().String(), NewHealthState())
+	assert.Error(t, err)
+	assert.Nil(t, server)
 }
 
 func TestWriteResponse(t *testing.T) {
@@ -323,6 +318,20 @@ func TestReadMessage_PartialBody(t *testing.T) {
 
 	_, err := readMessage(client, "none")
 	assert.Error(t, err)
+}
+
+func TestReadMessage_RejectsOversizedFrameBeforeReadingBody(t *testing.T) {
+	client, server := newTestConnPair(t)
+
+	go func() {
+		lenBuf := make([]byte, 4)
+		binary.BigEndian.PutUint32(lenBuf, uint32(util.MaxMessageSize+1))
+		_, _ = server.Write(lenBuf)
+	}()
+
+	_, err := readMessage(client, "none")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
 func TestReadMessage_WithGzipCompression(t *testing.T) {

--- a/pkg/stream/runtime.go
+++ b/pkg/stream/runtime.go
@@ -1,0 +1,12 @@
+package stream
+
+// ActiveCount returns the number of currently registered streaming consumers.
+func (sm *StreamManager) ActiveCount() int {
+	if sm == nil {
+		return 0
+	}
+
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return len(sm.streams)
+}

--- a/pkg/stream/runtime_test.go
+++ b/pkg/stream/runtime_test.go
@@ -1,0 +1,23 @@
+package stream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestActiveCountUsesCurrentRegistry(t *testing.T) {
+	manager := NewStreamManager(10, time.Minute, time.Minute)
+	if got := manager.ActiveCount(); got != 0 {
+		t.Fatalf("empty ActiveCount = %d", got)
+	}
+	manager.mu.Lock()
+	manager.streams["orders:0:workers"] = &StreamConnection{}
+	manager.mu.Unlock()
+	if got := manager.ActiveCount(); got != 1 {
+		t.Fatalf("ActiveCount = %d, want 1", got)
+	}
+	var nilManager *StreamManager
+	if got := nilManager.ActiveCount(); got != 0 {
+		t.Fatalf("nil ActiveCount = %d", got)
+	}
+}

--- a/pkg/topic/runtime.go
+++ b/pkg/topic/runtime.go
@@ -1,0 +1,55 @@
+package topic
+
+import "sort"
+
+// PartitionRuntimeSnapshot is a point-in-time view used by broker observability.
+type PartitionRuntimeSnapshot struct {
+	Topic         string
+	Partition     int
+	LogStart      uint64
+	LogEnd        uint64
+	HighWatermark uint64
+}
+
+// RuntimeSnapshot is a point-in-time view of topics and partitions.
+type RuntimeSnapshot struct {
+	TopicCount int
+	Partitions []PartitionRuntimeSnapshot
+}
+
+// RuntimeSnapshot returns a race-safe copy of broker topic state.
+func (tm *TopicManager) RuntimeSnapshot() RuntimeSnapshot {
+	if tm == nil {
+		return RuntimeSnapshot{}
+	}
+
+	tm.mu.RLock()
+	topics := make([]*Topic, 0, len(tm.topics))
+	for _, current := range tm.topics {
+		topics = append(topics, current)
+	}
+	tm.mu.RUnlock()
+
+	sort.Slice(topics, func(i, j int) bool { return topics[i].Name < topics[j].Name })
+	snapshot := RuntimeSnapshot{TopicCount: len(topics)}
+	for _, current := range topics {
+		current.mu.RLock()
+		partitions := append([]*Partition(nil), current.Partitions...)
+		current.mu.RUnlock()
+
+		for _, partition := range partitions {
+			if partition == nil {
+				continue
+			}
+			snapshot.Partitions = append(snapshot.Partitions, PartitionRuntimeSnapshot{
+				Topic:         current.Name,
+				Partition:     partition.ID(),
+				LogStart:      partition.GetFirstOffset(),
+				LogEnd:        partition.NextOffset(),
+				HighWatermark: partition.GetHWM(),
+			})
+		}
+	}
+
+	return snapshot
+}

--- a/pkg/topic/runtime_test.go
+++ b/pkg/topic/runtime_test.go
@@ -1,0 +1,26 @@
+package topic
+
+import (
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicManagerRuntimeSnapshot(t *testing.T) {
+	handler := new(MockStorageHandler)
+	handler.On("GetLatestOffset").Return(uint64(4)).Once()
+	handler.On("GetFirstOffset").Return(uint64(2)).Once()
+	provider := new(MockHandlerProvider)
+	provider.On("GetHandler", "orders", 0).Return(handler, nil).Once()
+
+	manager := NewTopicManager(config.DefaultConfig(), provider, nil)
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+	snapshot := manager.RuntimeSnapshot()
+
+	require.Equal(t, 1, snapshot.TopicCount)
+	require.Len(t, snapshot.Partitions, 1)
+	require.Equal(t, PartitionRuntimeSnapshot{
+		Topic: "orders", Partition: 0, LogStart: 2, LogEnd: 5, HighWatermark: 5,
+	}, snapshot.Partitions[0])
+}

--- a/pkg/topic/runtime_test.go
+++ b/pkg/topic/runtime_test.go
@@ -21,6 +21,6 @@ func TestTopicManagerRuntimeSnapshot(t *testing.T) {
 	require.Equal(t, 1, snapshot.TopicCount)
 	require.Len(t, snapshot.Partitions, 1)
 	require.Equal(t, PartitionRuntimeSnapshot{
-		Topic: "orders", Partition: 0, LogStart: 2, LogEnd: 5, HighWatermark: 5,
+		Topic: "orders", Partition: 0, LogStart: 2, LogEnd: 4, HighWatermark: 4,
 	}, snapshot.Partitions[0])
 }

--- a/test/cluster/docker-compose.yml
+++ b/test/cluster/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     networks:
       - cluster_network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 3s
       timeout: 1s
       retries: 3
@@ -45,7 +45,7 @@ services:
       - BOOTSTRAP_CLUSTER=false
     depends_on:
       broker-1:
-        condition: service_healthy
+        condition: service_started
     volumes:
       - ./config.yaml:/root/config.yaml:ro
     tmpfs:
@@ -56,7 +56,7 @@ services:
       - "9102:9100"
       - "8002:8000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 3s
       timeout: 1s
       retries: 3
@@ -78,7 +78,7 @@ services:
       - BOOTSTRAP_CLUSTER=false
     depends_on:
       broker-1:
-        condition: service_healthy
+        condition: service_started
     volumes:
       - ./config.yaml:/root/config.yaml:ro
     tmpfs:
@@ -89,7 +89,7 @@ services:
       - "9103:9100"
       - "8003:8000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 3s
       timeout: 1s
       retries: 3

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - test_network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 2s
       timeout: 1s
       retries: 3

--- a/test/e2e-cluster/docker-compose.yml
+++ b/test/e2e-cluster/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - ../cluster/config.yaml:/root/config.yaml
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 3s
       timeout: 1s
       retries: 3
@@ -46,13 +46,13 @@ services:
     volumes:
       - ../cluster/config.yaml:/root/config.yaml
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 3s
       timeout: 1s
       retries: 3
     depends_on:
       broker-1:
-        condition: service_healthy
+        condition: service_started
     networks:
       - cluster_network
 
@@ -76,13 +76,13 @@ services:
     volumes:
       - ../cluster/config.yaml:/root/config.yaml
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 3s
       timeout: 1s
       retries: 3
     depends_on:
       broker-1:
-        condition: service_healthy
+        condition: service_started
     networks:
       - cluster_network
 

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     networks:    
       - test_network  
     healthcheck:    
-      test: ["CMD", "curl", "-f", "http://localhost:9080/health"]    
+      test: ["CMD", "curl", "-f", "http://localhost:9080/ready"]
       interval: 10s    
       timeout: 5s    
       retries: 5    


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off.
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes

## Summary

This PR adds production health probes and scrape-time runtime metrics for brokers, consumer groups, partitions, replication, storage, and streams.

## Changes

- Add `/live`, `/ready`, and backward-compatible `/health` endpoints.
- Report command latency/results, connections, group lag, partition bounds, cluster state, and storage activity.
- Calculate lag from the committed high watermark and remove stale label state at scrape time.
- Wire liveness/readiness probes into Compose and Helm deployments without cluster bootstrap deadlock.
- Reject oversized wire frames before allocation.
- Replace the observability reference with the implemented metric and alert contract.

## Validation

- `go test ./pkg/... ./sdk/... -count=1`
- `go vet ./pkg/... ./sdk/...`
- `go build ./cmd/broker ./cmd/cli`
- Standalone Docker health, metrics, and command instrumentation verification.
- Three-node Docker readiness and leader/replication metric verification.
- Compose configuration and Helm template rendering checks.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.
