### PR TITLE
feat: align Go SDK with broker contracts

### DIFF
--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -457,7 +457,7 @@ and every partition.
 
 **COMMIT_OFFSET**
 ```
-COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N> [member=<actual-id> generation=<N>]
+COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N> member=<actual-id> generation=<N>
 ```
 Response: `OK`
 
@@ -465,7 +465,9 @@ The `offset` value is the next offset to read after the client has processed
 records. Commits are durable and monotonic per `(topic, group, partition)`.
 Committing the same offset is idempotent. Committing an offset lower than the
 current committed offset returns an error and does not move the stored offset
-backward.
+backward. `member` and `generation` are required and must identify the current
+partition owner; missing values are validation errors and stale values are fencing
+errors.
 
 **BATCH_COMMIT**
 ```
@@ -482,6 +484,8 @@ included partition. The broker validates `member` and `generation` before applyi
 the batch. If any partition is not owned by that member in that generation, the
 entire batch is rejected with `ERROR: NOT_OWNER ...`. Stale generations return
 `ERROR: GEN_MISMATCH ...`, and unknown members return `ERROR: member_not_found ...`.
+The whole batch is also rejected before any offset changes when `generation` is
+missing, an entry is malformed, or the same partition appears more than once.
 
 
 #### Transaction Coordinator
@@ -828,7 +832,16 @@ SDKs should parse the code and fields first, use `class` for broad handling, and
 | `offset_regression reason="..."` | Commit lower than current stored offset | Treat commit as failed; refetch offset |
 | `stale_producer_epoch producer=<id> current=<N> got=<N>` | Idempotent producer request uses an older fenced epoch | Treat as fatal for that producer instance; create a new producer session |
 | `OFFSET_OUT_OF_RANGE requested=N earliest=N latest=N` | Requested offset is older than retained log or beyond available range | Treat as data loss or reset according to policy |
-| `no_valid_offsets` | BATCH_COMMIT parse failure | Check format: `P<N>:<offset>` |
+| `no_valid_offsets` | BATCH_COMMIT contains no usable offsets | Supply at least one `P<N>:<offset>` entry |
+| `missing_generation command=<command>` | Group command omitted its generation | Rejoin if needed and send the current generation |
+| `invalid_batch_commit_entry entry=<entry>` | BATCH_COMMIT entry is not `P<N>:<offset>` | Correct the malformed entry and retry |
+| `duplicate_partition partition=N group=<G> topic=<T>` | BATCH_COMMIT repeats a partition | Send one next offset per partition; no offsets were committed |
+| `NOT_PARTITION_LEADER leader=<id> requested_leader=<id>` | Replication reached a broker that is not the current partition leader | Refresh partition metadata and retry against the leader |
+| `STALE_LEADER_EPOCH current=N requested=N` | Replication request carries a fenced leader epoch | Discard the stale leader session and refresh metadata |
+| `cluster_metadata_unavailable command=REPLICATE_MESSAGE` | Cluster metadata subsystem is temporarily unavailable | Back off and retry |
+| `partition_metadata_not_found topic=<T> partition=N` | Partition metadata does not exist | Refresh metadata and verify topic/partition |
+| `missing_leader_fence command=REPLICATE_MESSAGE` | Internal replication omitted leader ID or epoch | Correct the broker request; do not retry unchanged |
+| `invalid_commit_watermark reason="..."` | Commit watermark is ahead of local durable data or otherwise invalid | Repair/catch up the replica before retrying |
 | invalid_control_batch_bytes field=<key|value> | Broker-internal transaction control bytes are not valid base64 | Reject the internal publish and inspect broker compatibility |
 | `version_conflict current=N expected=N` | Optimistic concurrency failure | Reload aggregate and retry |
 | `event_sourcing_not_enabled topic=<X>` | ES command on non-ES topic | CREATE topic with `event_sourcing=true` |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -194,6 +194,12 @@ ERROR: missing_payload command=REPLICATE_MESSAGE
 ERROR: unmarshal_failed reason="..."
 ERROR: topic_not_found topic=<name>
 ERROR: partition_not_found partition=<N>
+ERROR: cluster_metadata_unavailable command=REPLICATE_MESSAGE
+ERROR: partition_metadata_not_found topic=<name> partition=<N>
+ERROR: missing_leader_fence command=REPLICATE_MESSAGE
+ERROR: NOT_PARTITION_LEADER leader=<broker-id> requested_leader=<broker-id>
+ERROR: STALE_LEADER_EPOCH current=<N> requested=<N>
+ERROR: invalid_commit_watermark reason="..."
 ERROR: replica_append_failed reason="..."
 ```
 
@@ -357,10 +363,10 @@ When no offset has been committed, the broker returns `OK offset=0`.
 ### COMMIT_OFFSET
 
 ```text
-COMMIT_OFFSET topic=<name> group=<group> partition=<N> offset=<nextOffset> [member=<member-id> generation=<N>]
+COMMIT_OFFSET topic=<name> group=<group> partition=<N> offset=<nextOffset> member=<member-id> generation=<N>
 ```
 
-The offset is the next offset to read after successful processing. Commits are monotonic per `(topic, group, partition)`: a commit lower than the current offset fails and does not rewind the group. When `member` or `generation` is supplied, both must be present and the member must own the partition in that generation. Legacy clients may omit both fields, but group-aware SDKs should send them.
+The offset is the next offset to read after successful processing. Commits are monotonic per `(topic, group, partition)`: a commit lower than the current offset fails and does not rewind the group. `member` and `generation` are required, and the member must own the partition in that generation.
 
 Success:
 
@@ -372,6 +378,7 @@ Common errors:
 
 ```text
 ERROR: invalid_offset
+ERROR: missing_generation command=COMMIT_OFFSET
 ERROR: invalid_generation command=COMMIT_OFFSET
 ERROR: offset_regression reason="..."
 ERROR: GEN_MISMATCH current=<N> requested=<N> group=<group> member=<member-id>
@@ -398,7 +405,10 @@ Common errors:
 
 ```text
 ERROR: invalid_batch_commit_format
+ERROR: invalid_batch_commit_entry entry=<entry>
+ERROR: missing_generation command=BATCH_COMMIT
 ERROR: invalid_generation command=BATCH_COMMIT
+ERROR: duplicate_partition partition=<N> group=<group> topic=<topic>
 ERROR: no_valid_offsets
 ERROR: offset_regression reason="..."
 ERROR: GEN_MISMATCH current=<N> requested=<N> group=<group> member=<member-id>

--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -72,6 +72,8 @@ flowchart TB
 | Partition Leader Routing | ✅ | ✅ | ✅ |
 | Protocol capability negotiation | ✅ | pending | pending |
 | Typed structured broker errors | ✅ | pending | pending |
+| Broker-managed transactions | ✅ | pending | pending |
+| Connection authentication | ✅ | pending | pending |
 | Framework Integration | — | Spring Boot | FastAPI |
 | Iterator Pattern | — | — | ✅ for/async for |
 
@@ -130,3 +132,88 @@ if errors.As(err, &brokerErr) {
 ```
 
 `BrokerError` exposes `Code`, `Class`, `Retryable`, `Fields`, and the raw response. It also remains compatible with existing Go SDK sentinels such as `ErrTopicNotFound`, `ErrInvalidPartition`, and `ErrNotLeader` through `errors.Is`.
+
+## Go Transactional Producer
+
+The Go SDK exposes both the existing low-level transaction commands and a
+session-preserving `TransactionalProducer`:
+
+```go
+cfg := sdk.NewDefaultConsumerConfig()
+cfg.BrokerAddrs = []string{"broker-1:9000", "broker-2:9000"}
+
+client, err := sdk.NewConsumerClient(cfg)
+if err != nil {
+    return err
+}
+producer, err := client.NewTransactionalProducer("game-server-events")
+if err != nil {
+    return err
+}
+if err := producer.Begin(); err != nil {
+    return err
+}
+if err := producer.Publish("events", -1, sdk.Message{
+    SeqNum:  1,
+    Key:     "match-42",
+    Payload: payload,
+}); err != nil {
+    _ = producer.Abort()
+    return err
+}
+if err := producer.SendOffsets(
+    "events",
+    groupID,
+    memberID,
+    generation,
+    map[int]uint64{partition: lastProcessedOffset + 1},
+); err != nil {
+    _ = producer.Abort()
+    return err
+}
+return producer.Commit()
+```
+
+The broker allocates and fences the producer ID and epoch. The high-level
+producer retains that session across reconnects and serializes lifecycle calls.
+`NOT_COORDINATOR` responses update a per-transaction coordinator cache and are
+retried with a bounded delay. Fencing, authorization, validation, and ambiguous
+network failures are returned to the caller as errors rather than retried.
+
+`Commit` and `Abort` may be called again with the same session after an
+uncertain response. The broker is authoritative for final transaction state;
+`Describe` returns the typed state, message count, and offset count.
+
+## Go Consumer Resume Contract
+
+The Go consumer fetches the broker-owned committed `nextOffset` after
+assignment and rejoin. Applications that commit after processing should commit
+`lastProcessedOffset + 1`. Reconnects roll back the local fetch position to the
+last broker-committed offset, providing at-least-once processing.
+
+`AutoOffsetResetEarliest` and `AutoOffsetResetLatest` are sent as
+`autoOffsetReset=earliest|latest` in polling and streaming commands.
+`AutoOffsetResetError` leaves reset selection disabled and surfaces an
+out-of-range condition.
+
+The current broker data path is committed-only: transactional records remain
+hidden until a commit marker is durable, open transactions form the visibility
+boundary, and aborted records are skipped. The Go SDK does not expose a
+`read_uncommitted` option because that is not part of the current broker wire
+contract.
+
+## Go Client Authentication
+
+Publisher and consumer configs accept connection credentials:
+
+```go
+cfg.Principal = "game-server"
+cfg.AuthToken = os.Getenv("CURSUS_AUTH_TOKEN")
+```
+
+When both fields are set, every new or reconnected SDK connection performs
+`AUTH principal=<principal> token=<token>` after protocol negotiation and
+before application commands. The two fields must be configured together.
+Authentication and authorization failures are returned as typed
+`*sdk.BrokerError` values. TLS remains required when credentials cross an
+untrusted network.

--- a/pkg/protocol/errors.go
+++ b/pkg/protocol/errors.go
@@ -58,15 +58,15 @@ func buildErrorRegistry() map[string]ErrorClassification {
 	}
 
 	register(ErrorClassRouting, true,
-		"NOT_COORDINATOR", "NOT_LEADER",
+		"NOT_COORDINATOR", "NOT_LEADER", "NOT_PARTITION_LEADER",
 	)
 	register(ErrorClassAvailability, true,
-		"cluster_not_available", "coordinator_not_available", "fsm_not_available",
+		"cluster_metadata_unavailable", "cluster_not_available", "coordinator_not_available", "fsm_not_available",
 		"leader_not_found", "no_raft_leader", "offset_manager_not_available", "router_not_available",
 		"transaction_abort_marker_failed", "transaction_commit_failed", "transaction_manager_not_available", "transaction_sync_failed",
 	)
 	register(ErrorClassFencing, false,
-		"GEN_MISMATCH", "NOT_OWNER", "member_not_found", "producer_fenced", "stale_producer_epoch",
+		"GEN_MISMATCH", "NOT_OWNER", "STALE_LEADER_EPOCH", "member_not_found", "producer_fenced", "stale_producer_epoch",
 	)
 	register(ErrorClassConflict, false,
 		"OFFSET_OUT_OF_RANGE", "offset_regression", "snapshot_version_exceeds_stream",
@@ -80,14 +80,14 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"internal_txn_publish_forbidden", "transaction_metadata_forbidden",
 	)
 	register(ErrorClassNotFound, false,
-		"group_not_found", "partition_not_found", "topic_not_found", "transaction_not_found",
+		"group_not_found", "partition_metadata_not_found", "partition_not_found", "topic_not_found", "transaction_not_found",
 	)
 	register(ErrorClassValidation, false,
 		"UNSUPPORTED_FEATURE", "UNSUPPORTED_PROTOCOL_VERSION", "batch_decode_failed", "decode_failed",
-		"distribution_not_enabled", "distribution_required", "empty_command", "empty_messages",
-		"empty_required_params", "event_sourcing_not_enabled", "invalid_acks", "invalid_batch_commit_format",
+		"distribution_not_enabled", "distribution_required", "duplicate_partition", "empty_command", "empty_messages",
+		"empty_required_params", "event_sourcing_not_enabled", "invalid_acks", "invalid_batch_commit_entry", "invalid_batch_commit_format",
 		"invalid_auth", "invalid_consume_syntax", "invalid_control_batch_bytes", "invalid_control_batch_coordinator_epoch",
-		"invalid_control_batch_version", "invalid_epoch", "invalid_generation", "invalid_is_idempotent",
+		"invalid_control_batch_version", "invalid_commit_watermark", "invalid_epoch", "invalid_generation", "invalid_is_idempotent",
 		"invalid_offset", "invalid_partition", "invalid_partitions", "invalid_payload", "invalid_payload_json",
 		"invalid_protocol_features", "invalid_protocol_version", "invalid_replication_factor", "invalid_require_features",
 		"invalid_transaction_control_batch", "invalid_transaction_control_epoch", "invalid_transaction_control_record",
@@ -95,8 +95,8 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"invalid_transaction_state", "invalid_txn_offsets",
 		"invalid_retention_bytes", "invalid_retention_hours", "invalid_schema_version", "invalid_seq_num",
 		"invalid_snapshot_catchup_response", "invalid_snapshot_payload", "invalid_stream_syntax",
-		"invalid_topic_policy", "invalid_version", "malformed_input", "missing_group", "missing_key",
-		"missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
+		"invalid_topic_policy", "invalid_version", "malformed_input", "missing_generation", "missing_group", "missing_key",
+		"missing_leader_fence", "missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
 		"missing_coordinator_key", "missing_ownership_params", "missing_producer_id", "missing_protocol_version",
 		"missing_required_params", "missing_topic", "missing_transactional_id",
 		"missing_version", "no_valid_offsets", "unknown_command", "unmarshal_failed",

--- a/pkg/protocol/errors_test.go
+++ b/pkg/protocol/errors_test.go
@@ -45,7 +45,16 @@ func TestClassifyFencingAndAvailability(t *testing.T) {
 		{"transaction_manager_not_available", ErrorClassAvailability, true},
 		{"authentication_failed", ErrorClassAuthorization, false},
 		{"coordinator_not_available", ErrorClassAvailability, true},
+		{"cluster_metadata_unavailable", ErrorClassAvailability, true},
+		{"NOT_PARTITION_LEADER", ErrorClassRouting, true},
+		{"STALE_LEADER_EPOCH", ErrorClassFencing, false},
+		{"partition_metadata_not_found", ErrorClassNotFound, false},
+		{"invalid_commit_watermark", ErrorClassValidation, false},
+		{"missing_leader_fence", ErrorClassValidation, false},
+		{"duplicate_partition", ErrorClassValidation, false},
+		{"invalid_batch_commit_entry", ErrorClassValidation, false},
 		{"invalid_partition", ErrorClassValidation, false},
+		{"missing_generation", ErrorClassValidation, false},
 	}
 	for _, test := range tests {
 		got := ClassifyErrorCode(test.code)

--- a/sdk/auth.go
+++ b/sdk/auth.go
@@ -1,0 +1,49 @@
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+const authenticationTimeout = 5 * time.Second
+
+func authenticateConfiguredClient(conn net.Conn, principal, token string) error {
+	if principal == "" && token == "" {
+		return nil
+	}
+	if principal == "" || token == "" {
+		return fmt.Errorf("principal and auth token must be configured together")
+	}
+	if strings.ContainsAny(principal, " \t\r\n") {
+		return fmt.Errorf("principal must not contain whitespace")
+	}
+	if strings.ContainsAny(token, " \t\r\n") {
+		return fmt.Errorf("auth token must not contain whitespace")
+	}
+	if conn == nil {
+		return fmt.Errorf("authentication connection is nil")
+	}
+	if err := conn.SetDeadline(time.Now().Add(authenticationTimeout)); err != nil {
+		return fmt.Errorf("set authentication deadline: %w", err)
+	}
+	defer func() { _ = conn.SetDeadline(time.Time{}) }()
+
+	cmd := fmt.Sprintf("AUTH principal=%s token=%s", principal, token)
+	if err := WriteWithLength(conn, EncodeMessage("", cmd)); err != nil {
+		return fmt.Errorf("send authentication command: %w", err)
+	}
+	resp, err := ReadWithLength(conn)
+	if err != nil {
+		return fmt.Errorf("read authentication response: %w", err)
+	}
+	value := strings.TrimSpace(string(resp))
+	if brokerErr, ok := ParseBrokerError(value); ok {
+		return brokerErr
+	}
+	if _, err := parseOKResponse(value); err != nil {
+		return fmt.Errorf("unexpected authentication response: %s", value)
+	}
+	return nil
+}

--- a/sdk/auth_contract_test.go
+++ b/sdk/auth_contract_test.go
@@ -1,0 +1,73 @@
+package sdk
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestAuthenticateConfiguredClientSendsExactCommand(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		request, err := ReadWithLength(server)
+		if err != nil {
+			done <- err
+			return
+		}
+		if got := string(request[2:]); got != "AUTH principal=game-server token=secret-token" {
+			done <- errors.New("unexpected auth command: " + got)
+			return
+		}
+		done <- WriteWithLength(server, []byte("OK principal=game-server"))
+	}()
+
+	if err := authenticateConfiguredClient(client, "game-server", "secret-token"); err != nil {
+		t.Fatalf("authenticate failed: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthenticateConfiguredClientPreservesBrokerError(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		_, _ = ReadWithLength(server)
+		_ = WriteWithLength(server, []byte("ERROR: authentication_failed class=authorization retryable=false"))
+	}()
+
+	err := authenticateConfiguredClient(client, "game-server", "wrong-token")
+	var brokerErr *BrokerError
+	if !errors.As(err, &brokerErr) {
+		t.Fatalf("expected BrokerError, got %T: %v", err, err)
+	}
+	if brokerErr.Code != "authentication_failed" || brokerErr.Class != ErrorClassAuthorization {
+		t.Fatalf("unexpected broker error: %+v", brokerErr)
+	}
+}
+
+func TestAuthenticateConfiguredClientValidatesCredentialPair(t *testing.T) {
+	if err := authenticateConfiguredClient(nil, "", ""); err != nil {
+		t.Fatalf("empty credentials should disable authentication: %v", err)
+	}
+	for _, test := range []struct {
+		principal string
+		token     string
+	}{
+		{principal: "game-server"},
+		{token: "secret-token"},
+		{principal: "game server", token: "secret-token"},
+		{principal: "game-server", token: "secret token"},
+	} {
+		if err := authenticateConfiguredClient(nil, test.principal, test.token); err == nil {
+			t.Fatalf("invalid credentials accepted: principal=%q token=%q", test.principal, test.token)
+		}
+	}
+}

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -39,6 +39,9 @@ type PublisherConfig struct {
 	TLSCertPath string `yaml:"tls_cert_path" json:"tls_cert_path"`
 	TLSKeyPath  string `yaml:"tls_key_path" json:"tls_key_path"`
 
+	Principal string `yaml:"principal" json:"principal"`
+	AuthToken string `yaml:"auth_token" json:"auth_token"`
+
 	ProtocolVersion              int      `yaml:"protocol_version" json:"protocol_version"`
 	ProtocolFeatures             []string `yaml:"protocol_features" json:"protocol_features"`
 	RequireProtocolFeatures      bool     `yaml:"require_protocol_features" json:"require_protocol_features"`
@@ -137,6 +140,9 @@ type ConsumerConfig struct {
 	UseTLS      bool   `yaml:"use_tls" json:"use_tls"`
 	TLSCertPath string `yaml:"tls_cert_path" json:"tls_cert_path"`
 	TLSKeyPath  string `yaml:"tls_key_path" json:"tls_key_path"`
+
+	Principal string `yaml:"principal" json:"principal"`
+	AuthToken string `yaml:"auth_token" json:"auth_token"`
 
 	ProtocolVersion              int      `yaml:"protocol_version" json:"protocol_version"`
 	ProtocolFeatures             []string `yaml:"protocol_features" json:"protocol_features"`

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -2,9 +2,11 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -355,9 +357,14 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "BATCH_COMMIT topic=%s group=%s generation=%d member=%s ",
 		c.config.Topic, c.config.GroupID, generation, memberID)
-	parts := make([]string, 0, len(offsets))
-	for pid, off := range offsets {
-		parts = append(parts, fmt.Sprintf("P%d:%d", pid, off))
+	partitions := make([]int, 0, len(offsets))
+	for pid := range offsets {
+		partitions = append(partitions, pid)
+	}
+	sort.Ints(partitions)
+	parts := make([]string, 0, len(partitions))
+	for _, pid := range partitions {
+		parts = append(parts, fmt.Sprintf("P%d:%d", pid, offsets[pid]))
 	}
 	sb.WriteString(strings.Join(parts, ","))
 
@@ -385,7 +392,7 @@ func (c *Consumer) sendBatchCommit(offsets map[int]uint64) bool {
 	}
 
 	respStr := string(resp)
-	if strings.HasPrefix(respStr, "OK") {
+	if hasOKStatus(respStr) {
 		return true
 	}
 
@@ -443,15 +450,19 @@ func (c *Consumer) directCommit(partition int, offset uint64) error {
 		return fmt.Errorf("direct commit response: %w", err)
 	}
 
-	respStr := string(resp)
-	if strings.Contains(respStr, "ERROR") {
+	respStr := strings.TrimSpace(string(resp))
+	if brokerErr, ok := ParseBrokerError(respStr); ok {
 		if c.handleNotCoordinator(respStr) {
-			return fmt.Errorf("coordinator moved: %s", respStr)
+			return brokerErr
 		}
-		if strings.Contains(respStr, "GEN_MISMATCH") || strings.Contains(respStr, "NOT_OWNER") || strings.Contains(respStr, "member_not_found") {
+		switch strings.ToUpper(brokerErr.Code) {
+		case "GEN_MISMATCH", "NOT_OWNER", "REBALANCE_REQUIRED", "MEMBER_NOT_FOUND":
 			go c.handleRebalanceSignal()
 		}
-		return fmt.Errorf("direct commit error: %s", respStr)
+		return brokerErr
+	}
+	if !hasOKStatus(respStr) {
+		return fmt.Errorf("unexpected direct commit response: %s", respStr)
 	}
 	return nil
 }
@@ -491,7 +502,7 @@ func (c *Consumer) fetchMetadata() error {
 	}
 
 	respStr := strings.TrimSpace(string(resp))
-	if !strings.HasPrefix(respStr, "OK") {
+	if !hasOKStatus(respStr) {
 		return fmt.Errorf("metadata failed: %s", respStr)
 	}
 
@@ -612,9 +623,10 @@ func (c *Consumer) joinGroup() (int64, string, []int, error) {
 	if c.handleNotCoordinator(respStr) {
 		return 0, "", nil, fmt.Errorf("coordinator moved, retry")
 	}
-	if !strings.HasPrefix(respStr, "OK") {
-		if resuming && strings.Contains(respStr, "GEN_MISMATCH") {
-			currentText := parseOKFields(respStr)["current"]
+	if !hasOKStatus(respStr) {
+		brokerErr, hasBrokerErr := ParseBrokerError(respStr)
+		if resuming && hasBrokerErr && strings.EqualFold(brokerErr.Code, "GEN_MISMATCH") {
+			currentText := brokerErr.Fields["current"]
 			current, parseErr := strconv.ParseInt(currentText, 10, 64)
 			if parseErr == nil {
 				assignments, syncErr := c.syncGroup(current, mID)
@@ -623,7 +635,7 @@ func (c *Consumer) joinGroup() (int64, string, []int, error) {
 				}
 			}
 		}
-		if resuming && strings.Contains(respStr, "member_not_found") {
+		if resuming && hasBrokerErr && strings.EqualFold(brokerErr.Code, "member_not_found") {
 			c.mu.Lock()
 			if c.memberID == mID {
 				c.memberID = ""
@@ -668,7 +680,7 @@ func (c *Consumer) syncGroup(generation int64, memberID string) ([]int, error) {
 	}
 
 	respStr := strings.TrimSpace(string(resp))
-	if !strings.HasPrefix(respStr, "OK") {
+	if !hasOKStatus(respStr) {
 		return nil, fmt.Errorf("sync rejected: %s", respStr)
 	}
 
@@ -745,40 +757,46 @@ func (c *Consumer) fetchOffset(partition int) (uint64, error) {
 	}
 
 	respStr := strings.TrimSpace(string(resp))
-	if c.handleNotCoordinator(respStr) {
-		return 0, fmt.Errorf("NOT_COORDINATOR during fetch offset")
+	if brokerErr, ok := ParseBrokerError(respStr); ok {
+		_ = c.handleNotCoordinator(respStr)
+		return 0, brokerErr
 	}
 	return parseFetchOffsetResponse(respStr)
 }
 
 func isRetryableFetchOffsetError(err error) bool {
-	if err == nil {
+	var brokerErr *BrokerError
+	if !errors.As(err, &brokerErr) {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "group_not_found") ||
-		strings.Contains(msg, "member_not_found") ||
-		strings.Contains(msg, "NOT_COORDINATOR")
+	if brokerErr.Retryable {
+		return true
+	}
+	switch strings.ToLower(brokerErr.Code) {
+	case "group_not_found", "member_not_found", "not_coordinator":
+		return true
+	default:
+		return false
+	}
 }
 
 func parseFetchOffsetResponse(respStr string) (uint64, error) {
-	if strings.HasPrefix(respStr, "ERROR:") {
-		return 0, fmt.Errorf("fetch offset broker error: %s", respStr)
+	if brokerErr, ok := ParseBrokerError(respStr); ok {
+		return 0, brokerErr
 	}
-
-	if !strings.HasPrefix(respStr, "OK") {
+	fields, err := parseOKResponse(respStr)
+	if err != nil {
 		return 0, fmt.Errorf("unexpected offset response: %s", respStr)
 	}
-	for _, part := range strings.Fields(respStr) {
-		if strings.HasPrefix(part, "offset=") {
-			offset, err := strconv.ParseUint(strings.TrimPrefix(part, "offset="), 10, 64)
-			if err != nil {
-				return 0, fmt.Errorf("invalid offset response: %s", respStr)
-			}
-			return offset, nil
-		}
+	offsetValue := fields["offset"]
+	if offsetValue == "" {
+		return 0, fmt.Errorf("missing offset in response: %s", respStr)
 	}
-	return 0, fmt.Errorf("missing offset in response: %s", respStr)
+	offset, err := strconv.ParseUint(offsetValue, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid offset response: %s", respStr)
+	}
+	return offset, nil
 }
 
 // ─── Close ────────────────────────────────────────────────────────────────────
@@ -879,18 +897,15 @@ func (c *Consumer) findCoordinator() (string, error) {
 	}
 
 	respStr := strings.TrimSpace(string(resp))
-	if !strings.HasPrefix(respStr, "OK") {
+	if brokerErr, ok := ParseBrokerError(respStr); ok {
+		return "", brokerErr
+	}
+	fields, err := parseOKResponse(respStr)
+	if err != nil {
 		return "", fmt.Errorf("find_coordinator failed: %s", respStr)
 	}
 
-	var host, port string
-	for _, part := range strings.Fields(respStr) {
-		if strings.HasPrefix(part, "host=") {
-			host = strings.TrimPrefix(part, "host=")
-		} else if strings.HasPrefix(part, "port=") {
-			port = strings.TrimPrefix(part, "port=")
-		}
-	}
+	host, port := fields["host"], fields["port"]
 	if host == "" || port == "" {
 		return "", fmt.Errorf("find_coordinator: missing host/port in response: %s", respStr)
 	}
@@ -945,17 +960,11 @@ func isLoopbackCoordinatorHost(host string) bool {
 }
 
 func (c *Consumer) handleNotCoordinator(respStr string) bool {
-	if !strings.Contains(respStr, "NOT_COORDINATOR") {
+	brokerErr, ok := ParseBrokerError(strings.TrimSpace(respStr))
+	if !ok || !strings.EqualFold(brokerErr.Code, "NOT_COORDINATOR") {
 		return false
 	}
-	var host, port string
-	for _, part := range strings.Fields(respStr) {
-		if strings.HasPrefix(part, "host=") {
-			host = strings.TrimPrefix(part, "host=")
-		} else if strings.HasPrefix(part, "port=") {
-			port = strings.TrimPrefix(part, "port=")
-		}
-	}
+	host, port := brokerErr.Fields["host"], brokerErr.Fields["port"]
 	if host != "" && port != "" {
 		newAddr := c.coordinatorAddrFromHostPort(host, port)
 		c.mu.Lock()

--- a/sdk/consumer_client.go
+++ b/sdk/consumer_client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,10 +20,11 @@ type consumerLeaderInfo struct {
 
 // ConsumerClient manages broker connections with leader-aware failover.
 type ConsumerClient struct {
-	ID        string
-	config    *ConsumerConfig
-	leader    atomic.Pointer[consumerLeaderInfo]
-	tlsConfig *tls.Config
+	ID                      string
+	config                  *ConsumerConfig
+	leader                  atomic.Pointer[consumerLeaderInfo]
+	tlsConfig               *tls.Config
+	transactionCoordinators sync.Map // transactional_id -> advertised client address
 }
 
 func NewConsumerClient(cfg *ConsumerConfig) (*ConsumerClient, error) {
@@ -92,6 +94,10 @@ func (c *ConsumerClient) Connect(addr string) (net.Conn, error) {
 	if err := negotiateConfiguredProtocol(conn, c.config.ProtocolVersion, c.config.ProtocolFeatures, c.config.RequireProtocolFeatures, c.config.ProtocolNegotiationTimeoutMS); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("protocol negotiation with %s failed: %w", addr, err)
+	}
+	if err := authenticateConfiguredClient(conn, c.config.Principal, c.config.AuthToken); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("authenticate with %s: %w", addr, err)
 	}
 	return conn, nil
 }

--- a/sdk/consumer_command_contract_test.go
+++ b/sdk/consumer_command_contract_test.go
@@ -1,0 +1,32 @@
+package sdk
+
+import "testing"
+
+func TestAutoOffsetResetArgumentMatchesBrokerContract(t *testing.T) {
+	tests := []struct {
+		policy AutoOffsetResetPolicy
+		want   string
+	}{
+		{policy: "", want: " autoOffsetReset=earliest"},
+		{policy: AutoOffsetResetEarliest, want: " autoOffsetReset=earliest"},
+		{policy: AutoOffsetResetLatest, want: " autoOffsetReset=latest"},
+		{policy: AutoOffsetResetError, want: ""},
+		{policy: "unsupported", want: " autoOffsetReset=earliest"},
+	}
+	for _, test := range tests {
+		if got := autoOffsetResetArgument(test.policy); got != test.want {
+			t.Fatalf("policy %q: want %q, got %q", test.policy, test.want, got)
+		}
+	}
+}
+
+func TestHasOKStatusRequiresExactToken(t *testing.T) {
+	if !hasOKStatus("OK state=ready") {
+		t.Fatal("valid OK response was rejected")
+	}
+	for _, response := range []string{"", "OKAY state=ready", "prefix OK", "ERROR: failed"} {
+		if hasOKStatus(response) {
+			t.Fatalf("invalid response accepted: %q", response)
+		}
+	}
+}

--- a/sdk/consumer_test.go
+++ b/sdk/consumer_test.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -292,18 +293,14 @@ func TestParseFetchOffsetResponse_StrictContract(t *testing.T) {
 }
 
 func TestIsRetryableFetchOffsetError(t *testing.T) {
-	assert.True(t, isRetryableFetchOffsetError(&fetchOffsetTestError{msg: "fetch offset broker error: ERROR: NOT_COORDINATOR host=broker-2 port=9000"}))
-	assert.True(t, isRetryableFetchOffsetError(&fetchOffsetTestError{msg: "fetch offset broker error: ERROR: group_not_found group=g1"}))
-	assert.True(t, isRetryableFetchOffsetError(&fetchOffsetTestError{msg: "fetch offset broker error: ERROR: member_not_found member=m1"}))
-	assert.False(t, isRetryableFetchOffsetError(&fetchOffsetTestError{msg: "fetch offset broker error: ERROR: offset_manager_not_available"}))
+	assert.True(t, isRetryableFetchOffsetError(&BrokerError{Code: "NOT_COORDINATOR"}))
+	assert.True(t, isRetryableFetchOffsetError(&BrokerError{Code: "group_not_found"}))
+	assert.True(t, isRetryableFetchOffsetError(&BrokerError{Code: "member_not_found"}))
+	assert.True(t, isRetryableFetchOffsetError(&BrokerError{Code: "broker_busy", Retryable: true}))
+	assert.False(t, isRetryableFetchOffsetError(&BrokerError{Code: "offset_manager_not_available"}))
+	assert.False(t, isRetryableFetchOffsetError(errors.New("NOT_COORDINATOR in unstructured text")))
 	assert.False(t, isRetryableFetchOffsetError(nil))
 }
-
-type fetchOffsetTestError struct {
-	msg string
-}
-
-func (e *fetchOffsetTestError) Error() string { return e.msg }
 
 func TestParseListOffsetsResponse(t *testing.T) {
 	ranges, err := parseListOffsetsResponse("OK topic=t partitions=2 offsets=P0:earliest=0:latest=10:leo=12:hwm=11,P1:earliest=3:latest=7:leo=8:hwm=7")

--- a/sdk/partition.go
+++ b/sdk/partition.go
@@ -166,8 +166,8 @@ func (pc *PartitionConsumer) pollAndProcess() {
 	memberID, generation := c.memberID, c.generation
 	c.mu.RUnlock()
 
-	consumeCmd := fmt.Sprintf("CONSUME topic=%s partition=%d offset=%d group=%s generation=%d member=%s batch=%d",
-		c.config.Topic, pc.partitionID, currentOffset, c.config.GroupID, generation, memberID, effectivePollBatchSize(c.config))
+	consumeCmd := fmt.Sprintf("CONSUME topic=%s partition=%d offset=%d group=%s generation=%d member=%s%s batch=%d",
+		c.config.Topic, pc.partitionID, currentOffset, c.config.GroupID, generation, memberID, autoOffsetResetArgument(c.config.AutoOffsetReset), effectivePollBatchSize(c.config))
 
 	if err := WriteWithLength(conn, EncodeMessage("", consumeCmd)); err != nil {
 		LogError("Partition [%d] send CONSUME failed: %v", pc.partitionID, err)
@@ -291,8 +291,8 @@ func (pc *PartitionConsumer) startStreamLoop() {
 		memberID, generation := c.memberID, c.generation
 		c.mu.RUnlock()
 
-		streamCmd := fmt.Sprintf("STREAM topic=%s partition=%d group=%s offset=%d generation=%d member=%s batch=%d",
-			c.config.Topic, pid, c.config.GroupID, currentOffset, generation, memberID, effectiveStreamBatchSize(c.config))
+		streamCmd := fmt.Sprintf("STREAM topic=%s partition=%d group=%s offset=%d generation=%d member=%s%s batch=%d",
+			c.config.Topic, pid, c.config.GroupID, currentOffset, generation, memberID, autoOffsetResetArgument(c.config.AutoOffsetReset), effectiveStreamBatchSize(c.config))
 
 		if err := WriteWithLength(conn, EncodeMessage("", streamCmd)); err != nil {
 			LogError("Partition [%d] STREAM send failed: %v", pid, err)
@@ -814,5 +814,18 @@ func (pc *PartitionConsumer) closeConnection() {
 	if pc.conn != nil {
 		_ = pc.conn.Close()
 		pc.conn = nil
+	}
+}
+
+func autoOffsetResetArgument(policy AutoOffsetResetPolicy) string {
+	switch policy {
+	case AutoOffsetResetLatest:
+		return " autoOffsetReset=latest"
+	case AutoOffsetResetError:
+		return ""
+	case "", AutoOffsetResetEarliest:
+		return " autoOffsetReset=earliest"
+	default:
+		return " autoOffsetReset=earliest"
 	}
 }

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -145,6 +145,10 @@ func (p *Producer) fetchMetadata() {
 			_ = conn.Close()
 			continue
 		}
+		if err := authenticateConfiguredClient(conn, p.config.Principal, p.config.AuthToken); err != nil {
+			_ = conn.Close()
+			continue
+		}
 		cmd := fmt.Sprintf("METADATA topic=%s", p.config.Topic)
 		if err := WriteWithLength(conn, EncodeMessage("", cmd)); err != nil {
 			_ = conn.Close()
@@ -200,6 +204,9 @@ func (p *Producer) CreateTopic(topic string, partitions int) error {
 
 	if err := negotiateConfiguredProtocol(conn, p.config.ProtocolVersion, p.config.ProtocolFeatures, p.config.RequireProtocolFeatures, p.config.ProtocolNegotiationTimeoutMS); err != nil {
 		return fmt.Errorf("protocol negotiation: %w", err)
+	}
+	if err := authenticateConfiguredClient(conn, p.config.Principal, p.config.AuthToken); err != nil {
+		return fmt.Errorf("authentication: %w", err)
 	}
 	createCmd := fmt.Sprintf("CREATE topic=%s partitions=%d idempotent=%t", topic, partitions, p.config.EnableIdempotence)
 	cmdBytes := EncodeMessage("admin", createCmd)

--- a/sdk/producer_client.go
+++ b/sdk/producer_client.go
@@ -103,6 +103,10 @@ func (pc *ProducerClient) connectPartitionLocked(idx int, addr string) error {
 		_ = conn.Close()
 		return fmt.Errorf("protocol negotiation with %s failed: %w", addr, err)
 	}
+	if err := authenticateConfiguredClient(conn, pc.config.Principal, pc.config.AuthToken); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("authenticate with %s: %w", addr, err)
+	}
 
 	var currentConns []net.Conn
 	if ptr := pc.conns.Load(); ptr != nil {

--- a/sdk/response.go
+++ b/sdk/response.go
@@ -15,3 +15,8 @@ func parseOKFields(resp string) map[string]string {
 	}
 	return out
 }
+
+func hasOKStatus(resp string) bool {
+	fields := strings.Fields(strings.TrimSpace(resp))
+	return len(fields) > 0 && fields[0] == "OK"
+}

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -1,11 +1,17 @@
 package sdk
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 )
+
+const transactionCommandTimeout = 10 * time.Second
 
 type ProducerSession struct {
 	TransactionalID string
@@ -13,15 +19,101 @@ type ProducerSession struct {
 	Epoch           int64
 }
 
+type TransactionStatusInfo struct {
+	TransactionalID string
+	State           string
+	Messages        int
+	Offsets         int
+}
+
+// TransactionalProducer preserves the broker-owned producer session and
+// serializes lifecycle calls for one transactional ID.
+type TransactionalProducer struct {
+	mu      sync.Mutex
+	client  *ConsumerClient
+	session ProducerSession
+}
+
+func (c *ConsumerClient) NewTransactionalProducer(transactionalID string) (*TransactionalProducer, error) {
+	session, err := c.InitProducerID(transactionalID)
+	if err != nil {
+		return nil, err
+	}
+	return &TransactionalProducer{client: c, session: session}, nil
+}
+
+func (p *TransactionalProducer) Session() ProducerSession {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.session
+}
+
+// Reinitialize obtains a new epoch and fences callers that still use the old session.
+func (p *TransactionalProducer) Reinitialize() (ProducerSession, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	session, err := p.client.InitProducerID(p.session.TransactionalID)
+	if err != nil {
+		return ProducerSession{}, err
+	}
+	p.session = session
+	return session, nil
+}
+
+func (p *TransactionalProducer) Begin() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.client.BeginTransaction(p.session.TransactionalID, p.session.ProducerID, p.session.Epoch)
+}
+
+func (p *TransactionalProducer) Publish(topic string, partition int, msg Message) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	msg.ProducerID = p.session.ProducerID
+	msg.Epoch = p.session.Epoch
+	return p.client.TransactionalPublish(p.session.TransactionalID, topic, partition, msg)
+}
+
+func (p *TransactionalProducer) SendOffsets(topic, group, member string, generation int, offsets map[int]uint64) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.client.SendOffsetsToTransaction(p.session.TransactionalID, p.session.ProducerID, topic, group, member, generation, p.session.Epoch, offsets)
+}
+
+func (p *TransactionalProducer) Commit() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.client.EndTransaction(p.session.TransactionalID, p.session.ProducerID, p.session.Epoch, true)
+}
+
+func (p *TransactionalProducer) Abort() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.client.EndTransaction(p.session.TransactionalID, p.session.ProducerID, p.session.Epoch, false)
+}
+
+func (p *TransactionalProducer) Describe() (TransactionStatusInfo, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.client.DescribeTransaction(p.session.TransactionalID)
+}
+
 func (c *ConsumerClient) InitProducerID(transactionalID string) (ProducerSession, error) {
-	resp, err := c.execTxnCommand(fmt.Sprintf("INIT_PRODUCER_ID transactional_id=%s", transactionalID))
+	if err := validateTransactionToken("transactional ID", transactionalID); err != nil {
+		return ProducerSession{}, err
+	}
+	resp, err := c.execTxnCommand(transactionalID, fmt.Sprintf("INIT_PRODUCER_ID transactional_id=%s", transactionalID))
 	if err != nil {
 		return ProducerSession{}, err
 	}
 	return parseProducerSession(resp)
 }
+
 func parseProducerSession(resp string) (ProducerSession, error) {
-	fields := parseOKFields(resp)
+	fields, err := parseOKResponse(resp)
+	if err != nil {
+		return ProducerSession{}, err
+	}
 	txnID := fields["transactional_id"]
 	producerID := fields["producerId"]
 	if producerID == "" {
@@ -38,12 +130,34 @@ func parseProducerSession(resp string) (ProducerSession, error) {
 }
 
 func (c *ConsumerClient) BeginTransaction(transactionalID, producerID string, epoch int64) error {
+	if err := validateTransactionOwner(transactionalID, producerID); err != nil {
+		return err
+	}
 	cmd := fmt.Sprintf("BEGIN_TXN transactional_id=%s producerId=%s epoch=%d", transactionalID, producerID, epoch)
-	_, err := c.execTxnCommand(cmd)
+	_, err := c.execTxnCommand(transactionalID, cmd)
 	return err
 }
 
 func (c *ConsumerClient) TransactionalPublish(transactionalID, topic string, partition int, msg Message) error {
+	if err := validateTransactionOwner(transactionalID, msg.ProducerID); err != nil {
+		return err
+	}
+	if err := validateTransactionToken("topic", topic); err != nil {
+		return err
+	}
+	if partition < -1 {
+		return fmt.Errorf("transactional publish partition must be -1 or non-negative")
+	}
+	if msg.SeqNum == 0 {
+		return fmt.Errorf("transactional publish sequence must be greater than zero")
+	}
+	if msg.Payload == "" {
+		return fmt.Errorf("transactional publish payload is required")
+	}
+	if strings.ContainsAny(msg.Payload, "\r\n") {
+		return fmt.Errorf("transactional publish payload must not contain line breaks")
+	}
+
 	cmd := fmt.Sprintf("TXN_PUBLISH transactional_id=%s topic=%s partition=%d producerId=%s seqNum=%d epoch=%d", transactionalID, topic, partition, msg.ProducerID, msg.SeqNum, msg.Epoch)
 	if msg.Key != "" {
 		if strings.ContainsAny(msg.Key, " \t\r\n") {
@@ -52,46 +166,177 @@ func (c *ConsumerClient) TransactionalPublish(transactionalID, topic string, par
 		cmd += fmt.Sprintf(" key=%s", msg.Key)
 	}
 	cmd += " message=" + msg.Payload
-	_, err := c.execTxnCommand(cmd)
+	_, err := c.execTxnCommand(transactionalID, cmd)
 	return err
 }
 
 func (c *ConsumerClient) SendOffsetsToTransaction(transactionalID, producerID, topic, group, member string, generation int, epoch int64, offsets map[int]uint64) error {
-	pairs := make([]string, 0, len(offsets))
-	partitions := make([]int, 0, len(offsets))
-	for partition := range offsets {
-		partitions = append(partitions, partition)
+	cmd, err := buildSendOffsetsToTransactionCommand(transactionalID, producerID, topic, group, member, generation, epoch, offsets)
+	if err != nil {
+		return err
 	}
-	sort.Ints(partitions)
-	for _, partition := range partitions {
-		pairs = append(pairs, fmt.Sprintf("P%d:%d", partition, offsets[partition]))
-	}
-	cmd := fmt.Sprintf("SEND_OFFSETS_TO_TXN transactional_id=%s producerId=%s epoch=%d topic=%s group=%s member=%s generation=%d %s", transactionalID, producerID, epoch, topic, group, member, generation, strings.Join(pairs, ","))
-	_, err := c.execTxnCommand(cmd)
+	_, err = c.execTxnCommand(transactionalID, cmd)
 	return err
 }
 
+func buildSendOffsetsToTransactionCommand(transactionalID, producerID, topic, group, member string, generation int, epoch int64, offsets map[int]uint64) (string, error) {
+	if err := validateTransactionOwner(transactionalID, producerID); err != nil {
+		return "", err
+	}
+	if err := validateTransactionToken("topic", topic); err != nil {
+		return "", err
+	}
+	if err := validateTransactionToken("group", group); err != nil {
+		return "", err
+	}
+	if err := validateTransactionToken("member", member); err != nil {
+		return "", err
+	}
+	if generation < 0 {
+		return "", fmt.Errorf("transaction generation must be non-negative")
+	}
+	if len(offsets) == 0 {
+		return "", fmt.Errorf("transaction offsets must not be empty")
+	}
+
+	partitions := make([]int, 0, len(offsets))
+	for partition := range offsets {
+		if partition < 0 {
+			return "", fmt.Errorf("transaction offset partition must be non-negative: %d", partition)
+		}
+		partitions = append(partitions, partition)
+	}
+	sort.Ints(partitions)
+	pairs := make([]string, 0, len(partitions))
+	for _, partition := range partitions {
+		pairs = append(pairs, fmt.Sprintf("P%d:%d", partition, offsets[partition]))
+	}
+	return fmt.Sprintf("SEND_OFFSETS_TO_TXN transactional_id=%s producerId=%s epoch=%d topic=%s group=%s member=%s generation=%d %s", transactionalID, producerID, epoch, topic, group, member, generation, strings.Join(pairs, ",")), nil
+}
+
 func (c *ConsumerClient) EndTransaction(transactionalID, producerID string, epoch int64, commit bool) error {
+	if err := validateTransactionOwner(transactionalID, producerID); err != nil {
+		return err
+	}
 	result := "abort"
 	if commit {
 		result = "commit"
 	}
 	cmd := fmt.Sprintf("END_TXN transactional_id=%s producerId=%s epoch=%d result=%s", transactionalID, producerID, epoch, result)
-	_, err := c.execTxnCommand(cmd)
+	_, err := c.execTxnCommand(transactionalID, cmd)
 	return err
 }
 
+// TransactionStatus preserves the original raw response API for compatibility.
 func (c *ConsumerClient) TransactionStatus(transactionalID string) (string, error) {
-	return c.execTxnCommand(fmt.Sprintf("TXN_STATUS transactional_id=%s", transactionalID))
-}
-
-func (c *ConsumerClient) execTxnCommand(cmd string) (string, error) {
-	conn, _, err := c.ConnectWithFailover()
-	if err != nil {
+	if err := validateTransactionToken("transactional ID", transactionalID); err != nil {
 		return "", err
 	}
-	defer func() { _ = conn.Close() }()
+	return c.execTxnCommand(transactionalID, fmt.Sprintf("TXN_STATUS transactional_id=%s", transactionalID))
+}
 
+// DescribeTransaction returns the broker transaction status as typed fields.
+func (c *ConsumerClient) DescribeTransaction(transactionalID string) (TransactionStatusInfo, error) {
+	resp, err := c.TransactionStatus(transactionalID)
+	if err != nil {
+		return TransactionStatusInfo{}, err
+	}
+	return parseTransactionStatus(resp)
+}
+
+func parseTransactionStatus(resp string) (TransactionStatusInfo, error) {
+	fields, err := parseOKResponse(resp)
+	if err != nil {
+		return TransactionStatusInfo{}, err
+	}
+	status := TransactionStatusInfo{
+		TransactionalID: fields["transactional_id"],
+		State:           fields["state"],
+	}
+	if status.TransactionalID == "" || status.State == "" {
+		return TransactionStatusInfo{}, fmt.Errorf("transaction status response missing transactional_id or state: %s", resp)
+	}
+	status.Messages, err = strconv.Atoi(fields["messages"])
+	if err != nil || status.Messages < 0 {
+		return TransactionStatusInfo{}, fmt.Errorf("invalid transaction message count %q", fields["messages"])
+	}
+	status.Offsets, err = strconv.Atoi(fields["offsets"])
+	if err != nil || status.Offsets < 0 {
+		return TransactionStatusInfo{}, fmt.Errorf("invalid transaction offset count %q", fields["offsets"])
+	}
+	return status, nil
+}
+
+func (c *ConsumerClient) execTxnCommand(transactionalID, cmd string) (string, error) {
+	const maxRedirects = 5
+	var lastErr error
+	for attempt := 0; attempt < maxRedirects; attempt++ {
+		conn, _, err := c.connectTransactionCoordinator(transactionalID)
+		if err != nil {
+			return "", err
+		}
+		resp, commandErr := executeTransactionCommand(conn, cmd)
+		_ = conn.Close()
+		if commandErr == nil {
+			return resp, nil
+		}
+
+		var brokerErr *BrokerError
+		if !errors.As(commandErr, &brokerErr) || !strings.EqualFold(brokerErr.Code, "NOT_COORDINATOR") {
+			return "", commandErr
+		}
+		addr, addrErr := c.transactionCoordinatorAddress(brokerErr)
+		if addrErr != nil {
+			return "", fmt.Errorf("transaction coordinator redirect: %w", addrErr)
+		}
+		c.transactionCoordinators.Store(transactionalID, addr)
+		lastErr = brokerErr
+		if attempt+1 < maxRedirects {
+			time.Sleep(time.Duration(attempt+1) * 50 * time.Millisecond)
+		}
+	}
+	return "", fmt.Errorf("transaction coordinator redirect limit exceeded: %w", lastErr)
+}
+
+func (c *ConsumerClient) connectTransactionCoordinator(transactionalID string) (net.Conn, string, error) {
+	if cached, ok := c.transactionCoordinators.Load(transactionalID); ok {
+		addr, _ := cached.(string)
+		if addr != "" {
+			conn, err := c.ConnectToAddr(addr)
+			if err == nil {
+				return conn, addr, nil
+			}
+			c.transactionCoordinators.Delete(transactionalID)
+		}
+	}
+	return c.ConnectWithFailover()
+}
+
+func (c *ConsumerClient) transactionCoordinatorAddress(brokerErr *BrokerError) (string, error) {
+	if brokerErr == nil {
+		return "", fmt.Errorf("missing broker error")
+	}
+	host := brokerErr.Fields["host"]
+	port := brokerErr.Fields["port"]
+	parsedPort, err := strconv.Atoi(port)
+	if host == "" || err != nil || parsedPort < 1 || parsedPort > 65535 {
+		return "", fmt.Errorf("invalid NOT_COORDINATOR address host=%q port=%q", host, port)
+	}
+	if isLoopbackCoordinatorHost(host) && len(c.config.BrokerAddrs) > 0 {
+		if bootstrapHost, _, splitErr := net.SplitHostPort(c.config.BrokerAddrs[0]); splitErr == nil && !isLoopbackCoordinatorHost(bootstrapHost) {
+			host = bootstrapHost
+		}
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+func executeTransactionCommand(conn net.Conn, cmd string) (string, error) {
+	if conn == nil {
+		return "", fmt.Errorf("transaction command connection is nil")
+	}
+	if err := conn.SetDeadline(time.Now().Add(transactionCommandTimeout)); err != nil {
+		return "", fmt.Errorf("set transaction command deadline: %w", err)
+	}
 	if err := WriteWithLength(conn, EncodeMessage("", cmd)); err != nil {
 		return "", fmt.Errorf("send transaction command: %w", err)
 	}
@@ -100,11 +345,28 @@ func (c *ConsumerClient) execTxnCommand(cmd string) (string, error) {
 		return "", fmt.Errorf("read transaction response: %w", err)
 	}
 	respStr := strings.TrimSpace(string(resp))
-	if strings.HasPrefix(respStr, "ERROR:") {
-		return "", fmt.Errorf("transaction command failed: %s", respStr)
+	if brokerErr, ok := ParseBrokerError(respStr); ok {
+		return "", brokerErr
 	}
-	if !strings.HasPrefix(respStr, "OK") {
+	if _, err := parseOKResponse(respStr); err != nil {
 		return "", fmt.Errorf("unexpected transaction response: %s", respStr)
 	}
 	return respStr, nil
+}
+
+func validateTransactionOwner(transactionalID, producerID string) error {
+	if err := validateTransactionToken("transactional ID", transactionalID); err != nil {
+		return err
+	}
+	return validateTransactionToken("producer ID", producerID)
+}
+
+func validateTransactionToken(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if strings.ContainsAny(value, " \t\r\n") {
+		return fmt.Errorf("%s must not contain whitespace", name)
+	}
+	return nil
 }

--- a/sdk/transaction_contract_test.go
+++ b/sdk/transaction_contract_test.go
@@ -1,0 +1,128 @@
+package sdk
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestExecuteTransactionCommandPreservesStructuredBrokerError(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		request, err := ReadWithLength(server)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if got := string(request[2:]); got != "END_TXN transactional_id=tx-1 producerId=p-1 epoch=2 result=commit" {
+			serverDone <- errors.New("unexpected transaction command: " + got)
+			return
+		}
+		serverDone <- WriteWithLength(server, []byte("ERROR: producer_fenced class=fencing retryable=false current_epoch=3 requested_epoch=2"))
+	}()
+
+	_, err := executeTransactionCommand(client, "END_TXN transactional_id=tx-1 producerId=p-1 epoch=2 result=commit")
+	var brokerErr *BrokerError
+	if !errors.As(err, &brokerErr) {
+		t.Fatalf("expected typed BrokerError, got %T: %v", err, err)
+	}
+	if brokerErr.Code != "producer_fenced" || brokerErr.Class != ErrorClassFencing || brokerErr.Retryable {
+		t.Fatalf("unexpected broker error: %+v", brokerErr)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExecuteTransactionCommandRequiresExactOKToken(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		_, _ = ReadWithLength(server)
+		_ = WriteWithLength(server, []byte("OKAY state=committed"))
+	}()
+
+	if _, err := executeTransactionCommand(client, "TXN_STATUS transactional_id=tx-1"); err == nil {
+		t.Fatal("broad OK prefix was accepted")
+	}
+}
+
+func TestBuildSendOffsetsToTransactionCommandSortsPartitions(t *testing.T) {
+	cmd, err := buildSendOffsetsToTransactionCommand(
+		"tx-1", "producer-1", "orders", "workers", "member-1", 4, 2,
+		map[int]uint64{10: 90, 2: 30, 0: 11},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "SEND_OFFSETS_TO_TXN transactional_id=tx-1 producerId=producer-1 epoch=2 topic=orders group=workers member=member-1 generation=4 P0:11,P2:30,P10:90"
+	if cmd != expected {
+		t.Fatalf("command mismatch\nwant: %s\n got: %s", expected, cmd)
+	}
+}
+
+func TestBuildSendOffsetsToTransactionCommandRejectsUnsafeInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		txnID   string
+		group   string
+		offsets map[int]uint64
+	}{
+		{name: "empty offsets", txnID: "tx-1", group: "workers", offsets: map[int]uint64{}},
+		{name: "negative partition", txnID: "tx-1", group: "workers", offsets: map[int]uint64{-1: 1}},
+		{name: "whitespace identifier", txnID: "tx 1", group: "workers", offsets: map[int]uint64{0: 1}},
+		{name: "whitespace group", txnID: "tx-1", group: "worker pool", offsets: map[int]uint64{0: 1}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := buildSendOffsetsToTransactionCommand(test.txnID, "producer-1", "orders", test.group, "member-1", 1, 0, test.offsets)
+			if err == nil {
+				t.Fatal("unsafe input was accepted")
+			}
+		})
+	}
+}
+
+func TestParseTransactionStatus(t *testing.T) {
+	status, err := parseTransactionStatus("OK transactional_id=tx-1 state=committed messages=2 offsets=3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.TransactionalID != "tx-1" || status.State != "committed" || status.Messages != 2 || status.Offsets != 3 {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+
+	for _, response := range []string{
+		"OK transactional_id=tx-1 messages=2 offsets=3",
+		"OK transactional_id=tx-1 state=committed messages=-1 offsets=3",
+		"OK transactional_id=tx-1 state=committed messages=two offsets=3",
+		"OKAY transactional_id=tx-1 state=committed messages=2 offsets=3",
+	} {
+		if _, err := parseTransactionStatus(response); err == nil {
+			t.Fatalf("invalid status accepted: %s", response)
+		}
+	}
+}
+
+func TestTransactionValidationStopsBeforeDial(t *testing.T) {
+	client := &ConsumerClient{config: &ConsumerConfig{}}
+	if _, err := client.InitProducerID("bad id"); err == nil || !strings.Contains(err.Error(), "whitespace") {
+		t.Fatalf("unexpected transactional ID validation: %v", err)
+	}
+	if err := client.TransactionalPublish("tx-1", "orders", -2, Message{ProducerID: "p-1", SeqNum: 1, Payload: "payload"}); err == nil {
+		t.Fatal("partition below the auto-assignment sentinel was accepted")
+	}
+	if err := client.TransactionalPublish("tx-1", "orders", -1, Message{ProducerID: "p-1", SeqNum: 1, Payload: "payload"}); err == nil || strings.Contains(err.Error(), "partition") {
+		t.Fatalf("auto-assignment partition sentinel was rejected before dial: %v", err)
+	}
+	if err := client.TransactionalPublish("tx-1", "orders", 0, Message{ProducerID: "p-1", SeqNum: 0, Payload: "payload"}); err == nil {
+		t.Fatal("zero sequence was accepted")
+	}
+}

--- a/sdk/transaction_integration_test.go
+++ b/sdk/transaction_integration_test.go
@@ -1,0 +1,209 @@
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTransactionalProducerAgainstBroker(t *testing.T) {
+	rawAddrs := strings.TrimSpace(os.Getenv("CURSUS_INTEGRATION_ADDRS"))
+	if rawAddrs == "" {
+		t.Skip("set CURSUS_INTEGRATION_ADDRS to run broker integration validation")
+	}
+	addrs := strings.Split(rawAddrs, ",")
+	for i := range addrs {
+		addrs[i] = strings.TrimSpace(addrs[i])
+	}
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	topic := "sdk-transaction-" + suffix
+	transactionalID := "sdk-transactional-" + suffix
+	offsetGroup := "sdk-offset-" + suffix
+	visibilityGroup := "sdk-visible-" + suffix
+
+	cfg := NewDefaultConsumerConfig()
+	cfg.BrokerAddrs = addrs
+	client, err := NewConsumerClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := integrationOKCommand(client, fmt.Sprintf("CREATE topic=%s partitions=1", topic)); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = integrationOKCommand(client, fmt.Sprintf("DELETE topic=%s", topic))
+	})
+
+	offsetGeneration, offsetMember := integrationJoinGroup(t, client, topic, offsetGroup)
+	visibilityGeneration, visibilityMember := integrationJoinGroup(t, client, topic, visibilityGroup)
+
+	producer, err := client.NewTransactionalProducer(transactionalID)
+	if err != nil {
+		t.Fatalf("initialize transactional producer: %v", err)
+	}
+	if err := producer.Begin(); err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	if err := producer.Publish(topic, 0, Message{SeqNum: 1, Payload: "sdk-transaction-record"}); err != nil {
+		t.Fatalf("transactional publish: %v", err)
+	}
+	if err := producer.SendOffsets(topic, offsetGroup, offsetMember, offsetGeneration, map[int]uint64{0: 1}); err != nil {
+		t.Fatalf("send offsets to transaction: %v", err)
+	}
+
+	open, err := producer.Describe()
+	if err != nil {
+		t.Fatalf("describe open transaction: %v", err)
+	}
+	if open.State != "open" || open.Messages != 1 || open.Offsets != 1 {
+		t.Fatalf("unexpected open transaction: %+v", open)
+	}
+	if messages := integrationConsumePartition(t, client, addrs, topic, visibilityGroup, visibilityMember, visibilityGeneration); len(messages) != 0 {
+		t.Fatalf("open transaction became visible: %+v", messages)
+	}
+
+	if err := producer.Commit(); err != nil {
+		t.Fatalf("commit transaction: %v", err)
+	}
+	if err := producer.Commit(); err != nil {
+		t.Fatalf("retry transaction commit: %v", err)
+	}
+	committed, err := producer.Describe()
+	if err != nil {
+		t.Fatalf("describe committed transaction: %v", err)
+	}
+	if committed.State != "committed" {
+		t.Fatalf("unexpected committed transaction: %+v", committed)
+	}
+
+	messages := integrationConsumePartition(t, client, addrs, topic, visibilityGroup, visibilityMember, visibilityGeneration)
+	if len(messages) != 1 || messages[0].Payload != "sdk-transaction-record" {
+		t.Fatalf("unexpected committed records: %+v", messages)
+	}
+	offsetResp, err := integrationOKCommand(client, fmt.Sprintf("FETCH_OFFSET topic=%s partition=0 group=%s", topic, offsetGroup))
+	if err != nil {
+		t.Fatalf("fetch committed offset: %v", err)
+	}
+	offsetFields, err := parseOKResponse(offsetResp)
+	if err != nil || offsetFields["offset"] != "1" {
+		t.Fatalf("unexpected committed offset response %q: %v", offsetResp, err)
+	}
+}
+
+func integrationJoinGroup(t *testing.T, client *ConsumerClient, topic, group string) (int, string) {
+	t.Helper()
+	joinResp, err := integrationOKCommand(client, fmt.Sprintf("JOIN_GROUP topic=%s group=%s member=sdk-client", topic, group))
+	if err != nil {
+		t.Fatalf("join group %s: %v", group, err)
+	}
+	fields := parseOKFields(joinResp)
+	generation, err := strconv.Atoi(fields["generation"])
+	if err != nil || fields["member"] == "" {
+		t.Fatalf("invalid join response %q", joinResp)
+	}
+	member := fields["member"]
+	if _, err := integrationOKCommand(client, fmt.Sprintf("SYNC_GROUP topic=%s group=%s member=%s generation=%d", topic, group, member, generation)); err != nil {
+		t.Fatalf("sync group %s: %v", group, err)
+	}
+	return generation, member
+}
+
+func integrationOKCommand(client *ConsumerClient, command string) (string, error) {
+	addr := ""
+	for attempt := 0; attempt < 8; attempt++ {
+		var conn net.Conn
+		var connErr error
+		var connAddr string
+		if addr == "" {
+			conn, connAddr, connErr = client.ConnectWithFailover()
+		} else {
+			conn, connErr = client.ConnectToAddr(addr)
+			connAddr = addr
+		}
+		if connErr != nil {
+			return "", connErr
+		}
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		if err := WriteWithLength(conn, EncodeMessage("", command)); err != nil {
+			_ = conn.Close()
+			return "", err
+		}
+		response, err := ReadWithLength(conn)
+		_ = conn.Close()
+		if err != nil {
+			return "", err
+		}
+		value := strings.TrimSpace(string(response))
+		if brokerErr, ok := ParseBrokerError(value); ok {
+			if strings.EqualFold(brokerErr.Code, "NOT_COORDINATOR") {
+				host, port := brokerErr.Fields["host"], brokerErr.Fields["port"]
+				if host == "" || port == "" {
+					return "", brokerErr
+				}
+				addr = netJoinCoordinator(client, host, port)
+				continue
+			}
+			return "", brokerErr
+		}
+		if !hasOKStatus(value) {
+			return "", fmt.Errorf("unexpected response from %s: %s", connAddr, value)
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("coordinator redirect limit exceeded for %s", command)
+}
+
+func netJoinCoordinator(client *ConsumerClient, host, port string) string {
+	if isLoopbackCoordinatorHost(host) && len(client.config.BrokerAddrs) > 0 {
+		bootstrapHost, _, err := net.SplitHostPort(client.config.BrokerAddrs[0])
+		if err == nil && !isLoopbackCoordinatorHost(bootstrapHost) {
+			host = bootstrapHost
+		}
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func integrationConsumePartition(t *testing.T, client *ConsumerClient, addrs []string, topic, group, member string, generation int) []Message {
+	t.Helper()
+	command := fmt.Sprintf("CONSUME topic=%s partition=0 offset=0 group=%s generation=%d member=%s autoOffsetReset=earliest batch=10", topic, group, generation, member)
+	var lastErr error
+	for _, addr := range addrs {
+		conn, err := client.ConnectToAddr(addr)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+		if err := WriteWithLength(conn, EncodeMessage("", command)); err != nil {
+			_ = conn.Close()
+			lastErr = err
+			continue
+		}
+		response, err := ReadWithLength(conn)
+		_ = conn.Close()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if brokerErr, ok := ParseBrokerError(strings.TrimSpace(string(response))); ok {
+			lastErr = brokerErr
+			if strings.EqualFold(brokerErr.Code, "NOT_LEADER") {
+				continue
+			}
+			break
+		}
+		messages, _, _, err := DecodeBatchMessages(response)
+		if err == nil {
+			return messages
+		}
+		lastErr = err
+	}
+	t.Fatalf("consume partition through SDK: %v", lastErr)
+	return nil
+}

--- a/sdk/transaction_redirect_test.go
+++ b/sdk/transaction_redirect_test.go
@@ -1,0 +1,203 @@
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTransactionCommandsFollowAndCacheCoordinatorRedirect(t *testing.T) {
+	coordinator, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer coordinator.Close()
+	bootstrap, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bootstrap.Close()
+
+	_, portText, err := net.SplitHostPort(coordinator.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverErrors := make(chan error, 2)
+	commands := make(chan string, 3)
+	go serveTransactionConnections(bootstrap, 1, func(command string) string {
+		commands <- "bootstrap:" + command
+		return fmt.Sprintf("ERROR: NOT_COORDINATOR host=127.0.0.1 port=%d", port)
+	}, serverErrors)
+	go serveTransactionConnections(coordinator, 2, func(command string) string {
+		commands <- "coordinator:" + command
+		if strings.HasPrefix(command, "INIT_PRODUCER_ID ") {
+			return "OK transactional_id=tx-redirect producerId=producer-1 epoch=3"
+		}
+		return "OK transactional_id=tx-redirect state=open producerId=producer-1 epoch=3"
+	}, serverErrors)
+
+	cfg := NewDefaultConsumerConfig()
+	cfg.BrokerAddrs = []string{bootstrap.Addr().String()}
+	client, err := NewConsumerClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := client.InitProducerID("tx-redirect")
+	if err != nil {
+		t.Fatalf("init producer after redirect: %v", err)
+	}
+	if session.ProducerID != "producer-1" || session.Epoch != 3 {
+		t.Fatalf("unexpected session: %+v", session)
+	}
+	if err := client.BeginTransaction(session.TransactionalID, session.ProducerID, session.Epoch); err != nil {
+		t.Fatalf("begin through cached coordinator: %v", err)
+	}
+
+	got := make([]string, 0, 3)
+	for len(got) < 3 {
+		select {
+		case command := <-commands:
+			got = append(got, command)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for commands: %v", got)
+		}
+	}
+	if !strings.HasPrefix(got[0], "bootstrap:INIT_PRODUCER_ID ") {
+		t.Fatalf("first command did not use bootstrap broker: %v", got)
+	}
+	if !strings.HasPrefix(got[1], "coordinator:INIT_PRODUCER_ID ") ||
+		!strings.HasPrefix(got[2], "coordinator:BEGIN_TXN ") {
+		t.Fatalf("redirect was not cached: %v", got)
+	}
+	for i := 0; i < 2; i++ {
+		if err := <-serverErrors; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func serveTransactionConnections(listener net.Listener, count int, responder func(string) string, result chan<- error) {
+	for i := 0; i < count; i++ {
+		conn, err := listener.Accept()
+		if err != nil {
+			result <- err
+			return
+		}
+		request, err := ReadWithLength(conn)
+		if err == nil {
+			if len(request) < 2 {
+				err = fmt.Errorf("short encoded command")
+			} else {
+				command := string(request[2:])
+				err = WriteWithLength(conn, []byte(responder(command)))
+			}
+		}
+		_ = conn.Close()
+		if err != nil {
+			result <- err
+			return
+		}
+	}
+	result <- nil
+}
+
+func TestTransactionCoordinatorRedirectRejectsInvalidAddress(t *testing.T) {
+	brokerErr := &BrokerError{
+		Code:   "NOT_COORDINATOR",
+		Fields: map[string]string{"host": "localhost", "port": "invalid"},
+	}
+	client := &ConsumerClient{config: NewDefaultConsumerConfig()}
+	if _, err := client.transactionCoordinatorAddress(brokerErr); err == nil {
+		t.Fatal("invalid coordinator port was accepted")
+	}
+}
+
+func TestTransactionalProducerPreservesSessionAcrossLifecycle(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	commands := make(chan string, 7)
+	serverErrors := make(chan error, 1)
+	go serveTransactionConnections(listener, 7, func(command string) string {
+		commands <- command
+		switch {
+		case strings.HasPrefix(command, "INIT_PRODUCER_ID "):
+			return "OK transactional_id=tx-session producerId=producer-session epoch=4"
+		case strings.HasPrefix(command, "TXN_STATUS "):
+			return "OK transactional_id=tx-session state=open messages=1 offsets=2"
+		case strings.HasPrefix(command, "END_TXN "):
+			return "OK transactional_id=tx-session state=committed messages=1 offsets=2"
+		default:
+			return "OK transactional_id=tx-session state=open"
+		}
+	}, serverErrors)
+
+	cfg := NewDefaultConsumerConfig()
+	cfg.BrokerAddrs = []string{listener.Addr().String()}
+	client, err := NewConsumerClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	producer, err := client.NewTransactionalProducer("tx-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := producer.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	if err := producer.Publish("orders", -1, Message{SeqNum: 9, Payload: "created"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := producer.SendOffsets("orders", "workers", "member-1", 2, map[int]uint64{1: 8, 0: 5}); err != nil {
+		t.Fatal(err)
+	}
+	status, err := producer.Describe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.State != "open" || status.Messages != 1 || status.Offsets != 2 {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if err := producer.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := producer.Commit(); err != nil {
+		t.Fatalf("commit retry failed: %v", err)
+	}
+
+	got := make([]string, 0, 7)
+	for len(got) < 7 {
+		select {
+		case command := <-commands:
+			got = append(got, command)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for lifecycle commands: %v", got)
+		}
+	}
+	if !strings.Contains(got[2], "producerId=producer-session") ||
+		!strings.Contains(got[2], "epoch=4") ||
+		!strings.Contains(got[2], "partition=-1") {
+		t.Fatalf("publish did not use preserved session: %s", got[2])
+	}
+	if !strings.HasSuffix(got[3], "P0:5,P1:8") {
+		t.Fatalf("offsets were not deterministic: %s", got[3])
+	}
+	if got[5] != got[6] {
+		t.Fatalf("commit retry changed command:\nfirst: %s\nretry: %s", got[5], got[6])
+	}
+	if err := <-serverErrors; err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes

Adds the high-level transactional producer API, coordinator redirect handling, typed broker errors, authentication, durable offset resume behavior, and broker-backed integration coverage for the Go SDK.

Dependency: #94 must merge first. This branch is intentionally stacked and will be rebased onto main after #94 merges.

Validation:

- `go test ./pkg/protocol ./pkg/server ./pkg/controller ./sdk -count=1`
- `go test -race ./sdk -count=1` using the official Go container
- `CURSUS_INTEGRATION_ADDRS=localhost:9001,localhost:9002,localhost:9003 go test ./sdk -run '^TestTransactionalProducerAgainstBroker$' -count=1 -v`

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.
