### PR TITLE
fix: complete protocol error registry

### DIFF
--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -457,7 +457,7 @@ and every partition.
 
 **COMMIT_OFFSET**
 ```
-COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N> [member=<actual-id> generation=<N>]
+COMMIT_OFFSET topic=<name> partition=<N> group=<name> offset=<N> member=<actual-id> generation=<N>
 ```
 Response: `OK`
 
@@ -465,7 +465,9 @@ The `offset` value is the next offset to read after the client has processed
 records. Commits are durable and monotonic per `(topic, group, partition)`.
 Committing the same offset is idempotent. Committing an offset lower than the
 current committed offset returns an error and does not move the stored offset
-backward.
+backward. `member` and `generation` are required and must identify the current
+partition owner; missing values are validation errors and stale values are fencing
+errors.
 
 **BATCH_COMMIT**
 ```
@@ -482,6 +484,8 @@ included partition. The broker validates `member` and `generation` before applyi
 the batch. If any partition is not owned by that member in that generation, the
 entire batch is rejected with `ERROR: NOT_OWNER ...`. Stale generations return
 `ERROR: GEN_MISMATCH ...`, and unknown members return `ERROR: member_not_found ...`.
+The whole batch is also rejected before any offset changes when `generation` is
+missing, an entry is malformed, or the same partition appears more than once.
 
 
 #### Transaction Coordinator
@@ -828,7 +832,16 @@ SDKs should parse the code and fields first, use `class` for broad handling, and
 | `offset_regression reason="..."` | Commit lower than current stored offset | Treat commit as failed; refetch offset |
 | `stale_producer_epoch producer=<id> current=<N> got=<N>` | Idempotent producer request uses an older fenced epoch | Treat as fatal for that producer instance; create a new producer session |
 | `OFFSET_OUT_OF_RANGE requested=N earliest=N latest=N` | Requested offset is older than retained log or beyond available range | Treat as data loss or reset according to policy |
-| `no_valid_offsets` | BATCH_COMMIT parse failure | Check format: `P<N>:<offset>` |
+| `no_valid_offsets` | BATCH_COMMIT contains no usable offsets | Supply at least one `P<N>:<offset>` entry |
+| `missing_generation command=<command>` | Group command omitted its generation | Rejoin if needed and send the current generation |
+| `invalid_batch_commit_entry entry=<entry>` | BATCH_COMMIT entry is not `P<N>:<offset>` | Correct the malformed entry and retry |
+| `duplicate_partition partition=N group=<G> topic=<T>` | BATCH_COMMIT repeats a partition | Send one next offset per partition; no offsets were committed |
+| `NOT_PARTITION_LEADER leader=<id> requested_leader=<id>` | Replication reached a broker that is not the current partition leader | Refresh partition metadata and retry against the leader |
+| `STALE_LEADER_EPOCH current=N requested=N` | Replication request carries a fenced leader epoch | Discard the stale leader session and refresh metadata |
+| `cluster_metadata_unavailable command=REPLICATE_MESSAGE` | Cluster metadata subsystem is temporarily unavailable | Back off and retry |
+| `partition_metadata_not_found topic=<T> partition=N` | Partition metadata does not exist | Refresh metadata and verify topic/partition |
+| `missing_leader_fence command=REPLICATE_MESSAGE` | Internal replication omitted leader ID or epoch | Correct the broker request; do not retry unchanged |
+| `invalid_commit_watermark reason="..."` | Commit watermark is ahead of local durable data or otherwise invalid | Repair/catch up the replica before retrying |
 | invalid_control_batch_bytes field=<key|value> | Broker-internal transaction control bytes are not valid base64 | Reject the internal publish and inspect broker compatibility |
 | `version_conflict current=N expected=N` | Optimistic concurrency failure | Reload aggregate and retry |
 | `event_sourcing_not_enabled topic=<X>` | ES command on non-ES topic | CREATE topic with `event_sourcing=true` |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -194,6 +194,12 @@ ERROR: missing_payload command=REPLICATE_MESSAGE
 ERROR: unmarshal_failed reason="..."
 ERROR: topic_not_found topic=<name>
 ERROR: partition_not_found partition=<N>
+ERROR: cluster_metadata_unavailable command=REPLICATE_MESSAGE
+ERROR: partition_metadata_not_found topic=<name> partition=<N>
+ERROR: missing_leader_fence command=REPLICATE_MESSAGE
+ERROR: NOT_PARTITION_LEADER leader=<broker-id> requested_leader=<broker-id>
+ERROR: STALE_LEADER_EPOCH current=<N> requested=<N>
+ERROR: invalid_commit_watermark reason="..."
 ERROR: replica_append_failed reason="..."
 ```
 
@@ -357,10 +363,10 @@ When no offset has been committed, the broker returns `OK offset=0`.
 ### COMMIT_OFFSET
 
 ```text
-COMMIT_OFFSET topic=<name> group=<group> partition=<N> offset=<nextOffset> [member=<member-id> generation=<N>]
+COMMIT_OFFSET topic=<name> group=<group> partition=<N> offset=<nextOffset> member=<member-id> generation=<N>
 ```
 
-The offset is the next offset to read after successful processing. Commits are monotonic per `(topic, group, partition)`: a commit lower than the current offset fails and does not rewind the group. When `member` or `generation` is supplied, both must be present and the member must own the partition in that generation. Legacy clients may omit both fields, but group-aware SDKs should send them.
+The offset is the next offset to read after successful processing. Commits are monotonic per `(topic, group, partition)`: a commit lower than the current offset fails and does not rewind the group. `member` and `generation` are required, and the member must own the partition in that generation.
 
 Success:
 
@@ -372,6 +378,7 @@ Common errors:
 
 ```text
 ERROR: invalid_offset
+ERROR: missing_generation command=COMMIT_OFFSET
 ERROR: invalid_generation command=COMMIT_OFFSET
 ERROR: offset_regression reason="..."
 ERROR: GEN_MISMATCH current=<N> requested=<N> group=<group> member=<member-id>
@@ -398,7 +405,10 @@ Common errors:
 
 ```text
 ERROR: invalid_batch_commit_format
+ERROR: invalid_batch_commit_entry entry=<entry>
+ERROR: missing_generation command=BATCH_COMMIT
 ERROR: invalid_generation command=BATCH_COMMIT
+ERROR: duplicate_partition partition=<N> group=<group> topic=<topic>
 ERROR: no_valid_offsets
 ERROR: offset_regression reason="..."
 ERROR: GEN_MISMATCH current=<N> requested=<N> group=<group> member=<member-id>

--- a/pkg/protocol/errors.go
+++ b/pkg/protocol/errors.go
@@ -58,15 +58,15 @@ func buildErrorRegistry() map[string]ErrorClassification {
 	}
 
 	register(ErrorClassRouting, true,
-		"NOT_COORDINATOR", "NOT_LEADER",
+		"NOT_COORDINATOR", "NOT_LEADER", "NOT_PARTITION_LEADER",
 	)
 	register(ErrorClassAvailability, true,
-		"cluster_not_available", "coordinator_not_available", "fsm_not_available",
+		"cluster_metadata_unavailable", "cluster_not_available", "coordinator_not_available", "fsm_not_available",
 		"leader_not_found", "no_raft_leader", "offset_manager_not_available", "router_not_available",
 		"transaction_abort_marker_failed", "transaction_commit_failed", "transaction_manager_not_available", "transaction_sync_failed",
 	)
 	register(ErrorClassFencing, false,
-		"GEN_MISMATCH", "NOT_OWNER", "member_not_found", "producer_fenced", "stale_producer_epoch",
+		"GEN_MISMATCH", "NOT_OWNER", "STALE_LEADER_EPOCH", "member_not_found", "producer_fenced", "stale_producer_epoch",
 	)
 	register(ErrorClassConflict, false,
 		"OFFSET_OUT_OF_RANGE", "offset_regression", "snapshot_version_exceeds_stream",
@@ -80,14 +80,14 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"internal_txn_publish_forbidden", "transaction_metadata_forbidden",
 	)
 	register(ErrorClassNotFound, false,
-		"group_not_found", "partition_not_found", "topic_not_found", "transaction_not_found",
+		"group_not_found", "partition_metadata_not_found", "partition_not_found", "topic_not_found", "transaction_not_found",
 	)
 	register(ErrorClassValidation, false,
 		"UNSUPPORTED_FEATURE", "UNSUPPORTED_PROTOCOL_VERSION", "batch_decode_failed", "decode_failed",
-		"distribution_not_enabled", "distribution_required", "empty_command", "empty_messages",
-		"empty_required_params", "event_sourcing_not_enabled", "invalid_acks", "invalid_batch_commit_format",
+		"distribution_not_enabled", "distribution_required", "duplicate_partition", "empty_command", "empty_messages",
+		"empty_required_params", "event_sourcing_not_enabled", "invalid_acks", "invalid_batch_commit_entry", "invalid_batch_commit_format",
 		"invalid_auth", "invalid_consume_syntax", "invalid_control_batch_bytes", "invalid_control_batch_coordinator_epoch",
-		"invalid_control_batch_version", "invalid_epoch", "invalid_generation", "invalid_is_idempotent",
+		"invalid_control_batch_version", "invalid_commit_watermark", "invalid_epoch", "invalid_generation", "invalid_is_idempotent",
 		"invalid_offset", "invalid_partition", "invalid_partitions", "invalid_payload", "invalid_payload_json",
 		"invalid_protocol_features", "invalid_protocol_version", "invalid_replication_factor", "invalid_require_features",
 		"invalid_transaction_control_batch", "invalid_transaction_control_epoch", "invalid_transaction_control_record",
@@ -95,8 +95,8 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"invalid_transaction_state", "invalid_txn_offsets",
 		"invalid_retention_bytes", "invalid_retention_hours", "invalid_schema_version", "invalid_seq_num",
 		"invalid_snapshot_catchup_response", "invalid_snapshot_payload", "invalid_stream_syntax",
-		"invalid_topic_policy", "invalid_version", "malformed_input", "missing_group", "missing_key",
-		"missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
+		"invalid_topic_policy", "invalid_version", "malformed_input", "missing_generation", "missing_group", "missing_key",
+		"missing_leader_fence", "missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
 		"missing_coordinator_key", "missing_ownership_params", "missing_producer_id", "missing_protocol_version",
 		"missing_required_params", "missing_topic", "missing_transactional_id",
 		"missing_version", "no_valid_offsets", "unknown_command", "unmarshal_failed",

--- a/pkg/protocol/errors_test.go
+++ b/pkg/protocol/errors_test.go
@@ -45,7 +45,16 @@ func TestClassifyFencingAndAvailability(t *testing.T) {
 		{"transaction_manager_not_available", ErrorClassAvailability, true},
 		{"authentication_failed", ErrorClassAuthorization, false},
 		{"coordinator_not_available", ErrorClassAvailability, true},
+		{"cluster_metadata_unavailable", ErrorClassAvailability, true},
+		{"NOT_PARTITION_LEADER", ErrorClassRouting, true},
+		{"STALE_LEADER_EPOCH", ErrorClassFencing, false},
+		{"partition_metadata_not_found", ErrorClassNotFound, false},
+		{"invalid_commit_watermark", ErrorClassValidation, false},
+		{"missing_leader_fence", ErrorClassValidation, false},
+		{"duplicate_partition", ErrorClassValidation, false},
+		{"invalid_batch_commit_entry", ErrorClassValidation, false},
 		{"invalid_partition", ErrorClassValidation, false},
+		{"missing_generation", ErrorClassValidation, false},
 	}
 	for _, test := range tests {
 		got := ClassifyErrorCode(test.code)


### PR DESCRIPTION
Fixes protocol error registry coverage after consumer-group, replication, and capability changes landed in different merge order.

This registers every static broker error introduced by the recent group and failover contracts, documents the response contract, and keeps structured error classification fail-closed.

Validation:

- `go test ./pkg/protocol ./pkg/controller`
- `go vet ./pkg/protocol ./pkg/controller`
- `git diff --check`

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.