### PR TITLE
fix: preserve large replication commands

### DIFF
--- a/pkg/cluster/controller/router.go
+++ b/pkg/cluster/controller/router.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cursus-io/cursus/pkg/config"
+	wireprotocol "github.com/cursus-io/cursus/pkg/protocol"
 	"github.com/cursus-io/cursus/util"
 )
 
@@ -261,6 +262,9 @@ func (r *ClusterRouter) processLocally(req string) string {
 func (r *ClusterRouter) withInternalToken(command string) string {
 	if r.internalToken == "" {
 		return command
+	}
+	if wireprotocol.IsTextCommand(command) {
+		return injectInternalToken(command, r.internalToken)
 	}
 	if _, payload, err := util.DecodeMessage([]byte(command)); err == nil {
 		return string(util.EncodeMessage("", injectInternalToken(payload, r.internalToken)))

--- a/pkg/cluster/controller/router.go
+++ b/pkg/cluster/controller/router.go
@@ -274,17 +274,25 @@ func (r *ClusterRouter) withInternalToken(command string) string {
 
 func injectInternalToken(command, token string) string {
 	trimmed := strings.TrimSpace(command)
-	if trimmed == "" || strings.Contains(trimmed, " internal_token=") || strings.HasPrefix(trimmed, "internal_token=") {
+	if trimmed == "" {
 		return command
 	}
-	parts := strings.Fields(trimmed)
-	if len(parts) == 0 {
-		return command
+	commandEnd := strings.IndexAny(trimmed, " \t\r\n")
+	if commandEnd == -1 {
+		return trimmed + " internal_token=" + token
 	}
-	commandName := parts[0]
-	rest := strings.TrimSpace(trimmed[len(commandName):])
+	commandName := trimmed[:commandEnd]
+	rest := strings.TrimLeft(trimmed[commandEnd:], " \t\r\n")
 	if rest == "" {
 		return commandName + " internal_token=" + token
+	}
+	firstArgEnd := strings.IndexAny(rest, " \t\r\n")
+	firstArg := rest
+	if firstArgEnd >= 0 {
+		firstArg = rest[:firstArgEnd]
+	}
+	if strings.HasPrefix(firstArg, "internal_token=") {
+		return command
 	}
 	return commandName + " internal_token=" + token + " " + rest
 }

--- a/pkg/cluster/controller/router_test.go
+++ b/pkg/cluster/controller/router_test.go
@@ -24,6 +24,22 @@ func TestWithInternalTokenPreservesLongRawCommand(t *testing.T) {
 	}
 }
 
+func TestInjectInternalTokenOnlyInspectsCommandArguments(t *testing.T) {
+	command := "REPLICATE_MESSAGE payload=message internal_token=payload-value"
+	got := injectInternalToken(command, "secret")
+	want := "REPLICATE_MESSAGE internal_token=secret payload=message internal_token=payload-value"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestInjectInternalTokenPreservesExistingFirstArgument(t *testing.T) {
+	command := "REPLICATE_MESSAGE internal_token=secret payload=value"
+	if got := injectInternalToken(command, "secret"); got != command {
+		t.Fatalf("command = %q, want unchanged", got)
+	}
+}
+
 func TestWithInternalTokenPreservesLegacyEnvelope(t *testing.T) {
 	router := &ClusterRouter{internalToken: "secret"}
 	encoded := util.EncodeMessage("", "HELP")

--- a/pkg/cluster/controller/router_test.go
+++ b/pkg/cluster/controller/router_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -8,8 +9,34 @@ import (
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
 	"github.com/hashicorp/raft"
 )
+
+func TestWithInternalTokenPreservesLongRawCommand(t *testing.T) {
+	router := &ClusterRouter{internalToken: "secret"}
+	command := "REPLICATE_MESSAGE payload=" + strings.Repeat("x", 22000)
+
+	got := router.withInternalToken(command)
+	wantPrefix := "REPLICATE_MESSAGE internal_token=secret payload="
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("command prefix = %q, want %q", got[:min(len(got), len(wantPrefix))], wantPrefix)
+	}
+}
+
+func TestWithInternalTokenPreservesLegacyEnvelope(t *testing.T) {
+	router := &ClusterRouter{internalToken: "secret"}
+	encoded := util.EncodeMessage("", "HELP")
+
+	got := router.withInternalToken(string(encoded))
+	_, payload, err := util.DecodeMessage([]byte(got))
+	if err != nil {
+		t.Fatalf("decode forwarded envelope: %v", err)
+	}
+	if payload != "HELP internal_token=secret" {
+		t.Fatalf("payload = %q", payload)
+	}
+}
 
 type MockRaftManager struct {
 	isLeader bool

--- a/pkg/protocol/commands.go
+++ b/pkg/protocol/commands.go
@@ -1,0 +1,69 @@
+package protocol
+
+import "strings"
+
+var textCommands = map[string]struct{}{
+	"CREATE":              {},
+	"DELETE":              {},
+	"LIST":                {},
+	"LIST_CLUSTER":        {},
+	"CLUSTER_STATUS":      {},
+	"ELECT_LEADER":        {},
+	"PUBLISH":             {},
+	"CONSUME":             {},
+	"STREAM":              {},
+	"HELP":                {},
+	"HEARTBEAT":           {},
+	"JOIN_GROUP":          {},
+	"LEAVE_GROUP":         {},
+	"COMMIT_OFFSET":       {},
+	"BATCH_COMMIT":        {},
+	"REGISTER_GROUP":      {},
+	"GROUP_STATUS":        {},
+	"FETCH_OFFSET":        {},
+	"LIST_GROUPS":         {},
+	"SYNC_GROUP":          {},
+	"DESCRIBE":            {},
+	"INIT_PRODUCER_ID":    {},
+	"BEGIN_TXN":           {},
+	"TXN_PUBLISH":         {},
+	"SEND_OFFSETS_TO_TXN": {},
+	"END_TXN":             {},
+	"TXN_STATUS":          {},
+	"APPEND_STREAM":       {},
+	"READ_STREAM":         {},
+	"SAVE_SNAPSHOT":       {},
+	"READ_SNAPSHOT":       {},
+	"STREAM_VERSION":      {},
+	"REPLICATE_MESSAGE":   {},
+	"REPLICATE_SNAPSHOT":  {},
+	"LIST_SNAPSHOTS":      {},
+	"FETCH_SNAPSHOT":      {},
+	"CATCHUP_SNAPSHOTS":   {},
+	"FIND_COORDINATOR":    {},
+	"RAFT_APPLY":          {},
+	"METADATA":            {},
+	"INTERNAL_BATCH":      {},
+	"PROTOCOL_INFO":       {},
+	"NEGOTIATE":           {},
+}
+
+// IsTextCommand distinguishes a raw command from the legacy topic envelope.
+// DecodeMessage alone is not sufficient because the first two ASCII bytes of
+// a long command can also form a valid uint16 topic length.
+func IsTextCommand(value string) bool {
+	trimmed := strings.TrimLeft(value, " \t\r\n")
+	if trimmed == "" {
+		return false
+	}
+	first := trimmed[0]
+	if (first < 'A' || first > 'Z') && (first < 'a' || first > 'z') {
+		return false
+	}
+	end := strings.IndexAny(trimmed, " \t\r\n")
+	if end == -1 {
+		end = len(trimmed)
+	}
+	_, ok := textCommands[strings.ToUpper(trimmed[:end])]
+	return ok
+}

--- a/pkg/protocol/commands.go
+++ b/pkg/protocol/commands.go
@@ -2,7 +2,10 @@ package protocol
 
 import "strings"
 
+const maxTextCommandLength = len("SEND_OFFSETS_TO_TXN")
+
 var textCommands = map[string]struct{}{
+	"AUTH":                {},
 	"CREATE":              {},
 	"DELETE":              {},
 	"LIST":                {},
@@ -22,6 +25,7 @@ var textCommands = map[string]struct{}{
 	"GROUP_STATUS":        {},
 	"FETCH_OFFSET":        {},
 	"LIST_GROUPS":         {},
+	"LIST_OFFSETS":        {},
 	"SYNC_GROUP":          {},
 	"DESCRIBE":            {},
 	"INIT_PRODUCER_ID":    {},
@@ -60,8 +64,15 @@ func IsTextCommand(value string) bool {
 	if (first < 'A' || first > 'Z') && (first < 'a' || first > 'z') {
 		return false
 	}
-	end := strings.IndexAny(trimmed, " \t\r\n")
+	searchEnd := len(trimmed)
+	if searchEnd > maxTextCommandLength+1 {
+		searchEnd = maxTextCommandLength + 1
+	}
+	end := strings.IndexAny(trimmed[:searchEnd], " \t\r\n")
 	if end == -1 {
+		if len(trimmed) > maxTextCommandLength {
+			return false
+		}
 		end = len(trimmed)
 	}
 	_, ok := textCommands[strings.ToUpper(trimmed[:end])]

--- a/pkg/protocol/commands_test.go
+++ b/pkg/protocol/commands_test.go
@@ -1,0 +1,21 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsTextCommandRecognizesLongRawCommand(t *testing.T) {
+	command := "REPLICATE_MESSAGE payload=" + strings.Repeat("x", 22000)
+	if !IsTextCommand(command) {
+		t.Fatal("long raw replication command was not recognized")
+	}
+}
+
+func TestIsTextCommandRequiresCommandToken(t *testing.T) {
+	for _, value := range []string{"", "LISTEN", "\x00\x00HELP", "not-a-command"} {
+		if IsTextCommand(value) {
+			t.Fatalf("unexpected command match for %q", value)
+		}
+	}
+}

--- a/pkg/protocol/commands_test.go
+++ b/pkg/protocol/commands_test.go
@@ -12,8 +12,19 @@ func TestIsTextCommandRecognizesLongRawCommand(t *testing.T) {
 	}
 }
 
+func TestIsTextCommandRecognizesServerCommands(t *testing.T) {
+	for _, value := range []string{
+		"AUTH principal=alice token=secret",
+		"LIST_OFFSETS topic=events partition=0",
+	} {
+		if !IsTextCommand(value) {
+			t.Fatalf("server command was not recognized: %q", value)
+		}
+	}
+}
+
 func TestIsTextCommandRequiresCommandToken(t *testing.T) {
-	for _, value := range []string{"", "LISTEN", "\x00\x00HELP", "not-a-command"} {
+	for _, value := range []string{"", "LISTEN", "\x00\x00HELP", "not-a-command", strings.Repeat("a", 1<<20)} {
 		if IsTextCommand(value) {
 			t.Fatalf("unexpected command match for %q", value)
 		}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -502,20 +502,20 @@ func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *con
 		return false, nil
 	}
 
+	rawInput, isRawCommand := parseRawTextCommand(data)
+	if strings.HasPrefix(strings.ToUpper(rawInput), "INTERNAL_BATCH ") {
+		return handleInternalBatchMessage(rawInput, cmdHandler, ctx, conn)
+	}
+	if isRawCommand {
+		if resp := authorizeInternalListenerCommand(rawInput, cmdHandler, ctx); resp != "" {
+			writeResponse(conn, resp)
+			return false, nil
+		}
+		return handleCommandMessage(rawInput, cmdHandler, ctx, conn)
+	}
+
 	_, payload, err := util.DecodeMessage(data)
 	if err != nil {
-		rawInput := string(data)
-		rawInput = strings.Trim(rawInput, "\x00 \t\n\r")
-		if strings.HasPrefix(strings.ToUpper(rawInput), "INTERNAL_BATCH ") {
-			return handleInternalBatchMessage(rawInput, cmdHandler, ctx, conn)
-		}
-		if isCommand(rawInput) {
-			if resp := authorizeInternalListenerCommand(rawInput, cmdHandler, ctx); resp != "" {
-				writeResponse(conn, resp)
-				return false, nil
-			}
-			return handleCommandMessage(rawInput, cmdHandler, ctx, conn)
-		}
 		util.Error("⚠️ Decode error and not a raw command: %v [%s]", err, string(data))
 		writeResponse(conn, decorateServerResponse(fmt.Sprintf("ERROR: decode_failed reason=%q", err.Error()), ctx))
 		return false, nil
@@ -542,10 +542,14 @@ func processMessage(data []byte, cmdHandler *controller.CommandHandler, ctx *con
 		return handleCommandMessage(payload, cmdHandler, ctx, conn)
 	}
 
-	rawInput := strings.TrimSpace(string(data))
 	util.Debug("[%s] Received unrecognized input: %s", conn.RemoteAddr().String(), rawInput)
 	writeResponse(conn, decorateServerResponse("ERROR: malformed_input reason=missing_topic_or_payload", ctx))
 	return true, nil
+}
+
+func parseRawTextCommand(data []byte) (string, bool) {
+	rawInput := strings.Trim(string(data), " \t\n\r")
+	return rawInput, isCommand(rawInput)
 }
 
 func authorizeInternalListenerCommand(payload string, cmdHandler *controller.CommandHandler, ctx *controller.ClientContext) string {
@@ -665,19 +669,7 @@ func isBatchMessage(data []byte) bool {
 }
 
 func isCommand(s string) bool {
-	keywords := []string{"CREATE", "DELETE", "LIST", "LIST_CLUSTER", "CLUSTER_STATUS", "ELECT_LEADER", "PUBLISH", "CONSUME", "STREAM", "HELP",
-		"HEARTBEAT", "JOIN_GROUP", "LEAVE_GROUP", "COMMIT_OFFSET", "BATCH_COMMIT", "REGISTER_GROUP",
-		"GROUP_STATUS", "FETCH_OFFSET", "LIST_GROUPS", "SYNC_GROUP", "DESCRIBE",
-		"INIT_PRODUCER_ID", "BEGIN_TXN", "TXN_PUBLISH", "SEND_OFFSETS_TO_TXN", "END_TXN", "TXN_STATUS",
-		"APPEND_STREAM", "READ_STREAM", "SAVE_SNAPSHOT", "READ_SNAPSHOT", "STREAM_VERSION",
-		"REPLICATE_MESSAGE", "REPLICATE_SNAPSHOT", "LIST_SNAPSHOTS", "FETCH_SNAPSHOT", "CATCHUP_SNAPSHOTS",
-		"FIND_COORDINATOR", "RAFT_APPLY", "METADATA", "INTERNAL_BATCH", "PROTOCOL_INFO", "NEGOTIATE"}
-	for _, k := range keywords {
-		if strings.HasPrefix(strings.ToUpper(s), k) {
-			return true
-		}
-	}
-	return false
+	return wireprotocol.IsTextCommand(s)
 }
 
 // writeResponseWithTimeout adds write timeout

--- a/pkg/server/protocol_negotiation_test.go
+++ b/pkg/server/protocol_negotiation_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/controller"
+	wireprotocol "github.com/cursus-io/cursus/pkg/protocol"
 	"github.com/cursus-io/cursus/util"
 )
 
@@ -50,9 +51,32 @@ func TestProcessMessageNegotiatesAndDecoratesSubsequentErrors(t *testing.T) {
 }
 
 func TestProtocolCommandsAreRecognizedAsRawCommands(t *testing.T) {
-	for _, command := range []string{"PROTOCOL_INFO", "NEGOTIATE version=1"} {
+	for _, command := range []string{
+		"AUTH principal=alice token=secret",
+		"LIST_OFFSETS topic=events",
+		"PROTOCOL_INFO",
+		"NEGOTIATE version=1",
+	} {
 		if !isCommand(command) {
 			t.Fatalf("%s was not recognized", command)
 		}
+	}
+}
+
+func TestDecorateServerResponsePreservesGroupSuccess(t *testing.T) {
+	ctx := controller.NewClientContext("group", 0)
+	ctx.SetProtocol(wireprotocol.CurrentVersion, []wireprotocol.Feature{wireprotocol.FeatureStructuredErrorsV1})
+	response := "OK generation=2 member=member-1 assignments=[0]"
+	if got := decorateServerResponse(response, ctx); got != response {
+		t.Fatalf("decorated success = %q, want %q", got, response)
+	}
+}
+
+func TestDecorateServerResponseEnrichesNegotiatedGroupError(t *testing.T) {
+	ctx := controller.NewClientContext("group", 0)
+	ctx.SetProtocol(wireprotocol.CurrentVersion, []wireprotocol.Feature{wireprotocol.FeatureStructuredErrorsV1})
+	want := "ERROR: GEN_MISMATCH class=fencing retryable=false expected=2 actual=1"
+	if got := decorateServerResponse("ERROR: GEN_MISMATCH expected=2 actual=1", ctx); got != want {
+		t.Fatalf("decorated error = %q, want %q", got, want)
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -435,6 +436,19 @@ func TestProcessMessage_RawCommand(t *testing.T) {
 	msg := readFramed(t, client)
 	assert.NotEmpty(t, msg)
 	<-done
+}
+
+func TestParseRawTextCommandPreservesLongCommand(t *testing.T) {
+	rawData := []byte("REPLICATE_MESSAGE payload=" + strings.Repeat("x", 22000))
+	got, ok := parseRawTextCommand(rawData)
+	assert.True(t, ok)
+	assert.Equal(t, string(rawData), got)
+}
+
+func TestParseRawTextCommandRejectsLegacyEnvelope(t *testing.T) {
+	encoded := util.EncodeMessage("", "HELP")
+	_, ok := parseRawTextCommand(encoded)
+	assert.False(t, ok)
 }
 
 func TestProcessMessage_EncodedCommand(t *testing.T) {


### PR DESCRIPTION
Fixes

Large raw `REPLICATE_MESSAGE` batches could be misread as legacy topic envelopes because their first two ASCII bytes formed a valid envelope length. This caused cluster benchmark publishes to receive only the leader acknowledgement and fail quorum replication.

This change classifies known text commands before legacy envelope decoding in both the server and cluster router, while retaining the legacy envelope path. It also centralizes command-token recognition and covers large replication commands and envelope compatibility with regression tests.

Validation:

- `go test ./pkg/protocol ./pkg/cluster/controller ./pkg/server -count=1`
- `go vet ./pkg/protocol ./pkg/cluster/controller ./pkg/server`
- `go vet ./...`
- `RUN_E2E_BENCHMARK=1 go test -v -timeout 30m ./test/e2e-benchmark -count=1` (100,000 standalone and cluster messages; zero failed publishes, duplicates, or missing messages)

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.