### PR TITLE
feat: add standalone topic log compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Cursus is a lightweight, partitioned-log message broker written in Go. It runs a
 | Consumer delivery | At-least-once when processing finishes before committing `lastProcessedOffset + 1`. Committing first can produce at-most-once behavior. |
 | Transactions | Atomic broker visibility for staged output records plus one fenced consumer offset scope `(topic, group, member, generation)`. External database or service side effects are outside the broker transaction. |
 | Read isolation | `read_committed` is the default and hides open/aborted transactions. `read_uncommitted` exposes the raw committed partition log, including control records. |
-| Retention | Time/size deletion is supported. Log compaction is not implemented; `log_cleanup_policy` is normalized to `delete`. |
+| Retention | Time/size deletion and standalone keyed log compaction are supported. Compaction preserves offsets and transaction/control records; distributed and event-sourcing topics reject it. |
 | Protocol | Cursus-native TCP framing and commands. This project does not claim byte compatibility with another broker protocol. |
 
 ## Quick Start

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -35,7 +35,7 @@ A transaction does not collapse those owners into one in-memory object. The tran
 | Partition / consumer / broadcast buffers | `10000` / `1000` / `10000` |
 | Distribution | disabled unless configured |
 
-Configuration validation normalizes invalid values. Log compaction is not implemented; cleanup policy is `delete`.
+Configuration validation normalizes invalid values. Cleanup policy accepts `delete`, `compact`, or `delete,compact`; compaction is standalone-only and is rejected for event-sourcing topics.
 
 ## Concurrency
 

--- a/docs/core/storage/disk-format.md
+++ b/docs/core/storage/disk-format.md
@@ -56,7 +56,7 @@ uint64_be logicalOffset
 uint64_be bytePosition
 ```
 
-An entry is written after the configured byte interval (default 4096 bytes). Reads locate the segment and nearest indexed byte position, then scan and validate contiguous logical offsets. Segment data is opened through mmap for reads.
+An entry is written after the configured byte interval (default 4096 bytes). Reads locate the segment and nearest indexed byte position, validate that entry against the log, then scan records. Active segments require contiguous logical offsets. Compacted closed segments retain original offsets in strictly increasing order and may contain holes. Segment data is opened through mmap for reads.
 
 ## Write And Sync Contract
 
@@ -95,11 +95,13 @@ The encoded payload is limited to 32 MiB. Every accepted transition is appended 
 
 The journal is append-only and currently has no automatic compaction. Backups must keep it consistent with partition logs and the standalone consumer offset store.
 
-## Retention And Deletion
+## Retention And Compaction
 
-Time/size retention removes eligible closed segments through the retention loop. The active segment is preserved. `log_cleanup_policy=delete` is the only implemented cleanup policy; compaction is not implemented and unsupported values normalize to `delete`.
+`log_cleanup_policy` accepts `delete`, `compact`, or `delete,compact`. Time/size deletion removes complete eligible closed segments. Standalone compaction rewrites closed segments with same-directory `.compacting` files, fsyncs them, and atomically replaces the authoritative log followed by its rebuilt sparse index. Parent-directory metadata is synced where the platform supports it.
 
-Readers can hold references while retention runs. Deletion uses the storage lifecycle to avoid removing an actively read segment and returns `OFFSET_OUT_OF_RANGE` when a requested logical offset predates the earliest retained segment.
+The active segment is preserved by both operations. Active readers defer maintenance. A compacted closed log has a versioned `.log.compacted-<size>` sidecar; offset holes are accepted only when the sidecar is valid and its size matches the log. Backups must preserve the log, its matching sidecar, and its index as one generation. A stale sparse index after an interrupted replacement is correctness-safe because every candidate entry is validated and invalid entries fall back to a scan. Startup removes abandoned compaction temporary files and stale sidecars.
+
+Compaction preserves logical offsets and therefore permits holes only in closed segments. It is rejected for distributed and event-sourcing topics. The full selection and recovery contract is documented in [Log Compaction](log-compaction.md).
 
 ## Concurrency
 
@@ -121,3 +123,5 @@ Linux builds can apply sequential-access advice and zero-copy transfer where the
 | Linger | 50 ms |
 | File sync interval | 500 ms |
 | Cleanup policy | `delete` |
+| Compaction check interval | 300000 ms |
+| Minimum cleanable dirty ratio | 0.5 |

--- a/docs/core/storage/disk-persistence.md
+++ b/docs/core/storage/disk-persistence.md
@@ -7,7 +7,7 @@ Cursus stores every topic partition in an independent append-only segment log ma
 | Component | Responsibility |
 |---|---|
 | `DiskManager` | Handler registry keyed by topic/partition, shared configuration, close-all lifecycle, runtime storage metrics. |
-| `DiskHandler` | Offset allocation, buffered writes, segment/index files, mmap reads, recovery, sync callback, retention. |
+| `DiskHandler` | Offset allocation, buffered writes, segment/index files, mmap reads, recovery, sync callback, retention, and standalone compaction. |
 | `Partition` | HWM/LSO visibility, producer sequence state, transaction index, and broker-level read semantics. |
 
 The [disk format](disk-format.md) defines the record and sparse index bytes.
@@ -58,8 +58,8 @@ The old data file is flushed and synced, its index is flushed/closed, and the ne
 1. locates the segment containing the logical offset,
 2. uses the sparse `.index` file to choose a byte position,
 3. mmaps readable segments,
-4. validates record lengths and contiguous offsets,
-5. returns at most `max` decoded records.
+4. validates record lengths and offset order; active segments are contiguous while compacted closed segments may have holes,
+5. returns at most `max` decoded retained records.
 
 The raw storage read does not decide transaction visibility. `Partition.ReadCommitted` bounds records by HWM and LSO, hides control/aborted records, and requires matching partition and coordinator transaction decisions. `ReadMessages`/read-uncommitted callers receive raw committed-log content.
 
@@ -80,11 +80,13 @@ For the active segment, recovery scans length prefixes and serialized records. I
 
 After storage opens, higher layers rebuild producer sequence, event-stream, and transaction visibility indexes from durable state as needed. The consumer group coordinator restores offsets from the internal offset log. The transaction coordinator restores standalone state from `__transaction_state.journal` or distributed state from Raft metadata; neither coordinator infers its final decision from output record payloads alone.
 
-## Retention
+## Retention And Compaction
 
-The retention loop periodically evaluates closed segments against effective time and byte limits. Per-topic values override broker defaults. Deleted history changes the earliest readable offset; stale consumer reads receive `OFFSET_OUT_OF_RANGE` with earliest/latest boundaries.
+The maintenance loop evaluates delete retention and compaction on independent intervals. Per-topic retention and cleanup policy values override broker defaults.
 
-Only deletion cleanup is supported. Compaction settings are retained for configuration compatibility but do not activate compaction; `log_cleanup_policy` normalizes to `delete`.
+Delete retention removes complete closed segments and changes the earliest readable offset. Stale reads receive `OFFSET_OUT_OF_RANGE` with earliest/latest boundaries.
+
+Standalone compaction atomically rewrites eligible closed log/index files when the removable-byte ratio reaches the configured threshold. A durable size-bound sidecar distinguishes compacted holes from unmarked offset gaps in ordinary closed segments. Backups and restores must keep each compacted log, its matching sidecar, and its index together. Removed keyed records leave logical offset holes; reads continue at the first retained offset. Transaction/control records and the latest producer recovery record are protected. Distributed and event-sourcing topics reject compaction. See [Log Compaction](log-compaction.md).
 
 ## Shutdown
 
@@ -98,5 +100,6 @@ Only deletion cleanup is supported. Compaction settings are retained for configu
 | Lower latency | smaller batch/linger, shorter sync interval | More syscalls and lower aggregate throughput. |
 | Faster sparse seek | smaller index interval | Larger index files and more index writes. |
 | Shorter recovery | smaller segments/time roll | More files and metadata operations. |
+| More frequent compaction | shorter compaction interval or lower dirty ratio | More scans, rewrite I/O, and temporary disk usage. |
 
 Always validate tuning with restart and failure tests, not throughput alone.

--- a/docs/core/storage/log-compaction.md
+++ b/docs/core/storage/log-compaction.md
@@ -1,0 +1,79 @@
+# Log Compaction
+
+Cursus can compact keyed topic records on a standalone broker. Compaction retains the latest ordinary record for each key while preserving logical offsets and broker recovery metadata.
+
+## Scope
+
+Supported cleanup policies are:
+
+| Policy | Behavior |
+|---|---|
+| `delete` | Delete complete closed segments by retention time or retained bytes. |
+| `compact` | Rewrite eligible closed segments and remove superseded keyed records. |
+| `delete,compact` | Run both maintenance policies on their independent intervals. |
+
+Compaction is currently standalone-only. `CREATE` rejects a compact policy when distribution is enabled because follower catch-up does not yet install rewritten segment generations. Event-sourcing topics also reject compaction because aggregate replay requires complete history.
+
+## Record Selection
+
+Compaction operates independently per partition. A record can be removed only when all of the following are true:
+
+- it has a non-empty message key,
+- it has no transaction or control-batch metadata,
+- a later ordinary record with the same key exists in the partition,
+- it is not the latest durable record for its producer ID.
+
+Unkeyed records, transactional records, transaction markers, and control records are always retained. The latest record for each producer is retained as a producer sequence recovery anchor. An empty payload has no special expiry behavior; when it is the latest keyed value, it remains present.
+
+The active segment is never rewritten or used as a compaction input. Updates in the active segment become eligible only after that segment rolls. This can retain an older value for one extra pass, but it cannot remove the latest closed value prematurely.
+
+## Offset Contract
+
+Compaction never renumbers records and never moves the partition LEO or HWM. Removed records create physical holes in closed segments.
+
+A read from a removed offset returns the first retained record whose offset is greater than or equal to the requested offset. Consumer group commits remain `nextOffset` values, so a resumed consumer does not replay a compacted-away value. Unlike retention deletion, compaction does not move the earliest logical segment base solely because records were removed.
+
+The active segment remains contiguous and uses strict recovery validation. Closed compacted segments require strictly increasing offsets but may contain gaps.
+
+## Rewrite And Recovery
+
+The cleaner serializes with delete retention but keeps producer appends running during closed-segment scans and temporary-file construction:
+
+1. snapshot the set of closed segments,
+2. scan that snapshot to identify latest key and producer offsets,
+3. calculate superseded bytes in the same closed-segment snapshot,
+4. rewrite only closed segments when the dirty-byte ratio reaches `log_min_cleanable_dirty_ratio`,
+5. rebuild each rewritten sparse index,
+6. fsync same-directory temporary files and a versioned `.log.compacted-<size>` sidecar,
+7. install the sidecar before atomically replacing the log, then the index, and sync the parent directory where the platform supports it.
+
+The partition metadata lock is held only for the final replacement and directory sync. A segment that rolls while a pass is running is considered on the next pass.
+
+Readers permit logical offset holes only when a valid sidecar exists and its encoded size matches the current log file. A sidecar installed before a failed log replacement does not match the old larger file and is removed at startup. Once the compacted log is visible, its marker is already durable. Older size-bound markers remain until startup cleanup so an interrupted replacement still recognizes whichever log generation survived. Ordinary closed segments without a matching marker stay on strict contiguous-offset validation.
+
+The log is replaced first because it is authoritative. If a broker stops before the index replacement, a stale index entry is validated against the rewritten log and falls back to a scan. Startup removes abandoned `.compacting` files and stale sidecars. Rewritten segments retain their original modification time so time-based retention is not postponed.
+
+Active readers cause the maintenance pass to skip rather than replacing a mapped file.
+
+## Configuration
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `log_cleanup_policy` | `delete` | Broker default: `delete`, `compact`, or `delete,compact`. |
+| `log_compaction_check_interval_ms` | 300000 | Interval between compaction passes. |
+| `log_min_cleanable_dirty_ratio` | 0.5 | Minimum removable closed-segment bytes divided by total closed-segment bytes. |
+| `log_retention_check_interval_ms` | 300000 | Interval between delete-retention passes. |
+
+A topic overrides the broker cleanup default with `CREATE ... cleanup_policy=<policy>`. Repeating `CREATE` with the same partition count updates the topic policy. Provisioning code should issue the same idempotent topic declaration whenever it establishes broker resources.
+
+The Go SDK exposes `Producer.CreateTopicWithOptions` and `TopicOptions.CleanupPolicy`. Existing `CreateTopic(topic, partitions)` remains a compatibility wrapper and inherits the broker default.
+
+## Operational Guidance
+
+Keyed state topics are the intended use case. Choose a segment roll size/time that produces closed segments frequently enough to clean, then observe disk usage and cleaner duration before lowering the dirty ratio.
+
+Do not enable compaction for audit/event history that must retain every mutation. Use a separate compacted state topic and an uncompacted event-sourcing topic when both current state and full history are required.
+
+Backups and restores must preserve each compacted `.log` file together with its matching `.log.compacted-<size>` sidecar and `.index` file. A missing or invalid sidecar is not reconstructed from offset holes: startup and reads fail closed instead of treating an unmarked gap as valid compaction. Restore the files from the same backup generation before opening the broker.
+
+Distributed compacted-segment installation, tombstone grace periods, and per-topic dirty-ratio overrides are not part of the current contract.

--- a/docs/core/storage/segment-management.md
+++ b/docs/core/storage/segment-management.md
@@ -25,7 +25,7 @@ Rotation flushes and syncs the old data file, flushes/closes its index, resets b
 
 On open, the handler:
 
-1. removes completed deletion tombstones,
+1. removes completed deletion tombstones, abandoned `.compacting` files, and stale compaction sidecars,
 2. lists and sorts segment files,
 3. parses base offsets from filenames,
 4. scans and repairs the active tail,
@@ -36,13 +36,13 @@ Malformed filenames are skipped with an error log; an invalid active tail is tru
 
 ## Read Safety
 
-Reads copy the current ordered segment list and mmap each selected file. Active-reader accounting and the retention deletion lifecycle prevent a segment from disappearing while a read is using it. Sparse index entries map logical offsets to byte positions, after which the reader validates contiguous offsets.
+Reads copy the current ordered segment list and mmap each selected file. Active-reader accounting prevents retention or compaction from replacing a segment while a read is using it. Sparse index entries map logical offsets to byte positions and are validated against the log before use. Active and ordinary closed segments require contiguous offsets. A closed segment may contain physical holes only when its durable compaction sidecar matches the current log size.
 
-## Retention
+## Retention And Compaction
 
-Retention evaluates closed segments by age and total retained bytes. The active segment is never selected. Deletion is the only supported cleanup policy; log compaction is not implemented.
+Delete retention evaluates closed segments by age and total retained bytes. After deletion, `GetFirstOffset` exposes the new earliest base offset. A client requesting older data receives `OFFSET_OUT_OF_RANGE` and must follow its configured reset/error policy.
 
-After retention, `GetFirstOffset` exposes the new earliest base offset. A client requesting older data receives `OFFSET_OUT_OF_RANGE` and must follow its configured reset/error policy.
+Standalone compaction rewrites only closed segments and removes superseded keyed ordinary records. It preserves logical offsets, unkeyed records, transaction/control records, and the latest producer record. It does not move LEO/HWM or the logical segment base. The active segment is never rewritten. See [Log Compaction](log-compaction.md).
 
 ## Concurrency
 

--- a/docs/core/topic/topic-management.md
+++ b/docs/core/topic/topic-management.md
@@ -26,7 +26,9 @@ It does not use a global payload-hash deduplication map. Retry safety comes from
 | exists | greater | append new partitions and update policy |
 | exists | lower | reject; partition count never shrinks |
 
-New and existing partitions receive the current transaction decision resolver so `read_committed` uses coordinator authority.
+New and existing partitions receive the current transaction decision resolver so `read_committed` uses coordinator authority. Retention and cleanup policy are propagated to every partition handler. An existing event-sourcing topic remains protected even if a later idempotent create request omits or clears `event_sourcing`.
+
+`cleanup_policy` accepts `delete`, `compact`, and `delete,compact`. Compact policies are rejected when distribution is enabled or the topic is event-sourcing. Standalone compaction details are in [Log Compaction](../storage/log-compaction.md).
 
 ## Delete
 
@@ -45,7 +47,7 @@ Distributed command handling routes to the partition leader and applies replicat
 
 ## Topic
 
-A `Topic` owns partition selection, its partition slice, policy, and embedded consumer groups. `hash_key` uses key hashing and falls back to round-robin for empty keys; `round_robin` ignores keys. Policy controls retention overrides, read/write authorization, replication metadata, idempotent mode, and event-sourcing mode.
+A `Topic` owns partition selection, its partition slice, policy, and embedded consumer groups. `hash_key` uses key hashing and falls back to round-robin for empty keys; `round_robin` ignores keys. Policy controls cleanup/retention overrides and read/write authorization. Replication, idempotent mode, and event-sourcing mode are separate topic metadata.
 
 ## Partition
 

--- a/docs/core/topic/topics-and-partitions.md
+++ b/docs/core/topic/topics-and-partitions.md
@@ -58,7 +58,7 @@ Idempotent records use `(producerId, epoch, seqNum)` per partition. Higher epoch
 
 ## Storage
 
-Each partition has one `DiskHandler` with base-offset segment/index files. Async writes use a buffered channel and batch/linger policy; direct and follower writes preserve assigned offsets. Default data segments roll at 1 GiB, index capacity, or seven days. Retention deletes closed segments by time/size; compaction is not implemented.
+Each partition has one `DiskHandler` with base-offset segment/index files. Async writes use a buffered channel and batch/linger policy; direct and follower writes preserve assigned offsets. Default data segments roll at 1 GiB, index capacity, or seven days. Retention can delete closed segments by time/size. Standalone keyed topics can also compact closed segments while preserving logical offsets, unkeyed records, transaction/control records, and producer recovery anchors.
 
 ## Cluster Ownership
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -165,6 +165,7 @@ Version 1 features currently advertised by the broker are:
 | `offset_resume_v1` | Supports broker-owned `FETCH_OFFSET`/commit resume semantics |
 | `idempotent_producer_v1` | Supports producer ID, epoch, and sequence fencing |
 | `event_sourcing_v1` | Supports event stream and snapshot commands |
+| `topic_compaction_v1` | Supports per-topic cleanup policy declaration and standalone keyed closed-segment compaction |
 
 Feature names describe independent contracts; clients must not infer support for an unadvertised feature from the protocol version alone.
 
@@ -174,13 +175,15 @@ Feature names describe independent contracts; clients must not infer support for
 
 **CREATE**
 ```
-CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [replication_factor=<N>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read|acl>] [read_acl=<principal[,principal]>] [write_acl=<principal[,principal]>]
+CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [event_sourcing=<true|false>] [replication_factor=<N>] [cleanup_policy=<delete|compact|delete,compact>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read|acl>] [read_acl=<principal[,principal]>] [write_acl=<principal[,principal]>]
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
 | topic | Yes | - | Topic name |
 | partitions | No | 4 | Number of partitions |
 | idempotent | No | false | Enable producer dedup |
+| event_sourcing | No | false | Enable aggregate stream commands; requires non-compacted history |
+| cleanup_policy | No | broker default | `delete`, `compact`, or canonical combined policy `delete,compact` |
 | retention_hours | No | 0 | Per-topic retention hours override metadata; 0 means broker default |
 | retention_bytes | No | 0 | Per-topic retention bytes override metadata; 0 means broker default |
 | partitioner | No | hash_key | `hash_key` uses message key hash, `round_robin` ignores keys |
@@ -189,7 +192,9 @@ CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [replication_fact
 | write_acl | No | - | Comma-separated principals allowed to write when `auth_policy=acl`; `*` allows any authenticated principal |
 | replication_factor | No | 3 | Replica count (distributed mode) |
 
-Response: `OK topic=<name> partitions=<N> partitioner=<hash_key|round_robin> auth_policy=<open|deny_write|deny_read|acl> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>`
+Response: `OK topic=<name> partitions=<N> cleanup_policy=<policy> partitioner=<hash_key|round_robin> auth_policy=<open|deny_write|deny_read|acl> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>`
+
+`compact` and `delete,compact` are accepted only by standalone, non-event-sourcing topics. Unsupported combinations return `ERROR: invalid_topic_policy ...` or `ERROR: unsupported_topic_policy ...`. Repeating `CREATE` for an existing event-sourcing topic cannot use a false `event_sourcing` argument to bypass this validation.
 
 **DELETE**
 ```
@@ -298,9 +303,9 @@ METADATA topic=<name>
 |-------|----------|-------------|
 | topic | Yes | Topic name |
 
-Response: `OK topic=<name> partitions=<N> leaders=<host:port>,<host:port>,...`
+Response: `OK topic=<name> partitions=<N> leaders=<host:port>,<host:port>,... epochs=<csv> cleanup_policy=<policy> partitioner=<policy> auth_policy=<policy> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>`
 
-Returns the client-facing address of each partition's leader broker, in partition order (P0, P1, P2, ...).
+Returns partition leaders/epochs and the authoritative in-memory topic policy. Leader addresses are in partition order (P0, P1, P2, ...).
 
 Any broker can answer this command. Addresses are the advertised client addresses from the FSM broker registry.
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -58,7 +58,7 @@ With `structured_errors_v1` enabled, subsequent text errors use `ERROR: <code> c
 ### CREATE
 
 ```text
-CREATE topic=<name> [partitions=<N>] [idempotent=<bool>] [event_sourcing=<bool>] [replication_factor=<N>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read|acl>] [read_acl=<principal[,principal]>] [write_acl=<principal[,principal]>]
+CREATE topic=<name> [partitions=<N>] [idempotent=<bool>] [event_sourcing=<bool>] [replication_factor=<N>] [cleanup_policy=<delete|compact|delete,compact>] [retention_hours=<N>] [retention_bytes=<N>] [partitioner=<hash_key|round_robin>] [auth_policy=<open|deny_write|deny_read|acl>] [read_acl=<principal[,principal]>] [write_acl=<principal[,principal]>]
 ```
 
 Creates a topic or increases its partition count when the topic already exists.
@@ -66,7 +66,7 @@ Creates a topic or increases its partition count when the topic already exists.
 Success:
 
 ```text
-OK topic=<name> partitions=<N>
+OK topic=<name> partitions=<N> cleanup_policy=<policy> partitioner=<policy> auth_policy=<policy> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>
 ```
 
 Common errors:
@@ -75,6 +75,8 @@ Common errors:
 ERROR: missing_topic expected="CREATE topic=<name> [partitions=<N>]"
 ERROR: invalid_partitions reason="must be a positive integer"
 ERROR: invalid_replication_factor reason="must be a positive integer"
+ERROR: invalid_topic_policy field=cleanup_policy reason="..."
+ERROR: unsupported_topic_policy field=cleanup_policy reason="..."
 ERROR: create_topic_failed reason="..."
 ```
 
@@ -453,7 +455,11 @@ ERROR: NOT_COORDINATOR host=<host> port=<port>
 METADATA topic=<name>
 ```
 
-Success is a JSON metadata response with `status:"OK"`.
+Success is a text response:
+
+```text
+OK topic=<name> partitions=<N> leaders=<csv> epochs=<csv> cleanup_policy=<policy> partitioner=<policy> auth_policy=<policy> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>
+```
 
 Common errors:
 

--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -7,7 +7,7 @@ Cursus is a Cursus-native partitioned-log broker. Its goal is to provide durable
 | Area | Cursus today | Contract boundary |
 |---|---|---|
 | Deployment | Single Go binary; standalone or Raft-backed cluster | Cluster operation still requires deliberate storage, certificate, and quorum management. |
-| Storage | Append-only segments, offset index, mmap reads, configurable rolling, time/size deletion, corruption recovery | Log compaction and a general timestamp index are not implemented. |
+| Storage | Append-only segments, sparse offset index, mmap reads, configurable rolling, time/size deletion, standalone keyed compaction, corruption recovery | Compacted-segment replication and a general timestamp index are not implemented. |
 | Ordering | Stable order within one partition | No cross-partition total order. |
 | Consumer groups | Dynamic membership, generation/owner fencing, monotonic durable offsets, restart resume | Assignment strategy is intentionally simpler than mature multi-assignor ecosystems. |
 | Replication | Partition leaders, ISR/quorum checks, high-watermark recovery, follower catch-up | Long-running fault injection across every topology remains an ongoing validation area. |
@@ -30,7 +30,7 @@ Cursus is a Cursus-native partitioned-log broker. Its goal is to provide durable
 
 Cursus is a strong fit when a team wants a partitioned durable log, consumer-group resume, event streams, and transactional broker processing without operating a large runtime stack. It is especially useful for Go services, game backends, edge deployments, and focused event-processing systems where the compact text/binary protocol is an advantage.
 
-A more mature or specialized platform may be a better fit when the deployment requires a very large connector ecosystem, multi-datacenter replication with established operational tooling, many assignment strategies, log compaction, tiered storage, or independently audited long-duration failure evidence today.
+A more mature or specialized platform may be a better fit when the deployment requires a very large connector ecosystem, multi-datacenter compacted-log replication, established multi-datacenter tooling, many assignment strategies, tiered storage, or independently audited long-duration failure evidence today.
 
 ## Evaluation Rule
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -60,6 +60,12 @@ Batch related records and offsets into a meaningful transaction, but avoid unbou
 
 Coordinator synchronization currently persists the complete staged transaction snapshot after each mutation. Very large transactions therefore amplify standalone journal and distributed metadata traffic; keep transaction batches bounded and measure coordinator latency as well as partition throughput. A standalone encoded snapshot record is limited to 32 MiB. The standalone journal is append-only and does not yet compact superseded snapshots automatically.
 
+## Compaction Cost
+
+Standalone keyed compaction scans a snapshot of closed segments twice before rewriting only segments that contain removable records. Cleaner memory is proportional to the number of distinct keys and producer IDs in that closed snapshot, not just the active segment. Temporary disk demand can approach the retained size of the largest segment being rewritten.
+
+Producer appends continue during scanning and temporary-file construction. The partition metadata lock is held only while a prepared log/index pair replaces the closed segment and the directory entry is synced. Larger segments reduce roll frequency but increase cleaner scan time, peak temporary space, and the delay before an active key update becomes eligible.
+
 ## Example Profiles
 
 ### Throughput-oriented starting point

--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -135,6 +135,21 @@ if errors.As(err, &brokerErr) {
 
 `BrokerError` exposes `Code`, `Class`, `Retryable`, `Fields`, and the raw response. It also remains compatible with existing Go SDK sentinels such as `ErrTopicNotFound`, `ErrInvalidPartition`, and `ErrNotLeader` through `errors.Is`.
 
+## Go Topic Policy
+
+`CreateTopic` remains the compatibility API and inherits broker policy defaults. Use `CreateTopicWithOptions` for an explicit cleanup contract:
+
+```go
+err := producer.CreateTopicWithOptions("player-state", sdk.TopicOptions{
+    Partitions:     12,
+    CleanupPolicy:  sdk.TopicCleanupCompact,
+    RetentionHours: 168,
+    Partitioner:    "hash_key",
+})
+```
+
+The SDK canonicalizes `compact,delete` to `delete,compact` and rejects unsafe command values, negative retention, or unknown policy enums before opening the command connection. Compact policies require a standalone, non-event-sourcing topic. `EventStore.CreateTopic` explicitly declares `cleanup_policy=delete`.
+
 ## Go Transactional Producer
 
 The Go SDK exposes both the existing low-level transaction commands and a

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -101,8 +101,9 @@ RUN_E2E_BENCHMARK=1 go test -v -timeout 30m ./test/e2e-benchmark/...
 - one broker transaction may commit offsets for one `(topic, group, member, generation)` scope,
 - initialize a new producer epoch before each new transaction; finalization retry keeps the old epoch,
 - ordering is per partition,
-- retention deletion can create offset gaps,
-- log compaction is not implemented.
+- retention deletion can move the earliest offset,
+- standalone keyed compaction creates physical holes without renumbering logical offsets,
+- compaction is rejected for distributed and event-sourcing topics.
 
 ## Next Steps
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -156,8 +156,10 @@ These parameters directly affect the write path performance and batching behavio
 | `log_retention_hours`   | int  | 168     | Log retention period in hours (7 days default)            |
 | `log_retention_bytes`   | int64 | -1     | Retained byte limit; `-1` means unlimited                 |
 | `log_segment_roll_ms`   | int  | 604800000 | Time-based roll interval (7 days)                       |
-| `log_cleanup_policy`    | string | "delete" | Only implemented cleanup policy; compaction is unsupported |
-| `log_retention_check_interval_ms` | int | 300000 | Retention evaluation interval                          |
+| `log_cleanup_policy`    | string | "delete" | `delete`, `compact`, or `delete,compact`; compact policies are standalone-only |
+| `log_retention_check_interval_ms` | int | 300000 | Delete-retention evaluation interval                  |
+| `log_compaction_check_interval_ms` | int | 300000 | Closed-segment compaction evaluation interval         |
+| `log_min_cleanable_dirty_ratio` | float64 | 0.5 | Minimum removable-byte ratio before compaction         |
 | `compression_type`      | string | "none" | Compression type: "none", "gzip", "snappy", "lz4"       |
 
 
@@ -418,6 +420,6 @@ log.Fatal(http.ListenAndServe(":2112", nil))
 
 `Config.Normalize()` applies safe fallbacks for invalid or non-positive values, including write batching, sync intervals, segment/index sizes, retention intervals, channel capacities, replica settings, and transaction/producer retention. TLS certificate loading still fails startup when configured files are invalid.
 
-Unsupported `log_cleanup_policy` values, including `compact`, normalize to `delete` with a warning because compaction is not implemented. Operators should treat normalization warnings as configuration errors in production and verify the effective startup configuration.
+Cleanup policy values normalize to `delete`, `compact`, or canonical `delete,compact`; unknown values fall back to `delete` with a warning. A broker configured for distribution rejects compact topic creation, and event-sourcing topics always require `delete`. Operators should treat normalization and policy errors as configuration/provisioning failures and verify the effective topic policy with `METADATA`.
 
 Missing values fall back to defaults in `pkg/config/properties.go`. Configuration precedence is defaults, file, environment, then CLI overrides where a flag is exposed.

--- a/docs/user-guide/event-sourcing.md
+++ b/docs/user-guide/event-sourcing.md
@@ -23,7 +23,7 @@ Without broker-level support, applications must implement concurrency control, v
 ### 1. Create an Event-Sourcing Topic
 
 ```
-CREATE topic=orders partitions=4 event_sourcing=true
+CREATE topic=orders partitions=4 event_sourcing=true cleanup_policy=delete
 ```
 
 Response:

--- a/pkg/config/cleanup_policy.go
+++ b/pkg/config/cleanup_policy.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	CleanupPolicyDelete        = "delete"
+	CleanupPolicyCompact       = "compact"
+	CleanupPolicyDeleteCompact = "delete,compact"
+)
+
+// NormalizeCleanupPolicy returns the canonical cleanup policy and whether the
+// input contains only supported policy names.
+func NormalizeCleanupPolicy(value string) (string, bool) {
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(value)), ",")
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		switch part {
+		case CleanupPolicyDelete, CleanupPolicyCompact:
+			seen[part] = struct{}{}
+		default:
+			return "", false
+		}
+	}
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	if len(values) == 2 {
+		return CleanupPolicyDeleteCompact, true
+	}
+	return values[0], true
+}
+
+// HasCleanupPolicy reports whether a canonical cleanup policy includes the expected policy.
+func HasCleanupPolicy(policy, expected string) bool {
+	normalized, ok := NormalizeCleanupPolicy(policy)
+	if !ok {
+		return false
+	}
+	for _, value := range strings.Split(normalized, ",") {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/properties.go
+++ b/pkg/config/properties.go
@@ -54,7 +54,7 @@ type Config struct {
 	SegmentRollTimeMS         int     `yaml:"log_segment_roll_ms" json:"log.segment.roll.ms"`
 	IndexSize                 uint64  `yaml:"log_index_size_bytes" json:"log.index.size.bytes"`
 	IndexIntervalBytes        int     `yaml:"log_index_interval_bytes" json:"log.index.interval.bytes"`
-	CleanupPolicy             string  `yaml:"log_cleanup_policy" json:"log.cleanup.policy"` // delete; compaction is not implemented
+	CleanupPolicy             string  `yaml:"log_cleanup_policy" json:"log.cleanup.policy"`
 	RetentionHours            int     `yaml:"log_retention_hours" json:"log.retention.hours"`
 	RetentionBytes            int64   `yaml:"log_retention_bytes" json:"log.retention.bytes"`
 	RetentionCheckIntervalMS  int     `yaml:"log_retention_check_interval_ms" json:"log.retention.check.interval.ms"`
@@ -233,7 +233,7 @@ func LoadConfig() (*Config, error) {
 	var indexSizeInt64 int64
 	flag.Int64Var(&indexSizeInt64, "index-size", int64(cfg.IndexSize), "Max index file size")
 	flag.IntVar(&cfg.IndexIntervalBytes, "index-interval-bytes", cfg.IndexIntervalBytes, "Index interval bytes")
-	flag.StringVar(&cfg.CleanupPolicy, "cleanup-policy", cfg.CleanupPolicy, "Cleanup policy (delete)")
+	flag.StringVar(&cfg.CleanupPolicy, "cleanup-policy", cfg.CleanupPolicy, "Cleanup policy (delete, compact, or delete,compact)")
 	flag.IntVar(&cfg.RetentionHours, "retention-hours", cfg.RetentionHours, "Retention hours")
 	flag.Int64Var(&cfg.RetentionBytes, "retention-bytes", cfg.RetentionBytes, "Retention bytes")
 	flag.IntVar(&cfg.RetentionCheckIntervalMS, "retention-check-interval", cfg.RetentionCheckIntervalMS, "Retention check interval")

--- a/pkg/config/properties_ext_test.go
+++ b/pkg/config/properties_ext_test.go
@@ -34,12 +34,26 @@ func TestLoadConfig_EnvOverrides(t *testing.T) {
 	}
 }
 
-func TestConfigNormalizeFallsBackFromUnimplementedCompaction(t *testing.T) {
+func TestConfigNormalizeCleanupPolicies(t *testing.T) {
+	for input, expected := range map[string]string{
+		"compact":        config.CleanupPolicyCompact,
+		"delete":         config.CleanupPolicyDelete,
+		"compact,delete": config.CleanupPolicyDeleteCompact,
+		"delete,compact": config.CleanupPolicyDeleteCompact,
+	} {
+		cfg := config.DefaultConfig()
+		cfg.CleanupPolicy = input
+		cfg.Normalize()
+		if cfg.CleanupPolicy != expected {
+			t.Fatalf("cleanup policy %q normalized to %q, want %q", input, cfg.CleanupPolicy, expected)
+		}
+	}
+
 	cfg := config.DefaultConfig()
-	cfg.CleanupPolicy = "compact"
+	cfg.CleanupPolicy = "unknown"
 	cfg.Normalize()
-	if cfg.CleanupPolicy != "delete" {
-		t.Fatalf("expected unsupported compaction to normalize to delete, got %q", cfg.CleanupPolicy)
+	if cfg.CleanupPolicy != config.CleanupPolicyDelete {
+		t.Fatalf("invalid cleanup policy normalized to %q", cfg.CleanupPolicy)
 	}
 }
 

--- a/pkg/config/properties_helper.go
+++ b/pkg/config/properties_helper.go
@@ -48,12 +48,11 @@ func (cfg *Config) Normalize() {
 	}
 
 	// log segment & retention
-	cfg.CleanupPolicy = strings.ToLower(strings.TrimSpace(cfg.CleanupPolicy))
-	switch cfg.CleanupPolicy {
-	case "delete":
-	default:
+	if normalized, ok := NormalizeCleanupPolicy(cfg.CleanupPolicy); ok {
+		cfg.CleanupPolicy = normalized
+	} else {
 		util.Warn("Invalid cleanup_policy '%s', defaulting to 'delete'", cfg.CleanupPolicy)
-		cfg.CleanupPolicy = "delete"
+		cfg.CleanupPolicy = CleanupPolicyDelete
 	}
 	if cfg.CleanupInterval <= 0 {
 		cfg.CleanupInterval = 300

--- a/pkg/controller/cleanup_policy_test.go
+++ b/pkg/controller/cleanup_policy_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAndMetadataExposeCleanupPolicy(t *testing.T) {
+	handler, manager := newTestHandler(t)
+	response := handler.HandleCommand("CREATE topic=state partitions=1 cleanup_policy=compact", NewClientContext("", 0))
+	require.True(t, strings.HasPrefix(response, "OK "))
+	require.Contains(t, response, "cleanup_policy=compact")
+	require.Equal(t, config.CleanupPolicyCompact, manager.GetTopic("state").Policy.CleanupPolicy)
+
+	response = handler.HandleCommand("METADATA topic=state", NewClientContext("", 0))
+	require.True(t, strings.HasPrefix(response, "OK "))
+	require.Contains(t, response, "cleanup_policy=compact")
+}
+
+func TestCreateRejectsCompactionForExistingEventSourcingTopic(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	response := handler.HandleCommand("CREATE topic=events partitions=1 event_sourcing=true cleanup_policy=delete", NewClientContext("", 0))
+	require.True(t, strings.HasPrefix(response, "OK "))
+
+	response = handler.HandleCommand("CREATE topic=events partitions=1 cleanup_policy=compact", NewClientContext("", 0))
+	require.Contains(t, response, "ERROR: invalid_topic_policy")
+}
+
+func TestCreateRejectsCompactionForUnsupportedTopicModes(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	response := handler.HandleCommand("CREATE topic=events partitions=1 event_sourcing=true cleanup_policy=compact", NewClientContext("", 0))
+	require.Contains(t, response, "ERROR: invalid_topic_policy")
+
+	handler.Config.EnabledDistribution = true
+	response = handler.HandleCommand("CREATE topic=distributed partitions=1 cleanup_policy=compact", NewClientContext("", 0))
+	require.Contains(t, response, "ERROR: unsupported_topic_policy")
+}

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/util"
@@ -62,9 +63,21 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 		eventSourcing = strings.ToLower(esStr) == "true"
 	}
 
-	policy, policyErr := parseTopicPolicy(args)
+	policy, policyErr := parseTopicPolicy(args, ch.Config.CleanupPolicy)
 	if policyErr != "" {
 		return policyErr
+	}
+	effectiveEventSourcing := eventSourcing
+	if existing := ch.TopicManager.GetTopic(topicName); existing != nil && existing.IsEventSourcing {
+		effectiveEventSourcing = true
+	}
+	if config.HasCleanupPolicy(policy.CleanupPolicy, config.CleanupPolicyCompact) {
+		if effectiveEventSourcing {
+			return `ERROR: invalid_topic_policy field=cleanup_policy reason="compaction is not supported for event-sourcing topics"`
+		}
+		if ch.Config.EnabledDistribution {
+			return `ERROR: unsupported_topic_policy field=cleanup_policy reason="compaction is not supported in distributed mode"`
+		}
 	}
 
 	replicationFactor := ch.Config.DefaultReplicationFactor
@@ -111,11 +124,17 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 			util.Warn("Failed to register default group with coordinator: %v", err)
 		}
 	}
-	return fmt.Sprintf("OK topic=%s partitions=%d partitioner=%s auth_policy=%s read_acl=%s write_acl=%s retention_hours=%d retention_bytes=%d", topicName, len(t.Partitions), t.Policy.Partitioner, t.Policy.AuthPolicy, strings.Join(t.Policy.ReadACL, ","), strings.Join(t.Policy.WriteACL, ","), t.Policy.RetentionHours, t.Policy.RetentionBytes)
+	return fmt.Sprintf("OK topic=%s partitions=%d cleanup_policy=%s partitioner=%s auth_policy=%s read_acl=%s write_acl=%s retention_hours=%d retention_bytes=%d", topicName, len(t.Partitions), t.Policy.CleanupPolicy, t.Policy.Partitioner, t.Policy.AuthPolicy, strings.Join(t.Policy.ReadACL, ","), strings.Join(t.Policy.WriteACL, ","), t.Policy.RetentionHours, t.Policy.RetentionBytes)
 }
 
-func parseTopicPolicy(args map[string]string) (topic.Policy, string) {
+func parseTopicPolicy(args map[string]string, defaultCleanupPolicy string) (topic.Policy, string) {
 	policy := topic.DefaultPolicy()
+	if defaultCleanupPolicy != "" {
+		policy.CleanupPolicy = defaultCleanupPolicy
+	}
+	if v := args["cleanup_policy"]; v != "" {
+		policy.CleanupPolicy = v
+	}
 	if v := args["retention_hours"]; v != "" {
 		parsed, err := strconv.Atoi(v)
 		if err != nil {
@@ -1090,8 +1109,8 @@ func (ch *CommandHandler) handleMetadata(cmd string) string {
 		}
 	}
 
-	return fmt.Sprintf("OK topic=%s partitions=%d leaders=%s epochs=%s partitioner=%s auth_policy=%s read_acl=%s write_acl=%s retention_hours=%d retention_bytes=%d",
-		topicName, partitionCount, strings.Join(leaders, ","), strings.Join(epochs, ","), t.Policy.Partitioner, t.Policy.AuthPolicy, strings.Join(t.Policy.ReadACL, ","), strings.Join(t.Policy.WriteACL, ","), t.Policy.RetentionHours, t.Policy.RetentionBytes)
+	return fmt.Sprintf("OK topic=%s partitions=%d leaders=%s epochs=%s cleanup_policy=%s partitioner=%s auth_policy=%s read_acl=%s write_acl=%s retention_hours=%d retention_bytes=%d",
+		topicName, partitionCount, strings.Join(leaders, ","), strings.Join(epochs, ","), t.Policy.CleanupPolicy, t.Policy.Partitioner, t.Policy.AuthPolicy, strings.Join(t.Policy.ReadACL, ","), strings.Join(t.Policy.WriteACL, ","), t.Policy.RetentionHours, t.Policy.RetentionBytes)
 }
 
 func (ch *CommandHandler) handleFindCoordinator(cmd string) string {

--- a/pkg/disk/compaction.go
+++ b/pkg/disk/compaction.go
@@ -313,7 +313,7 @@ func (d *DiskHandler) compactClosedSegment(segment uint64, allowOffsetGaps bool,
 		if _, err := logFile.Write(frame.raw); err != nil {
 			return fmt.Errorf("write compacted log: %w", err)
 		}
-		outputPosition += uint64(frame.size)
+		outputPosition += safeIntToUint64(frame.size)
 		after += int64(frame.size)
 		return nil
 	})

--- a/pkg/disk/compaction.go
+++ b/pkg/disk/compaction.go
@@ -40,16 +40,16 @@ type compactionFrame struct {
 // EnforceCompaction rewrites eligible closed segments for compacted topics.
 func (d *DiskHandler) EnforceCompaction() (CompactionResult, error) {
 	var result CompactionResult
-	if !config.HasCleanupPolicy(d.CleanupPolicy(), config.CleanupPolicyCompact) {
-		result.SkippedReason = "policy_disabled"
-		return result, nil
-	}
 	if d.distributed {
 		return result, fmt.Errorf("log compaction is not supported in distributed mode")
 	}
 
 	d.maintenanceMu.Lock()
 	defer d.maintenanceMu.Unlock()
+	if !config.HasCleanupPolicy(d.CleanupPolicy(), config.CleanupPolicyCompact) {
+		result.SkippedReason = "policy_disabled"
+		return result, nil
+	}
 	if atomic.LoadInt32(&d.activeReaders) > 0 {
 		result.SkippedReason = "active_readers"
 		return result, nil

--- a/pkg/disk/compaction.go
+++ b/pkg/disk/compaction.go
@@ -1,0 +1,529 @@
+package disk
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
+)
+
+var errCompactionReadersActive = errors.New("compaction deferred while readers are active")
+
+// CompactionResult describes the work completed by one compaction pass.
+type CompactionResult struct {
+	SegmentsScanned   int
+	SegmentsRewritten int
+	RecordsScanned    int
+	RecordsRemoved    int
+	BytesBefore       int64
+	BytesAfter        int64
+	SkippedReason     string
+}
+
+type compactionFrame struct {
+	message types.DiskMessage
+	raw     []byte
+	size    int
+}
+
+// EnforceCompaction rewrites eligible closed segments for compacted topics.
+func (d *DiskHandler) EnforceCompaction() (CompactionResult, error) {
+	var result CompactionResult
+	if !config.HasCleanupPolicy(d.CleanupPolicy(), config.CleanupPolicyCompact) {
+		result.SkippedReason = "policy_disabled"
+		return result, nil
+	}
+	if d.distributed {
+		return result, fmt.Errorf("log compaction is not supported in distributed mode")
+	}
+
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
+	if atomic.LoadInt32(&d.activeReaders) > 0 {
+		result.SkippedReason = "active_readers"
+		return result, nil
+	}
+
+	d.mu.Lock()
+	currentSegment := d.CurrentSegment
+	segmentSnapshot := append([]uint64(nil), d.segments...)
+	d.mu.Unlock()
+
+	closedSegments := make([]uint64, 0, len(segmentSnapshot))
+	for _, segment := range segmentSnapshot {
+		if segment != currentSegment {
+			closedSegments = append(closedSegments, segment)
+		}
+	}
+	sort.Slice(closedSegments, func(i, j int) bool { return closedSegments[i] < closedSegments[j] })
+	if len(closedSegments) == 0 {
+		result.SkippedReason = "no_closed_segments"
+		return result, nil
+	}
+
+	segmentAllowsGaps := make(map[uint64]bool, len(closedSegments))
+	for _, segment := range closedSegments {
+		info, err := os.Stat(d.GetSegmentPath(segment))
+		if err != nil {
+			return result, fmt.Errorf("stat segment %d: %w", segment, err)
+		}
+		segmentAllowsGaps[segment] = d.segmentAllowsOffsetGaps(segment, info.Size())
+	}
+
+	latestKeyOffset := make(map[string]uint64)
+	latestProducerOffset := make(map[string]uint64)
+	for _, segment := range closedSegments {
+		err := scanCompactionSegment(d.GetSegmentPath(segment), segment, false, segmentAllowsGaps[segment], func(frame compactionFrame) error {
+			result.RecordsScanned++
+			if isOrdinaryKeyedRecord(frame.message) {
+				latestKeyOffset[frame.message.Key] = frame.message.Offset
+			}
+			if frame.message.ProducerID != "" {
+				latestProducerOffset[frame.message.ProducerID] = frame.message.Offset
+			}
+			return nil
+		})
+		if err != nil {
+			return result, fmt.Errorf("scan segment %d: %w", segment, err)
+		}
+		result.SegmentsScanned++
+	}
+
+	var removableBytes int64
+	removableBytesBySegment := make(map[uint64]int64, len(closedSegments))
+	for _, segment := range closedSegments {
+		var segmentRemovableBytes int64
+		err := scanCompactionSegment(d.GetSegmentPath(segment), segment, false, segmentAllowsGaps[segment], func(frame compactionFrame) error {
+			frameBytes := int64(frame.size)
+			result.BytesBefore += frameBytes
+			if shouldRemoveCompactionRecord(frame.message, latestKeyOffset, latestProducerOffset) {
+				removableBytes += frameBytes
+				segmentRemovableBytes += frameBytes
+			}
+			return nil
+		})
+		if err != nil {
+			return result, fmt.Errorf("evaluate segment %d: %w", segment, err)
+		}
+		removableBytesBySegment[segment] = segmentRemovableBytes
+	}
+	if removableBytes == 0 {
+		result.BytesAfter = result.BytesBefore
+		result.SkippedReason = "no_superseded_records"
+		return result, nil
+	}
+
+	ratio := d.compactionDirtyRatio()
+	if result.BytesBefore == 0 || float64(removableBytes)/float64(result.BytesBefore) < ratio {
+		result.BytesAfter = result.BytesBefore
+		result.SkippedReason = "dirty_ratio"
+		return result, nil
+	}
+
+	var removedBytes int64
+	for _, segment := range closedSegments {
+		if removableBytesBySegment[segment] == 0 {
+			continue
+		}
+		removed, before, after, err := d.compactClosedSegment(segment, segmentAllowsGaps[segment], latestKeyOffset, latestProducerOffset)
+		if errors.Is(err, errCompactionReadersActive) {
+			result.BytesAfter = result.BytesBefore - removedBytes
+			result.SkippedReason = "active_readers"
+			return result, nil
+		}
+		if err != nil {
+			return result, fmt.Errorf("compact segment %d: %w", segment, err)
+		}
+		if removed > 0 {
+			result.SegmentsRewritten++
+			result.RecordsRemoved += removed
+			removedBytes += before - after
+		}
+	}
+	result.BytesAfter = result.BytesBefore - removedBytes
+	return result, nil
+}
+
+func (d *DiskHandler) compactionDirtyRatio() float64 {
+	d.retentionMu.RLock()
+	defer d.retentionMu.RUnlock()
+	if d.minCleanableDirtyRatio <= 0 || d.minCleanableDirtyRatio >= 1 {
+		return 0.5
+	}
+	return d.minCleanableDirtyRatio
+}
+
+func isOrdinaryKeyedRecord(message types.DiskMessage) bool {
+	return message.Key != "" && !hasTransactionMetadata(message)
+}
+
+func hasTransactionMetadata(message types.DiskMessage) bool {
+	return message.TransactionalID != "" ||
+		message.TransactionState != "" ||
+		message.TransactionMarker != "" ||
+		message.ControlBatchType != "" ||
+		message.ControlBatchVersion != 0 ||
+		message.ControlBatchCoordinatorEpoch != 0 ||
+		len(message.ControlBatchKey) != 0 ||
+		len(message.ControlBatchValue) != 0
+}
+
+func shouldRemoveCompactionRecord(message types.DiskMessage, latestKeyOffset, latestProducerOffset map[string]uint64) bool {
+	if !isOrdinaryKeyedRecord(message) || latestKeyOffset[message.Key] == message.Offset {
+		return false
+	}
+	if message.ProducerID != "" && latestProducerOffset[message.ProducerID] == message.Offset {
+		return false
+	}
+	return true
+}
+
+func scanCompactionSegment(path string, expectedBase uint64, includeRaw, allowOffsetGaps bool, visit func(compactionFrame) error) error {
+	// #nosec G304 -- path is generated from the broker-owned log directory and a numeric segment ID.
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReader(file)
+	var position uint64
+	var previousOffset uint64
+	havePrevious := false
+	for {
+		var lengthBytes [4]byte
+		_, err := io.ReadFull(reader, lengthBytes[:])
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read record length at byte %d: %w", position, err)
+		}
+
+		length := binary.BigEndian.Uint32(lengthBytes[:])
+		if length == 0 || length > MaxMessageSize {
+			return fmt.Errorf("invalid record length %d at byte %d", length, position)
+		}
+		payload := make([]byte, length)
+		if _, err := io.ReadFull(reader, payload); err != nil {
+			return fmt.Errorf("read record payload at byte %d: %w", position, err)
+		}
+		message, err := util.DeserializeDiskMessage(payload)
+		if err != nil {
+			return fmt.Errorf("decode record at byte %d: %w", position, err)
+		}
+		if !havePrevious && !allowOffsetGaps && message.Offset != expectedBase {
+			return fmt.Errorf("unexpected first offset %d for segment base %d", message.Offset, expectedBase)
+		}
+		if havePrevious && message.Offset <= previousOffset {
+			return fmt.Errorf("non-increasing offset %d after %d", message.Offset, previousOffset)
+		}
+		if havePrevious && !allowOffsetGaps && message.Offset != previousOffset+1 {
+			return fmt.Errorf("non-contiguous offset %d after %d", message.Offset, previousOffset)
+		}
+
+		size := 4 + len(payload)
+		var raw []byte
+		if includeRaw {
+			raw = make([]byte, size)
+			copy(raw[:4], lengthBytes[:])
+			copy(raw[4:], payload)
+		}
+		if err := visit(compactionFrame{message: message, raw: raw, size: size}); err != nil {
+			return err
+		}
+		position += uint64(size)
+		previousOffset = message.Offset
+		havePrevious = true
+	}
+}
+
+func (d *DiskHandler) compactClosedSegment(segment uint64, allowOffsetGaps bool, latestKeyOffset, latestProducerOffset map[string]uint64) (int, int64, int64, error) {
+	logPath := d.GetSegmentPath(segment)
+	indexPath := d.GetIndexPath(segment)
+	logTemp := logPath + ".compacting"
+	indexTemp := indexPath + ".compacting"
+	markerTemp := ""
+	_ = os.Remove(logTemp)
+	_ = os.Remove(indexTemp)
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	// #nosec G304 -- temporary paths are derived from broker-owned segment paths.
+	logFile, err := os.OpenFile(logTemp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	// #nosec G304 -- temporary paths are derived from broker-owned segment paths.
+	indexFile, err := os.OpenFile(indexTemp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		_ = logFile.Close()
+		_ = os.Remove(logTemp)
+		return 0, 0, 0, err
+	}
+
+	cleanupTemps := true
+	defer func() {
+		_ = logFile.Close()
+		_ = indexFile.Close()
+		if cleanupTemps {
+			_ = os.Remove(logTemp)
+			_ = os.Remove(indexTemp)
+			if markerTemp != "" {
+				_ = os.Remove(markerTemp)
+			}
+		}
+	}()
+
+	var removed int
+	var before int64
+	var after int64
+	var outputPosition uint64
+	var lastIndexPosition uint64
+	interval := d.indexInterval
+	if interval == 0 {
+		interval = 4096
+	}
+	err = scanCompactionSegment(logPath, segment, true, allowOffsetGaps, func(frame compactionFrame) error {
+		before += int64(frame.size)
+		if shouldRemoveCompactionRecord(frame.message, latestKeyOffset, latestProducerOffset) {
+			removed++
+			return nil
+		}
+		if outputPosition-lastIndexPosition >= interval {
+			entry := types.IndexEntry{Offset: frame.message.Offset, Position: outputPosition}
+			if err := binary.Write(indexFile, binary.BigEndian, entry); err != nil {
+				return fmt.Errorf("write compacted index: %w", err)
+			}
+			lastIndexPosition = outputPosition
+		}
+		if _, err := logFile.Write(frame.raw); err != nil {
+			return fmt.Errorf("write compacted log: %w", err)
+		}
+		outputPosition += uint64(frame.size)
+		after += int64(frame.size)
+		return nil
+	})
+	if err != nil {
+		return 0, before, after, err
+	}
+	if removed == 0 {
+		return 0, before, before, nil
+	}
+	if err := logFile.Sync(); err != nil {
+		return 0, before, after, err
+	}
+	if err := indexFile.Sync(); err != nil {
+		return 0, before, after, err
+	}
+	if err := logFile.Close(); err != nil {
+		return 0, before, after, err
+	}
+	if err := indexFile.Close(); err != nil {
+		return 0, before, after, err
+	}
+	if err := os.Chtimes(logTemp, info.ModTime(), info.ModTime()); err != nil {
+		return 0, before, after, err
+	}
+
+	markerPath := compactionMarkerPath(logPath, after)
+	markerTemp = markerPath + ".compacting"
+	_ = os.Remove(markerTemp)
+	// #nosec G304 -- the marker path is derived from a broker-owned segment path and its size.
+	markerFile, err := os.OpenFile(markerTemp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return 0, before, after, err
+	}
+	if _, err := markerFile.WriteString(compactionMarkerVersion); err != nil {
+		_ = markerFile.Close()
+		return 0, before, after, err
+	}
+	if err := markerFile.Sync(); err != nil {
+		_ = markerFile.Close()
+		return 0, before, after, err
+	}
+	if err := markerFile.Close(); err != nil {
+		return 0, before, after, err
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if segment == d.CurrentSegment {
+		return 0, before, before, fmt.Errorf("refusing to compact active segment")
+	}
+	if atomic.LoadInt32(&d.activeReaders) > 0 {
+		return 0, before, before, errCompactionReadersActive
+	}
+
+	directory := filepath.Dir(logPath)
+	if err := replaceCompactedFile(markerTemp, markerPath); err != nil {
+		return 0, before, after, err
+	}
+	if err := syncDirectory(directory); err != nil {
+		_ = os.Remove(markerPath)
+		return 0, before, after, err
+	}
+
+	originalMode := info.Mode().Perm()
+	if originalMode == 0 {
+		originalMode = 0o644
+	}
+	_ = os.Chmod(logPath, 0o600)
+	_ = os.Chmod(indexPath, 0o600)
+	if err := replaceCompactedFile(logTemp, logPath); err != nil {
+		_ = os.Chmod(logPath, originalMode)
+		_ = os.Remove(markerPath)
+		_ = syncDirectory(directory)
+		return 0, before, after, err
+	}
+	d.recordCompactedSegment(segment, after)
+	if err := replaceCompactedFile(indexTemp, indexPath); err != nil {
+		_ = os.Chmod(logPath, originalMode)
+		_ = syncDirectory(directory)
+		return 0, before, after, err
+	}
+	cleanupTemps = false
+	_ = os.Chmod(logPath, originalMode)
+	_ = os.Chmod(indexPath, originalMode)
+	if err := syncDirectory(directory); err != nil {
+		return 0, before, after, err
+	}
+	return removed, before, after, nil
+}
+
+const compactionMarkerVersion = "cursus-compaction-v1\n"
+
+func compactionMarkerPath(logPath string, size int64) string {
+	return fmt.Sprintf("%s.compacted-%d", logPath, size)
+}
+
+func (d *DiskHandler) segmentAllowsOffsetGaps(segment uint64, actualSize int64) bool {
+	d.compactionMu.RLock()
+	defer d.compactionMu.RUnlock()
+	expectedSize, ok := d.compactedSegments[segment]
+	return ok && expectedSize == actualSize
+}
+
+func (d *DiskHandler) recordCompactedSegment(segment uint64, size int64) {
+	d.compactionMu.Lock()
+	if d.compactedSegments == nil {
+		d.compactedSegments = make(map[uint64]int64)
+	}
+	d.compactedSegments[segment] = size
+	d.compactionMu.Unlock()
+}
+
+func (d *DiskHandler) forgetCompactedSegment(segment uint64) {
+	d.compactionMu.Lock()
+	delete(d.compactedSegments, segment)
+	d.compactionMu.Unlock()
+}
+
+func loadCompactionMarkers(base string) (map[uint64]int64, error) {
+	compacted := make(map[uint64]int64)
+	paths, err := filepath.Glob(base + "_segment_*.log.compacted-*")
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return compacted, nil
+	}
+
+	removed := false
+	prefix := base + "_segment_"
+	const delimiter = ".log.compacted-"
+	for _, path := range paths {
+		remainder := strings.TrimPrefix(path, prefix)
+		separator := strings.Index(remainder, delimiter)
+		if remainder == path || separator <= 0 {
+			_ = os.Chmod(path, 0o600)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return nil, err
+			}
+			removed = true
+			continue
+		}
+
+		segment, segmentErr := strconv.ParseUint(remainder[:separator], 10, 64)
+		expectedSize, sizeErr := strconv.ParseInt(remainder[separator+len(delimiter):], 10, 64)
+		logPath := path[:strings.LastIndex(path, ".compacted-")]
+		info, statErr := os.Stat(logPath)
+		if segmentErr != nil || sizeErr != nil || expectedSize < 0 || statErr != nil || info.Size() != expectedSize {
+			if statErr != nil && !os.IsNotExist(statErr) {
+				return nil, statErr
+			}
+			_ = os.Chmod(path, 0o600)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return nil, err
+			}
+			removed = true
+			continue
+		}
+
+		// #nosec G304 -- marker paths are discovered only under the broker-owned log directory.
+		marker, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if string(marker) != compactionMarkerVersion {
+			return nil, fmt.Errorf("invalid compaction marker %s", path)
+		}
+		compacted[segment] = expectedSize
+	}
+	if removed {
+		if err := syncDirectory(filepath.Dir(base)); err != nil {
+			return nil, err
+		}
+	}
+	return compacted, nil
+}
+
+func cleanupCompactionMarkersForLog(logPath string, keepSize int64) error {
+	paths, err := filepath.Glob(logPath + ".compacted-*")
+	if err != nil {
+		return err
+	}
+	keepPath := ""
+	if keepSize >= 0 {
+		keepPath = compactionMarkerPath(logPath, keepSize)
+	}
+	for _, path := range paths {
+		if path == keepPath {
+			continue
+		}
+		_ = os.Chmod(path, 0o600)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+func cleanupCompactionTemps(base string) error {
+	paths, err := filepath.Glob(base + "_segment_*.compacting")
+	if err != nil {
+		return err
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	for _, path := range paths {
+		_ = os.Chmod(path, 0o600)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove compaction temporary file %s: %w", path, err)
+		}
+	}
+	return syncDirectory(filepath.Dir(base))
+}

--- a/pkg/disk/compaction_replace_unix.go
+++ b/pkg/disk/compaction_replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package disk
+
+import "os"
+
+func replaceCompactedFile(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/pkg/disk/compaction_replace_windows.go
+++ b/pkg/disk/compaction_replace_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package disk
+
+import "golang.org/x/sys/windows"
+
+func replaceCompactedFile(source, destination string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/pkg/disk/compaction_test.go
+++ b/pkg/disk/compaction_test.go
@@ -1,0 +1,454 @@
+package disk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func compactionTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.CleanupPolicy = config.CleanupPolicyCompact
+	cfg.SegmentSize = 1 << 20
+	cfg.IndexSize = 1 << 20
+	cfg.IndexIntervalBytes = 64
+	cfg.DiskFlushBatchSize = 1
+	cfg.DiskFlushIntervalMS = 10
+	cfg.DiskWriteTimeoutMS = 100
+	cfg.LingerMS = 1
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+	cfg.MinCleanableDirtyRatio = 0.01
+	return cfg
+}
+
+func appendCompactionMessage(t *testing.T, handler *DiskHandler, message types.Message) uint64 {
+	t.Helper()
+	offset, err := handler.AppendMessageSync("orders", 0, &message)
+	require.NoError(t, err)
+	return offset
+}
+
+func rollCompactionSegment(t *testing.T, handler *DiskHandler) {
+	t.Helper()
+	handler.mu.Lock()
+	handler.ioMu.Lock()
+	err := handler.rotateSegment(handler.GetAbsoluteOffset())
+	handler.ioMu.Unlock()
+	handler.mu.Unlock()
+	require.NoError(t, err)
+}
+
+func messageOffsets(messages []types.Message) []uint64 {
+	offsets := make([]uint64, len(messages))
+	for i, message := range messages {
+		offsets[i] = message.Offset
+	}
+	return offsets
+}
+
+func TestEnforceCompactionPreservesLogicalOffsetsAndProtectedRecords(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), appendCompactionMessage(t, handler, types.Message{Key: "account", Payload: "old", ProducerID: "p1", SeqNum: 1}))
+	require.Equal(t, uint64(1), appendCompactionMessage(t, handler, types.Message{Key: "region", Payload: "east", ProducerID: "p1", SeqNum: 2}))
+	require.Equal(t, uint64(2), appendCompactionMessage(t, handler, types.Message{Key: "account", Payload: "current", ProducerID: "p2", SeqNum: 1}))
+	require.Equal(t, uint64(3), appendCompactionMessage(t, handler, types.Message{Payload: "unkeyed", ProducerID: "p3", SeqNum: 1}))
+	require.Equal(t, uint64(4), appendCompactionMessage(t, handler, types.Message{
+		Key:              "account",
+		Payload:          "transactional",
+		ProducerID:       "tx-producer",
+		SeqNum:           1,
+		TransactionalID:  "tx-1",
+		TransactionState: types.TransactionStateCommitted,
+	}))
+	require.Equal(t, uint64(5), appendCompactionMessage(t, handler, types.Message{Key: "producer-anchor", Payload: "anchor", ProducerID: "p1", SeqNum: 3}))
+	rollCompactionSegment(t, handler)
+
+	require.Equal(t, uint64(6), appendCompactionMessage(t, handler, types.Message{Key: "account", Payload: "active-old", ProducerID: "p4", SeqNum: 1}))
+	require.Equal(t, uint64(7), appendCompactionMessage(t, handler, types.Message{Key: "account", Payload: "active-current", ProducerID: "p4", SeqNum: 2}))
+	activePath := handler.GetSegmentPath(handler.GetCurrentSegment())
+	activeBefore, err := os.ReadFile(activePath)
+	require.NoError(t, err)
+
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.SegmentsRewritten)
+	require.Equal(t, 1, result.RecordsRemoved)
+	require.Empty(t, result.SkippedReason)
+	require.Equal(t, uint64(8), handler.GetAbsoluteOffset())
+
+	closedSegment := handler.segments[0]
+	closedInfo, err := os.Stat(handler.GetSegmentPath(closedSegment))
+	require.NoError(t, err)
+	require.FileExists(t, compactionMarkerPath(handler.GetSegmentPath(closedSegment), closedInfo.Size()))
+
+	activeAfter, err := os.ReadFile(activePath)
+	require.NoError(t, err)
+	require.Equal(t, activeBefore, activeAfter, "active segment must never be rewritten")
+
+	messages, err := handler.ReadMessages(0, 100)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7}, messageOffsets(messages))
+	require.Equal(t, "transactional", messages[3].Payload)
+	require.Equal(t, "tx-1", messages[3].TransactionalID)
+	require.Equal(t, "unkeyed", messages[2].Payload)
+	require.NoError(t, handler.Close())
+
+	reopened, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reopened.Close()) }()
+	require.Equal(t, uint64(8), reopened.GetAbsoluteOffset())
+	reopenedInfo, err := os.Stat(reopened.GetSegmentPath(closedSegment))
+	require.NoError(t, err)
+	require.True(t, reopened.segmentAllowsOffsetGaps(closedSegment, reopenedInfo.Size()))
+	messages, err = reopened.ReadMessages(0, 100)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7}, messageOffsets(messages))
+}
+
+func TestEnforceCompactionWaitsForActiveUpdateToRoll(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "account", Payload: "old"})
+	rollCompactionSegment(t, handler)
+	appendCompactionMessage(t, handler, types.Message{Key: "account", Payload: "new"})
+
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, "no_superseded_records", result.SkippedReason)
+	require.Zero(t, result.RecordsRemoved)
+
+	messages, err := handler.ReadMessages(0, 10)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{0, 1}, messageOffsets(messages))
+
+	rollCompactionSegment(t, handler)
+	result, err = handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Empty(t, result.SkippedReason)
+	require.Equal(t, 1, result.RecordsRemoved)
+
+	messages, err = handler.ReadMessages(0, 10)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, messageOffsets(messages))
+}
+
+func TestEnforceCompactionHonorsDirtyRatio(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	cfg.MinCleanableDirtyRatio = 0.9
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	for i := 0; i < 8; i++ {
+		appendCompactionMessage(t, handler, types.Message{Key: string(rune('a' + i)), Payload: "retained"})
+	}
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "new"})
+	rollCompactionSegment(t, handler)
+
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, "dirty_ratio", result.SkippedReason)
+	require.Zero(t, result.RecordsRemoved)
+
+	messages, err := handler.ReadMessages(0, 100)
+	require.NoError(t, err)
+	require.Len(t, messages, 10)
+}
+
+func TestNewDiskHandlerRemovesStaleCompactionTemps(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	dir := filepath.Join(cfg.LogDir, "orders")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	staleLog := filepath.Join(dir, "partition_0_segment_00000000000000000000.log.compacting")
+	staleIndex := filepath.Join(dir, "partition_0_segment_00000000000000000000.index.compacting")
+	staleMarker := filepath.Join(dir, "partition_0_segment_00000000000000000000.log.compacted-5")
+	require.NoError(t, os.WriteFile(staleLog, []byte("stale"), 0o600))
+	require.NoError(t, os.WriteFile(staleIndex, []byte("stale"), 0o600))
+	require.NoError(t, os.WriteFile(staleMarker, []byte(compactionMarkerVersion), 0o600))
+
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+	_, err = os.Stat(staleLog)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(staleIndex)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(staleMarker)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestCombinedCleanupPolicyEnablesCompaction(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	cfg.CleanupPolicy = config.CleanupPolicyDeleteCompact
+	cfg.RetentionHours = int((24 * time.Hour) / time.Hour)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "new"})
+	rollCompactionSegment(t, handler)
+
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+}
+
+func TestEnforceCompactionLeavesStaleIndexCorrectnessSafe(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	for i := 0; i < 12; i++ {
+		appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: string(rune('a' + i))})
+	}
+	appendCompactionMessage(t, handler, types.Message{Payload: "unkeyed"})
+	rollCompactionSegment(t, handler)
+
+	closedSegment := handler.segments[0]
+	indexPath := handler.GetIndexPath(closedSegment)
+	staleIndex, err := os.ReadFile(indexPath)
+	require.NoError(t, err)
+
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 11, result.RecordsRemoved)
+
+	require.NoError(t, os.Chmod(indexPath, 0o600))
+	require.NoError(t, os.WriteFile(indexPath, staleIndex, 0o600))
+	messages, err := handler.ReadMessages(11, 10)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{11, 12}, messageOffsets(messages))
+}
+
+func TestReadMessagesRejectsUnmarkedClosedOffsetHole(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "a", Payload: "zero"})
+	appendCompactionMessage(t, handler, types.Message{Key: "b", Payload: "one"})
+	appendCompactionMessage(t, handler, types.Message{Key: "c", Payload: "two"})
+	rollCompactionSegment(t, handler)
+
+	closedSegment := handler.segments[0]
+	logPath := handler.GetSegmentPath(closedSegment)
+	var retained []byte
+	err = scanCompactionSegment(logPath, closedSegment, true, false, func(frame compactionFrame) error {
+		if frame.message.Offset != 1 {
+			retained = append(retained, frame.raw...)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(logPath, 0o600))
+	require.NoError(t, os.WriteFile(logPath, retained, 0o600))
+
+	_, err = handler.ReadMessages(0, 10)
+	require.ErrorContains(t, err, "non-contiguous offset")
+}
+
+func TestRepeatedCompactionKeepsPriorMarkerUntilRestartCleanup(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "current"})
+	rollCompactionSegment(t, handler)
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+
+	firstSegment := handler.segments[0]
+	firstLogPath := handler.GetSegmentPath(firstSegment)
+	firstInfo, err := os.Stat(firstLogPath)
+	require.NoError(t, err)
+	firstMarker := compactionMarkerPath(firstLogPath, firstInfo.Size())
+	require.FileExists(t, firstMarker)
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "newest"})
+	rollCompactionSegment(t, handler)
+	result, err = handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+	require.FileExists(t, firstMarker)
+
+	markers, err := filepath.Glob(firstLogPath + ".compacted-*")
+	require.NoError(t, err)
+	require.Len(t, markers, 2)
+	require.NoError(t, handler.Close())
+
+	reopened, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reopened.Close()) }()
+	markers, err = filepath.Glob(firstLogPath + ".compacted-*")
+	require.NoError(t, err)
+	require.Len(t, markers, 1)
+
+	messages, err := reopened.ReadMessages(0, 10)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{2}, messageOffsets(messages))
+}
+
+func TestNewDiskHandlerRejectsCorruptCompactionMarker(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "new"})
+	rollCompactionSegment(t, handler)
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+
+	closedSegment := handler.segments[0]
+	info, err := os.Stat(handler.GetSegmentPath(closedSegment))
+	require.NoError(t, err)
+	markerPath := compactionMarkerPath(handler.GetSegmentPath(closedSegment), info.Size())
+	require.NoError(t, handler.Close())
+	require.NoError(t, os.WriteFile(markerPath, []byte("corrupt"), 0o600))
+
+	_, err = NewDiskHandler(cfg, "orders", 0)
+	require.ErrorContains(t, err, "invalid compaction marker")
+}
+
+func TestRetentionRemovesCompactionMarker(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "new"})
+	rollCompactionSegment(t, handler)
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+
+	closedSegment := handler.segments[0]
+	logPath := handler.GetSegmentPath(closedSegment)
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	markerPath := compactionMarkerPath(logPath, info.Size())
+	require.FileExists(t, markerPath)
+
+	require.NoError(t, handler.markAsDeleted(logPath))
+	require.NoFileExists(t, markerPath)
+	require.False(t, handler.segmentAllowsOffsetGaps(closedSegment, info.Size()))
+}
+
+func TestTruncateRejectsCompactedTargetSegment(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "new"})
+	rollCompactionSegment(t, handler)
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+
+	err = handler.TruncateTo(1)
+	require.ErrorContains(t, err, "cannot truncate compacted segment")
+}
+
+func TestEnforceCompactionSkipsActiveReader(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "new"})
+	rollCompactionSegment(t, handler)
+
+	session, err := handler.OpenForRead(0)
+	require.NoError(t, err)
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, "active_readers", result.SkippedReason)
+	require.NoError(t, session.Close())
+	require.NoError(t, session.Close())
+	require.Zero(t, handler.GetActiveReaders())
+
+	result, err = handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+}
+
+func TestCompactionCanLeaveAnEmptyClosedSegment(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "old"})
+	rollCompactionSegment(t, handler)
+	appendCompactionMessage(t, handler, types.Message{Key: "key", Payload: "current"})
+	rollCompactionSegment(t, handler)
+
+	result, err := handler.EnforceCompaction()
+	require.NoError(t, err)
+	require.Equal(t, 1, result.RecordsRemoved)
+
+	emptySegment := handler.segments[0]
+	info, err := os.Stat(handler.GetSegmentPath(emptySegment))
+	require.NoError(t, err)
+	require.Zero(t, info.Size())
+	require.FileExists(t, compactionMarkerPath(handler.GetSegmentPath(emptySegment), 0))
+
+	messages, err := handler.ReadMessages(0, 10)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, messageOffsets(messages))
+	require.NoError(t, handler.Close())
+
+	reopened, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reopened.Close()) }()
+	messages, err = reopened.ReadMessages(0, 10)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, messageOffsets(messages))
+}
+
+func TestDiskManagerPolicyCanReturnToBrokerRetentionDefaults(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	cfg.RetentionHours = 72
+	cfg.RetentionBytes = 4096
+	manager := NewDiskManager(cfg)
+	defer manager.CloseAllHandlers()
+
+	value, err := manager.GetHandlerWithPolicy("state", 0, config.CleanupPolicyCompact, 24, 1024)
+	require.NoError(t, err)
+	handler := value.(*DiskHandler)
+	hours, bytes := handler.RetentionPolicy()
+	require.Equal(t, 24, hours)
+	require.Equal(t, int64(1024), bytes)
+
+	value, err = manager.GetHandlerWithPolicy("state", 0, config.CleanupPolicyDelete, 0, 0)
+	require.NoError(t, err)
+	handler = value.(*DiskHandler)
+	hours, bytes = handler.RetentionPolicy()
+	require.Equal(t, cfg.RetentionHours, hours)
+	require.Equal(t, cfg.RetentionBytes, bytes)
+	require.Equal(t, config.CleanupPolicyDelete, handler.CleanupPolicy())
+}

--- a/pkg/disk/compaction_test.go
+++ b/pkg/disk/compaction_test.go
@@ -452,3 +452,35 @@ func TestDiskManagerPolicyCanReturnToBrokerRetentionDefaults(t *testing.T) {
 	require.Equal(t, cfg.RetentionBytes, bytes)
 	require.Equal(t, config.CleanupPolicyDelete, handler.CleanupPolicy())
 }
+
+func TestStoragePolicyUpdateWaitsForMaintenance(t *testing.T) {
+	cfg := compactionTestConfig(t)
+	handler, err := NewDiskHandler(cfg, "orders", 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handler.Close()) }()
+
+	handler.maintenanceMu.Lock()
+	updated := make(chan struct{})
+	go func() {
+		handler.SetStoragePolicy(config.CleanupPolicyDelete, 24, 1024)
+		close(updated)
+	}()
+
+	select {
+	case <-updated:
+		handler.maintenanceMu.Unlock()
+		t.Fatal("storage policy update completed during active maintenance")
+	case <-time.After(50 * time.Millisecond):
+	}
+	handler.maintenanceMu.Unlock()
+
+	select {
+	case <-updated:
+	case <-time.After(time.Second):
+		t.Fatal("storage policy update did not complete after maintenance")
+	}
+	require.Equal(t, config.CleanupPolicyDelete, handler.CleanupPolicy())
+	hours, bytes := handler.RetentionPolicy()
+	require.Equal(t, 24, hours)
+	require.Equal(t, int64(1024), bytes)
+}

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -121,7 +121,7 @@ func newDiskHandlerWithPolicy(cfg *config.Config, topicName string, partitionID 
 
 func newDiskHandler(cfg *config.Config, topicName string, partitionID int, cleanupPolicy string, initialRetention retentionLimits) (*DiskHandler, error) {
 	base := fmt.Sprintf("%s%c%s%cpartition_%d", cfg.LogDir, os.PathSeparator, topicName, os.PathSeparator, partitionID)
-	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(base), 0o750); err != nil {
 		return nil, err
 	}
 

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -56,13 +56,19 @@ type DiskHandler struct {
 	segmentRollTime  time.Duration
 	segmentCreatedAt time.Time
 
-	retentionMu         sync.RWMutex
-	retentionDefaults   retentionLimits
-	retentionPolicy     retentionLimits
-	retentionConfigured bool
+	retentionMu            sync.RWMutex
+	retentionDefaults      retentionLimits
+	retentionPolicy        retentionLimits
+	retentionConfigured    bool
+	cleanupPolicy          string
+	minCleanableDirtyRatio float64
+	distributed            bool
 
-	mu   sync.Mutex // metadata(offset, segment), file handler(d.file)
-	ioMu sync.Mutex // bufio.Writer, flush
+	maintenanceMu     sync.Mutex
+	compactionMu      sync.RWMutex
+	compactedSegments map[uint64]int64
+	mu                sync.Mutex // metadata(offset, segment), file handler(d.file)
+	ioMu              sync.Mutex // bufio.Writer, flush
 
 	file   *os.File
 	writer *bufio.Writer
@@ -91,6 +97,29 @@ func (d *DiskHandler) GetActiveReaders() int32 {
 }
 
 func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*DiskHandler, error) {
+	return newDiskHandler(cfg, topicName, partitionID, cfg.CleanupPolicy, retentionLimits{
+		hours: cfg.RetentionHours,
+		bytes: cfg.RetentionBytes,
+	})
+}
+
+func newDiskHandlerWithPolicy(cfg *config.Config, topicName string, partitionID int, cleanupPolicy string, retentionHours int, retentionBytes int64) (*DiskHandler, error) {
+	if cleanupPolicy == "" {
+		cleanupPolicy = cfg.CleanupPolicy
+	}
+	if retentionHours == 0 {
+		retentionHours = cfg.RetentionHours
+	}
+	if retentionBytes == 0 {
+		retentionBytes = cfg.RetentionBytes
+	}
+	return newDiskHandler(cfg, topicName, partitionID, cleanupPolicy, retentionLimits{
+		hours: retentionHours,
+		bytes: retentionBytes,
+	})
+}
+
+func newDiskHandler(cfg *config.Config, topicName string, partitionID int, cleanupPolicy string, initialRetention retentionLimits) (*DiskHandler, error) {
 	base := fmt.Sprintf("%s%c%s%cpartition_%d", cfg.LogDir, os.PathSeparator, topicName, os.PathSeparator, partitionID)
 	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
 		return nil, err
@@ -99,6 +128,13 @@ func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*Dis
 	tempDh := &DiskHandler{BaseName: base}
 	if err := cleanupDeletedSegments(base); err != nil {
 		return nil, fmt.Errorf("cleanup deleted segment tombstones: %w", err)
+	}
+	if err := cleanupCompactionTemps(base); err != nil {
+		return nil, fmt.Errorf("cleanup compaction temporary files: %w", err)
+	}
+	compactedSegments, markerErr := loadCompactionMarkers(base)
+	if markerErr != nil {
+		return nil, fmt.Errorf("load compaction markers: %w", markerErr)
 	}
 	pattern := base + "_segment_*.log"
 	files, _ := filepath.Glob(pattern)
@@ -134,6 +170,14 @@ func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*Dis
 	if len(files) == 0 {
 		recovery.nextOffset = currentSegmentBase
 	}
+	normalizedCleanupPolicy, ok := config.NormalizeCleanupPolicy(cleanupPolicy)
+	if !ok {
+		normalizedCleanupPolicy = config.CleanupPolicyDelete
+	}
+	minCleanableDirtyRatio := cfg.MinCleanableDirtyRatio
+	if minCleanableDirtyRatio <= 0 || minCleanableDirtyRatio >= 1 {
+		minCleanableDirtyRatio = 0.5
+	}
 
 	dh := &DiskHandler{
 		BaseName:       base,
@@ -155,13 +199,17 @@ func NewDiskHandler(cfg *config.Config, topicName string, partitionID int) (*Dis
 		writeTimeout:   time.Duration(cfg.DiskWriteTimeoutMS) * time.Millisecond,
 		syncIntervalMS: cfg.DiskFlushIntervalMS,
 
-		segmentRollTime:     time.Duration(cfg.SegmentRollTimeMS) * time.Millisecond,
-		segmentCreatedAt:    time.Now(),
-		retentionDefaults:   retentionLimits{hours: cfg.RetentionHours, bytes: cfg.RetentionBytes},
-		retentionPolicy:     retentionLimits{hours: cfg.RetentionHours, bytes: cfg.RetentionBytes},
-		retentionConfigured: true,
-		file:                file,
-		writer:              bufio.NewWriter(file),
+		segmentRollTime:        time.Duration(cfg.SegmentRollTimeMS) * time.Millisecond,
+		segmentCreatedAt:       time.Now(),
+		retentionDefaults:      retentionLimits{hours: cfg.RetentionHours, bytes: cfg.RetentionBytes},
+		retentionPolicy:        initialRetention,
+		retentionConfigured:    true,
+		cleanupPolicy:          normalizedCleanupPolicy,
+		minCleanableDirtyRatio: minCleanableDirtyRatio,
+		distributed:            cfg.EnabledDistribution,
+		compactedSegments:      compactedSegments,
+		file:                   file,
+		writer:                 bufio.NewWriter(file),
 	}
 	if recovery.modTime != 0 {
 		dh.segmentCreatedAt = time.Unix(0, recovery.modTime)
@@ -314,10 +362,11 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 	}
 
 	dh.mu.Lock()
+	currentSegment := dh.CurrentSegment
 	readableSegments := make([]uint64, len(dh.segments))
 	copy(readableSegments, dh.segments)
-	if len(readableSegments) == 0 || readableSegments[len(readableSegments)-1] != dh.CurrentSegment {
-		readableSegments = append(readableSegments, dh.CurrentSegment)
+	if len(readableSegments) == 0 || readableSegments[len(readableSegments)-1] != currentSegment {
+		readableSegments = append(readableSegments, currentSegment)
 	}
 	dh.mu.Unlock()
 
@@ -356,7 +405,9 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 			readPos = position
 		}
 
-		batch, readErr := dh.readMessagesFromPosition(reader, readPos, remaining, offset, segBase == dh.CurrentSegment)
+		activeSegment := segBase == currentSegment
+		allowOffsetGaps := !activeSegment && dh.segmentAllowsOffsetGaps(segBase, actualSize)
+		batch, readErr := dh.readMessagesFromPosition(reader, readPos, remaining, offset, segBase, activeSegment, allowOffsetGaps)
 		if readErr != nil {
 			_ = reader.Close()
 			return nil, fmt.Errorf("read segment %d: %w", segBase, readErr)
@@ -372,7 +423,7 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 				return nil, fmt.Errorf("reopen segment %d: %w", segBase, reErr)
 			}
 
-			batch, readErr = dh.readMessagesFromPosition(reader, readPos, remaining, offset, segBase == dh.CurrentSegment)
+			batch, readErr = dh.readMessagesFromPosition(reader, readPos, remaining, offset, segBase, activeSegment, allowOffsetGaps)
 			if readErr != nil {
 				_ = reader.Close()
 				return nil, fmt.Errorf("reread segment %d: %w", segBase, readErr)
@@ -401,7 +452,7 @@ func (dh *DiskHandler) ReadMessages(offset uint64, max int) ([]types.Message, er
 }
 
 // readMessagesFromPosition reads messages starting from a specific byte position
-func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position uint64, max int, targetOffset uint64, allowPartialTail bool) ([]types.Message, error) {
+func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position uint64, max int, targetOffset, segmentBase uint64, allowPartialTail, allowOffsetGaps bool) ([]types.Message, error) {
 	if position > math.MaxInt {
 		return nil, fmt.Errorf("read position %d exceeds int range", position)
 	}
@@ -442,7 +493,13 @@ func (dh *DiskHandler) readMessagesFromPosition(reader *mmap.ReaderAt, position 
 		if err != nil {
 			return nil, fmt.Errorf("decode message at byte %d: %w", pos, err)
 		}
-		if havePreviousOffset && diskMsg.Offset != previousOffset+1 {
+		if !havePreviousOffset && pos == 0 && !allowOffsetGaps && diskMsg.Offset != segmentBase {
+			return nil, fmt.Errorf("unexpected first offset at byte %d: got %d for segment base %d", pos, diskMsg.Offset, segmentBase)
+		}
+		if havePreviousOffset && diskMsg.Offset <= previousOffset {
+			return nil, fmt.Errorf("non-increasing offset at byte %d: got %d after %d", pos, diskMsg.Offset, previousOffset)
+		}
+		if havePreviousOffset && !allowOffsetGaps && diskMsg.Offset != previousOffset+1 {
 			return nil, fmt.Errorf("non-contiguous offset at byte %d: got %d after %d", pos, diskMsg.Offset, previousOffset)
 		}
 		previousOffset = diskMsg.Offset

--- a/pkg/disk/handler_test.go
+++ b/pkg/disk/handler_test.go
@@ -335,6 +335,9 @@ func TestReadSession_Close(t *testing.T) {
 	if err := session.Close(); err != nil {
 		t.Fatalf("ReadSession.Close failed: %v", err)
 	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("second ReadSession.Close failed: %v", err)
+	}
 	if dh.GetActiveReaders() != 0 {
 		t.Errorf("Expected 0 active readers after close, got %d", dh.GetActiveReaders())
 	}

--- a/pkg/disk/index.go
+++ b/pkg/disk/index.go
@@ -333,11 +333,20 @@ func (d *DiskHandler) findOffsetPosition(offset uint64, segmentBase ...uint64) (
 }
 
 func (d *DiskHandler) findOffsetPositionInIndex(offset, base uint64) (uint64, error) {
-	mapper, err := mmap.Open(d.GetIndexPath(base))
+	indexPath := d.GetIndexPath(base)
+	info, err := os.Stat(indexPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil
 		}
+		return 0, err
+	}
+	if info.Size() == 0 {
+		return 0, nil
+	}
+
+	mapper, err := mmap.Open(indexPath)
+	if err != nil {
 		return 0, err
 	}
 	defer func() { _ = mapper.Close() }()

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -64,7 +64,7 @@ func (dm *DiskManager) getHandlerLocked(topic string, partitionID int, policy *i
 		return handler, nil
 	}
 
-	if err := os.MkdirAll(dm.cfg.LogDir, 0o755); err != nil {
+	if err := os.MkdirAll(dm.cfg.LogDir, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create log directory %s: %w", dm.cfg.LogDir, err)
 	}
 

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -13,6 +13,12 @@ import (
 	"github.com/cursus-io/cursus/util"
 )
 
+type initialStoragePolicy struct {
+	cleanupPolicy  string
+	retentionHours int
+	retentionBytes int64
+}
+
 type DiskManager struct {
 	mu       sync.Mutex
 	handlers map[string]*DiskHandler
@@ -26,27 +32,54 @@ func NewDiskManager(cfg *config.Config) *DiskManager {
 	}
 }
 
-// GetHandler returns a StorageHandler for a given name or creates one if missing
+// GetHandler returns a StorageHandler for a given name or creates one if missing.
 func (dm *DiskManager) GetHandler(topic string, partitionID int) (types.StorageHandler, error) {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	return dm.getHandlerLocked(topic, partitionID, nil)
+}
+
+// GetHandlerWithPolicy initializes maintenance with the topic policy before its
+// background loops can run.
+func (dm *DiskManager) GetHandlerWithPolicy(topic string, partitionID int, cleanupPolicy string, retentionHours int, retentionBytes int64) (types.StorageHandler, error) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
 	key := diskHandlerKey(topic, partitionID)
-	if dh, ok := dm.handlers[key]; ok {
-		return dh, nil
+	if handler, ok := dm.handlers[key]; ok {
+		handler.SetStoragePolicy(cleanupPolicy, retentionHours, retentionBytes)
+		return handler, nil
 	}
 
-	if err := os.MkdirAll(dm.cfg.LogDir, 0755); err != nil {
+	return dm.getHandlerLocked(topic, partitionID, &initialStoragePolicy{
+		cleanupPolicy:  cleanupPolicy,
+		retentionHours: retentionHours,
+		retentionBytes: retentionBytes,
+	})
+}
+
+func (dm *DiskManager) getHandlerLocked(topic string, partitionID int, policy *initialStoragePolicy) (types.StorageHandler, error) {
+	key := diskHandlerKey(topic, partitionID)
+	if handler, ok := dm.handlers[key]; ok {
+		return handler, nil
+	}
+
+	if err := os.MkdirAll(dm.cfg.LogDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create log directory %s: %w", dm.cfg.LogDir, err)
 	}
 
-	dh, err := NewDiskHandler(dm.cfg, topic, partitionID)
+	var handler *DiskHandler
+	var err error
+	if policy == nil {
+		handler, err = NewDiskHandler(dm.cfg, topic, partitionID)
+	} else {
+		handler, err = newDiskHandlerWithPolicy(dm.cfg, topic, partitionID, policy.cleanupPolicy, policy.retentionHours, policy.retentionBytes)
+	}
 	if err != nil {
 		return nil, err
 	}
-
-	dm.handlers[key] = dh
-	return dh, nil
+	dm.handlers[key] = handler
+	return handler, nil
 }
 
 // ExistingPartitionCount discovers the highest persisted partition for a topic

--- a/pkg/disk/retention.go
+++ b/pkg/disk/retention.go
@@ -57,6 +57,9 @@ func (d *DiskHandler) OpenForRead(offset uint64) (*ReadSession, error) {
 
 // SetRetentionPolicy applies topic-level limits. Zero means inherit the broker default.
 func (d *DiskHandler) SetRetentionPolicy(hours int, bytes int64) {
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
+
 	d.retentionMu.Lock()
 	defer d.retentionMu.Unlock()
 
@@ -76,6 +79,9 @@ func (d *DiskHandler) SetCleanupPolicy(policy string) {
 	if !ok {
 		normalized = config.CleanupPolicyDelete
 	}
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
+
 	d.retentionMu.Lock()
 	d.cleanupPolicy = normalized
 	d.retentionMu.Unlock()
@@ -87,6 +93,9 @@ func (d *DiskHandler) SetStoragePolicy(cleanupPolicy string, hours int, bytes in
 	if !ok {
 		normalized = config.CleanupPolicyDelete
 	}
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
+
 	d.retentionMu.Lock()
 	defer d.retentionMu.Unlock()
 	if hours == 0 {
@@ -128,11 +137,11 @@ func (d *DiskHandler) effectiveRetention(cfg *config.Config) retentionLimits {
 }
 
 func (d *DiskHandler) EnforceRetention(cfg *config.Config) {
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
 	if !config.HasCleanupPolicy(d.CleanupPolicy(), config.CleanupPolicyDelete) {
 		return
 	}
-	d.maintenanceMu.Lock()
-	defer d.maintenanceMu.Unlock()
 	if atomic.LoadInt32(&d.activeReaders) > 0 {
 		util.Debug("Retention skipped: %d active readers", atomic.LoadInt32(&d.activeReaders))
 		return

--- a/pkg/disk/retention.go
+++ b/pkg/disk/retention.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -20,27 +21,33 @@ type retentionLimits struct {
 }
 
 type ReadSession struct {
-	File    *os.File
-	handler *DiskHandler
+	File      *os.File
+	handler   *DiskHandler
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func (s *ReadSession) Close() error {
-	atomic.AddInt32(&s.handler.activeReaders, -1)
-	return s.File.Close()
+	s.closeOnce.Do(func() {
+		atomic.AddInt32(&s.handler.activeReaders, -1)
+		s.closeErr = s.File.Close()
+	})
+	return s.closeErr
 }
 
 func (d *DiskHandler) OpenForRead(offset uint64) (*ReadSession, error) {
+	atomic.AddInt32(&d.activeReaders, 1)
 	path, _, err := d.findSegmentForOffset(offset)
 	if err != nil {
+		atomic.AddInt32(&d.activeReaders, -1)
 		return nil, err
 	}
 
 	f, err := os.Open(path)
 	if err != nil {
+		atomic.AddInt32(&d.activeReaders, -1)
 		return nil, err
 	}
-
-	atomic.AddInt32(&d.activeReaders, 1)
 
 	return &ReadSession{
 		File:    f,
@@ -63,6 +70,45 @@ func (d *DiskHandler) SetRetentionPolicy(hours int, bytes int64) {
 	d.retentionConfigured = true
 }
 
+// SetCleanupPolicy changes the maintenance policy for this partition.
+func (d *DiskHandler) SetCleanupPolicy(policy string) {
+	normalized, ok := config.NormalizeCleanupPolicy(policy)
+	if !ok {
+		normalized = config.CleanupPolicyDelete
+	}
+	d.retentionMu.Lock()
+	d.cleanupPolicy = normalized
+	d.retentionMu.Unlock()
+}
+
+// SetStoragePolicy atomically applies topic cleanup and retention settings.
+func (d *DiskHandler) SetStoragePolicy(cleanupPolicy string, hours int, bytes int64) {
+	normalized, ok := config.NormalizeCleanupPolicy(cleanupPolicy)
+	if !ok {
+		normalized = config.CleanupPolicyDelete
+	}
+	d.retentionMu.Lock()
+	defer d.retentionMu.Unlock()
+	if hours == 0 {
+		hours = d.retentionDefaults.hours
+	}
+	if bytes == 0 {
+		bytes = d.retentionDefaults.bytes
+	}
+	d.retentionPolicy = retentionLimits{hours: hours, bytes: bytes}
+	d.retentionConfigured = true
+	d.cleanupPolicy = normalized
+}
+
+func (d *DiskHandler) CleanupPolicy() string {
+	d.retentionMu.RLock()
+	defer d.retentionMu.RUnlock()
+	if d.cleanupPolicy == "" {
+		return config.CleanupPolicyDelete
+	}
+	return d.cleanupPolicy
+}
+
 func (d *DiskHandler) RetentionPolicy() (int, int64) {
 	d.retentionMu.RLock()
 	defer d.retentionMu.RUnlock()
@@ -82,6 +128,11 @@ func (d *DiskHandler) effectiveRetention(cfg *config.Config) retentionLimits {
 }
 
 func (d *DiskHandler) EnforceRetention(cfg *config.Config) {
+	if !config.HasCleanupPolicy(d.CleanupPolicy(), config.CleanupPolicyDelete) {
+		return
+	}
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
 	if atomic.LoadInt32(&d.activeReaders) > 0 {
 		util.Debug("Retention skipped: %d active readers", atomic.LoadInt32(&d.activeReaders))
 		return
@@ -178,6 +229,10 @@ func (d *DiskHandler) markAsDeleted(logPath string) error {
 		}
 		return err
 	}
+	if err := cleanupCompactionMarkersForLog(logPath, -1); err != nil {
+		util.Warn("failed to remove compaction marker for %s: %v", logPath, err)
+	}
+	d.forgetCompactedSegment(segmentOffset)
 
 	for i, s := range d.segments {
 		if s == segmentOffset {
@@ -218,19 +273,27 @@ func cleanupDeletedSegments(base string) error {
 }
 
 func (d *DiskHandler) retentionLoop(cfg *config.Config) {
-	interval := cfg.RetentionCheckIntervalMS
-	if interval <= 0 {
-		interval = 300000
+	retentionInterval := cfg.RetentionCheckIntervalMS
+	if retentionInterval <= 0 {
+		retentionInterval = 300000
+	}
+	compactionInterval := cfg.CompactionCheckIntervalMS
+	if compactionInterval <= 0 {
+		compactionInterval = 300000
 	}
 
-	ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
-	defer ticker.Stop()
+	retentionTicker := time.NewTicker(time.Duration(retentionInterval) * time.Millisecond)
+	compactionTicker := time.NewTicker(time.Duration(compactionInterval) * time.Millisecond)
+	defer retentionTicker.Stop()
+	defer compactionTicker.Stop()
 
 	for {
 		select {
-		case <-ticker.C:
-			if cfg.CleanupPolicy == "delete" {
-				d.EnforceRetention(cfg)
+		case <-retentionTicker.C:
+			d.EnforceRetention(cfg)
+		case <-compactionTicker.C:
+			if _, err := d.EnforceCompaction(); err != nil {
+				util.Error("log compaction failed for %s: %v", d.BaseName, err)
 			}
 		case <-d.done:
 			return

--- a/pkg/disk/truncate.go
+++ b/pkg/disk/truncate.go
@@ -18,6 +18,9 @@ import (
 func (d *DiskHandler) TruncateTo(nextOffset uint64) error {
 	d.Flush()
 
+	d.maintenanceMu.Lock()
+	defer d.maintenanceMu.Unlock()
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.ioMu.Lock()
@@ -46,6 +49,13 @@ func (d *DiskHandler) TruncateTo(nextOffset uint64) error {
 		targetBase = base
 	}
 	targetPath := d.GetSegmentPath(targetBase)
+	targetInfo, err := os.Stat(targetPath)
+	if err != nil {
+		return fmt.Errorf("stat truncate target segment %d: %w", targetBase, err)
+	}
+	if d.segmentAllowsOffsetGaps(targetBase, targetInfo.Size()) {
+		return fmt.Errorf("cannot truncate compacted segment %d", targetBase)
+	}
 	position, err := findTruncatePosition(targetPath, nextOffset)
 	if err != nil {
 		return err
@@ -80,6 +90,10 @@ func (d *DiskHandler) TruncateTo(nextOffset uint64) error {
 			kept = append(kept, base)
 			continue
 		}
+		if err := cleanupCompactionMarkersForLog(d.GetSegmentPath(base), -1); err != nil {
+			return fmt.Errorf("remove truncated compaction marker %d: %w", base, err)
+		}
+		d.forgetCompactedSegment(base)
 		if err := os.Remove(d.GetSegmentPath(base)); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove truncated segment %d: %w", base, err)
 		}

--- a/pkg/disk/truncate.go
+++ b/pkg/disk/truncate.go
@@ -90,16 +90,16 @@ func (d *DiskHandler) TruncateTo(nextOffset uint64) error {
 			kept = append(kept, base)
 			continue
 		}
-		if err := cleanupCompactionMarkersForLog(d.GetSegmentPath(base), -1); err != nil {
-			return fmt.Errorf("remove truncated compaction marker %d: %w", base, err)
-		}
-		d.forgetCompactedSegment(base)
 		if err := os.Remove(d.GetSegmentPath(base)); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove truncated segment %d: %w", base, err)
 		}
 		if err := os.Remove(d.GetIndexPath(base)); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove truncated index %d: %w", base, err)
 		}
+		if err := cleanupCompactionMarkersForLog(d.GetSegmentPath(base), -1); err != nil {
+			return fmt.Errorf("remove truncated compaction marker %d: %w", base, err)
+		}
+		d.forgetCompactedSegment(base)
 	}
 
 	// The target index is rebuilt lazily from offset zero within the retained segment.

--- a/pkg/protocol/capabilities.go
+++ b/pkg/protocol/capabilities.go
@@ -22,6 +22,7 @@ const (
 	FeatureOffsetResumeV1       Feature = "offset_resume_v1"
 	FeatureStreamControlV1      Feature = "stream_control_v1"
 	FeatureStructuredErrorsV1   Feature = "structured_errors_v1"
+	FeatureTopicCompactionV1    Feature = "topic_compaction_v1"
 )
 
 var supportedFeatures = []Feature{
@@ -30,6 +31,7 @@ var supportedFeatures = []Feature{
 	FeatureOffsetResumeV1,
 	FeatureStreamControlV1,
 	FeatureStructuredErrorsV1,
+	FeatureTopicCompactionV1,
 }
 
 func SupportedFeatures() []Feature {

--- a/pkg/protocol/errors.go
+++ b/pkg/protocol/errors.go
@@ -97,6 +97,7 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"invalid_retention_bytes", "invalid_retention_hours", "invalid_schema_version", "invalid_seq_num",
 		"invalid_snapshot_catchup_response", "invalid_snapshot_payload", "invalid_stream_syntax",
 		"invalid_topic_policy", "invalid_version", "invalid_from_version", "malformed_input", "missing_generation", "missing_group", "missing_key",
+		"unsupported_topic_policy",
 		"missing_broker", "missing_leader_fence", "missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
 		"missing_coordinator_key", "missing_ownership_params", "missing_producer_id", "missing_protocol_version",
 		"missing_required_params", "missing_topic", "missing_transactional_id",

--- a/pkg/topic/cleanup_policy_test.go
+++ b/pkg/topic/cleanup_policy_test.go
@@ -1,0 +1,129 @@
+package topic
+
+import (
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicCleanupPolicyUsesBrokerDefaultAndPropagates(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.CleanupPolicy = config.CleanupPolicyCompact
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+
+	diskManager := disk.NewDiskManager(cfg)
+	defer diskManager.CloseAllHandlers()
+	manager := NewTopicManager(cfg, diskManager, nil)
+	require.NoError(t, manager.CreateTopic("state", 1, false, false))
+
+	created := manager.GetTopic("state")
+	require.Equal(t, config.CleanupPolicyCompact, created.Policy.CleanupPolicy)
+	handlerValue, err := diskManager.GetHandler("state", 0)
+	require.NoError(t, err)
+	require.Equal(t, config.CleanupPolicyCompact, handlerValue.(*disk.DiskHandler).CleanupPolicy())
+	for _, partition := range created.Partitions {
+		partition.Close()
+	}
+}
+
+func TestTopicCleanupPolicyOverridesBrokerDefaultBeforeHandlerStarts(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.CleanupPolicy = config.CleanupPolicyCompact
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+
+	diskManager := disk.NewDiskManager(cfg)
+	defer diskManager.CloseAllHandlers()
+	manager := NewTopicManager(cfg, diskManager, nil)
+	policy := DefaultPolicy()
+	policy.CleanupPolicy = config.CleanupPolicyDelete
+	require.NoError(t, manager.CreateTopicWithPolicy("audit", 1, false, false, policy))
+
+	created := manager.GetTopic("audit")
+	require.Equal(t, config.CleanupPolicyDelete, created.Policy.CleanupPolicy)
+	handlerValue, err := diskManager.GetHandler("audit", 0)
+	require.NoError(t, err)
+	require.Equal(t, config.CleanupPolicyDelete, handlerValue.(*disk.DiskHandler).CleanupPolicy())
+	for _, partition := range created.Partitions {
+		partition.Close()
+	}
+}
+
+func TestTopicCleanupPolicyUpdateAppliesBeforePartitionGrowth(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+
+	diskManager := disk.NewDiskManager(cfg)
+	defer diskManager.CloseAllHandlers()
+	manager := NewTopicManager(cfg, diskManager, nil)
+	deletePolicy := DefaultPolicy()
+	deletePolicy.CleanupPolicy = config.CleanupPolicyDelete
+	require.NoError(t, manager.CreateTopicWithPolicy("state", 1, false, false, deletePolicy))
+
+	compactPolicy := DefaultPolicy()
+	compactPolicy.CleanupPolicy = config.CleanupPolicyCompact
+	require.NoError(t, manager.CreateTopicWithPolicy("state", 2, false, false, compactPolicy))
+
+	created := manager.GetTopic("state")
+	require.Equal(t, config.CleanupPolicyCompact, created.Policy.CleanupPolicy)
+	for partition := 0; partition < 2; partition++ {
+		handlerValue, err := diskManager.GetHandler("state", partition)
+		require.NoError(t, err)
+		require.Equal(t, config.CleanupPolicyCompact, handlerValue.(*disk.DiskHandler).CleanupPolicy())
+	}
+	for _, partition := range created.Partitions {
+		partition.Close()
+	}
+}
+
+func TestTopicCleanupPolicyRejectsUnsupportedTopicModes(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		distributed   bool
+		eventSourcing bool
+	}{
+		{name: "event sourcing", eventSourcing: true},
+		{name: "distributed", distributed: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.LogDir = t.TempDir()
+			cfg.EnabledDistribution = testCase.distributed
+			diskManager := disk.NewDiskManager(cfg)
+			defer diskManager.CloseAllHandlers()
+			manager := NewTopicManager(cfg, diskManager, nil)
+			policy := DefaultPolicy()
+			policy.CleanupPolicy = config.CleanupPolicyCompact
+			err := manager.CreateTopicWithPolicy("state", 1, false, testCase.eventSourcing, policy)
+			require.ErrorContains(t, err, "cleanup policy compact is not supported")
+			require.Nil(t, manager.GetTopic("state"))
+		})
+	}
+}
+
+func TestExistingEventSourcingTopicCannotBeChangedToCompact(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+	diskManager := disk.NewDiskManager(cfg)
+	defer diskManager.CloseAllHandlers()
+	manager := NewTopicManager(cfg, diskManager, nil)
+
+	require.NoError(t, manager.CreateTopic("events", 1, false, true))
+	compact := DefaultPolicy()
+	compact.CleanupPolicy = config.CleanupPolicyCompact
+	err := manager.CreateTopicWithPolicy("events", 1, false, false, compact)
+	require.ErrorContains(t, err, "cleanup policy compact is not supported")
+	require.Equal(t, config.CleanupPolicyDelete, manager.GetTopic("events").Policy.CleanupPolicy)
+	for _, partition := range manager.GetTopic("events").Partitions {
+		partition.Close()
+	}
+}

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -73,7 +73,11 @@ func NewTopicManager(cfg *config.Config, hp HandlerProvider, sm StreamManager) *
 }
 
 func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent bool, eventSourcing bool) error {
-	return tm.CreateTopicWithPolicy(name, partitionCount, idempotent, eventSourcing, DefaultPolicy())
+	policy := DefaultPolicy()
+	if tm.cfg != nil && tm.cfg.CleanupPolicy != "" {
+		policy.CleanupPolicy = tm.cfg.CleanupPolicy
+	}
+	return tm.CreateTopicWithPolicy(name, partitionCount, idempotent, eventSourcing, policy)
 }
 
 func (tm *TopicManager) CreateTopicWithPolicy(name string, partitionCount int, idempotent bool, eventSourcing bool, policy Policy) error {
@@ -81,21 +85,27 @@ func (tm *TopicManager) CreateTopicWithPolicy(name string, partitionCount int, i
 	if err != nil {
 		return err
 	}
+	if err := validateCleanupPolicyForTopic(normalizedPolicy, tm.cfg, eventSourcing); err != nil {
+		return err
+	}
 
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
 	if existing, ok := tm.topics[name]; ok {
+		if err := validateCleanupPolicyForTopic(normalizedPolicy, tm.cfg, existing.IsEventSourcing); err != nil {
+			return err
+		}
 		current := len(existing.Partitions)
 		switch {
 		case partitionCount < current:
 			util.Error("cannot decrease partitions for topic '%s' (%d -> %d)", name, current, partitionCount)
 			return fmt.Errorf("cannot decrease partition count for topic '%s': %d -> %d", name, current, partitionCount)
 		case partitionCount > current:
+			existing.ApplyPolicy(normalizedPolicy)
 			if err := existing.AddPartitions(partitionCount-current, tm.hp); err != nil {
 				return fmt.Errorf("failed to add partitions to topic '%s': %w", name, err)
 			}
-			existing.ApplyPolicy(normalizedPolicy)
 			util.Info("topic '%s' partitions increased: %d -> %d", name, current, len(existing.Partitions))
 			return nil
 		default:

--- a/pkg/topic/manager_test.go
+++ b/pkg/topic/manager_test.go
@@ -195,3 +195,19 @@ func TestTopicManagerCreateTopic(t *testing.T) {
 
 	tm.Stop()
 }
+
+func TestNewTopicClosesInitializedHandlersOnPartialFailure(t *testing.T) {
+	cfg := config.DefaultConfig()
+	hp := new(MockHandlerProvider)
+	first := new(MockStorageHandler)
+	first.On("GetLatestOffset").Return(uint64(0)).Once()
+	first.On("Close").Return(nil).Once()
+	hp.On("GetHandler", "partial-topic", 0).Return(first, nil).Once()
+	hp.On("GetHandler", "partial-topic", 1).Return(nil, assert.AnError).Once()
+
+	created, err := NewTopicWithPolicy("partial-topic", 2, hp, cfg, nil, false, false, DefaultPolicy())
+	assert.Error(t, err)
+	assert.Nil(t, created)
+	hp.AssertExpectations(t)
+	first.AssertExpectations(t)
+}

--- a/pkg/topic/policy.go
+++ b/pkg/topic/policy.go
@@ -3,6 +3,8 @@ package topic
 import (
 	"fmt"
 	"strings"
+
+	"github.com/cursus-io/cursus/pkg/config"
 )
 
 const (
@@ -17,6 +19,7 @@ const (
 type Policy struct {
 	RetentionHours int      `json:"retention_hours,omitempty"`
 	RetentionBytes int64    `json:"retention_bytes,omitempty"`
+	CleanupPolicy  string   `json:"cleanup_policy"`
 	Partitioner    string   `json:"partitioner"`
 	AuthPolicy     string   `json:"auth_policy"`
 	ReadACL        []string `json:"read_acl,omitempty"`
@@ -25,12 +28,22 @@ type Policy struct {
 
 func DefaultPolicy() Policy {
 	return Policy{
-		Partitioner: PartitionerHashKey,
-		AuthPolicy:  AuthPolicyOpen,
+		CleanupPolicy: config.CleanupPolicyDelete,
+		Partitioner:   PartitionerHashKey,
+		AuthPolicy:    AuthPolicyOpen,
 	}
 }
 
 func (p Policy) Normalize() (Policy, error) {
+	if p.CleanupPolicy == "" {
+		p.CleanupPolicy = config.CleanupPolicyDelete
+	}
+	normalizedCleanup, ok := config.NormalizeCleanupPolicy(p.CleanupPolicy)
+	if !ok {
+		return p, fmt.Errorf("invalid cleanup policy %q", p.CleanupPolicy)
+	}
+	p.CleanupPolicy = normalizedCleanup
+
 	if p.Partitioner == "" {
 		p.Partitioner = PartitionerHashKey
 	}
@@ -58,6 +71,19 @@ func (p Policy) Normalize() (Policy, error) {
 		return p, fmt.Errorf("retention_bytes must be >= 0")
 	}
 	return p, nil
+}
+
+func validateCleanupPolicyForTopic(policy Policy, cfg *config.Config, eventSourcing bool) error {
+	if !config.HasCleanupPolicy(policy.CleanupPolicy, config.CleanupPolicyCompact) {
+		return nil
+	}
+	if eventSourcing {
+		return fmt.Errorf("cleanup policy compact is not supported for event-sourcing topics")
+	}
+	if cfg != nil && cfg.EnabledDistribution {
+		return fmt.Errorf("cleanup policy compact is not supported in distributed mode")
+	}
+	return nil
 }
 
 func (p Policy) CanRead() bool {

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -39,19 +39,54 @@ func (t *Topic) SetTransactionDecisionResolver(resolver TransactionDecisionResol
 	}
 }
 
+type storagePolicySetter interface {
+	SetStoragePolicy(cleanupPolicy string, hours int, bytes int64)
+}
+
 type retentionPolicySetter interface {
 	SetRetentionPolicy(hours int, bytes int64)
 }
 
-func applyRetentionPolicy(handler types.StorageHandler, policy Policy) {
+type cleanupPolicySetter interface {
+	SetCleanupPolicy(policy string)
+}
+
+type policyHandlerProvider interface {
+	GetHandlerWithPolicy(topic string, partitionID int, cleanupPolicy string, retentionHours int, retentionBytes int64) (types.StorageHandler, error)
+}
+
+func getHandlerWithStoragePolicy(provider HandlerProvider, topic string, partitionID int, policy Policy) (types.StorageHandler, error) {
+	if policyProvider, ok := provider.(policyHandlerProvider); ok {
+		return policyProvider.GetHandlerWithPolicy(topic, partitionID, policy.CleanupPolicy, policy.RetentionHours, policy.RetentionBytes)
+	}
+	handler, err := provider.GetHandler(topic, partitionID)
+	if err != nil {
+		return nil, err
+	}
+	applyStoragePolicy(handler, policy)
+	return handler, nil
+}
+
+func applyStoragePolicy(handler types.StorageHandler, policy Policy) {
+	if setter, ok := handler.(storagePolicySetter); ok {
+		setter.SetStoragePolicy(policy.CleanupPolicy, policy.RetentionHours, policy.RetentionBytes)
+		return
+	}
 	if setter, ok := handler.(retentionPolicySetter); ok {
 		setter.SetRetentionPolicy(policy.RetentionHours, policy.RetentionBytes)
+	}
+	if setter, ok := handler.(cleanupPolicySetter); ok {
+		setter.SetCleanupPolicy(policy.CleanupPolicy)
 	}
 }
 
 // NewTopic initializes a topic with partitions.
 func NewTopic(name string, partitionCount int, hp HandlerProvider, cfg *config.Config, sm StreamManager, idempotent bool, eventSourcing bool) (*Topic, error) {
-	return NewTopicWithPolicy(name, partitionCount, hp, cfg, sm, idempotent, eventSourcing, DefaultPolicy())
+	policy := DefaultPolicy()
+	if cfg != nil && cfg.CleanupPolicy != "" {
+		policy.CleanupPolicy = cfg.CleanupPolicy
+	}
+	return NewTopicWithPolicy(name, partitionCount, hp, cfg, sm, idempotent, eventSourcing, policy)
 }
 
 func NewTopicWithPolicy(name string, partitionCount int, hp HandlerProvider, cfg *config.Config, sm StreamManager, idempotent bool, eventSourcing bool, policy Policy) (*Topic, error) {
@@ -59,14 +94,16 @@ func NewTopicWithPolicy(name string, partitionCount int, hp HandlerProvider, cfg
 	if err != nil {
 		return nil, err
 	}
+	if err := validateCleanupPolicyForTopic(normalizedPolicy, cfg, eventSourcing); err != nil {
+		return nil, err
+	}
 
 	partitions := make([]*Partition, partitionCount)
 	for i := 0; i < partitionCount; i++ {
-		dh, err := hp.GetHandler(name, i)
+		dh, err := getHandlerWithStoragePolicy(hp, name, i, normalizedPolicy)
 		if err != nil {
 			return nil, fmt.Errorf("open handler for %s[%d]: %w", name, i, err)
 		}
-		applyRetentionPolicy(dh, normalizedPolicy)
 		p := NewPartition(i, name, dh, sm, cfg)
 		p.isIdempotent = idempotent
 		p.RecoverProducerStateFromLog()
@@ -120,11 +157,10 @@ func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
 
 	for i := 0; i < extra; i++ {
 		idx := len(t.Partitions)
-		dh, err := hp.GetHandler(t.Name, idx)
+		dh, err := getHandlerWithStoragePolicy(hp, t.Name, idx, t.Policy)
 		if err != nil {
 			return fmt.Errorf("failed to attach partition %d for topic '%s': %w", idx, t.Name, err)
 		}
-		applyRetentionPolicy(dh, t.Policy)
 		newP := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
 		newP.SetTransactionDecisionResolver(t.txnResolver)
 		newP.isIdempotent = t.IsIdempotent
@@ -141,7 +177,7 @@ func (t *Topic) ApplyPolicy(policy Policy) {
 
 	t.Policy = policy
 	for _, partition := range t.Partitions {
-		applyRetentionPolicy(partition.dh, policy)
+		applyStoragePolicy(partition.dh, policy)
 	}
 }
 

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -102,6 +102,7 @@ func NewTopicWithPolicy(name string, partitionCount int, hp HandlerProvider, cfg
 	for i := 0; i < partitionCount; i++ {
 		dh, err := getHandlerWithStoragePolicy(hp, name, i, normalizedPolicy)
 		if err != nil {
+			closePartiallyInitializedTopic(name, hp, partitions[:i])
 			return nil, fmt.Errorf("open handler for %s[%d]: %w", name, i, err)
 		}
 		p := NewPartition(i, name, dh, sm, cfg)
@@ -120,6 +121,21 @@ func NewTopicWithPolicy(name string, partitionCount int, hp HandlerProvider, cfg
 		IsEventSourcing: eventSourcing,
 		Policy:          normalizedPolicy,
 	}, nil
+}
+
+func closePartiallyInitializedTopic(name string, provider HandlerProvider, partitions []*Partition) {
+	for _, partition := range partitions {
+		partition.Close()
+	}
+	if closer, ok := provider.(topicHandlerCloser); ok {
+		closer.CloseTopicHandlers(name)
+		return
+	}
+	for _, partition := range partitions {
+		if err := partition.dh.Close(); err != nil {
+			util.Warn("Failed to close storage handler for partially initialized topic %s[%d]: %v", name, partition.ID, err)
+		}
+	}
 }
 
 // getPartitionIndex computes the target partition index without acquiring any lock.

--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -127,7 +127,7 @@ func (es *EventStore) sendCommand(cmd string) (string, error) {
 
 // CreateTopic creates an event-sourcing-enabled topic if it doesn't exist.
 func (es *EventStore) CreateTopic(partitions int) error {
-	resp, err := es.sendCommand(fmt.Sprintf("CREATE topic=%s partitions=%d event_sourcing=true", es.topic, partitions))
+	resp, err := es.sendCommand(fmt.Sprintf("CREATE topic=%s partitions=%d event_sourcing=true cleanup_policy=delete", es.topic, partitions))
 	if err != nil {
 		return err
 	}

--- a/sdk/eventstore_test.go
+++ b/sdk/eventstore_test.go
@@ -2,10 +2,13 @@ package sdk
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/cursus-io/cursus/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,6 +143,7 @@ func TestAppendCommandFormat(t *testing.T) {
 	assert.Contains(t, cmd, "producerId=p-1")
 	assert.Contains(t, cmd, `message={"id":1}`)
 }
+
 func TestParseSnapshotResponse_StrictContract(t *testing.T) {
 	snapshotJSON, ok, err := parseSnapshotResponse(`OK snapshot={"version":1,"payload":"x"}`)
 	require.NoError(t, err)
@@ -172,4 +176,35 @@ func TestParseStreamVersionResponse_StrictContract(t *testing.T) {
 	_, err = parseStreamVersionResponse("OK")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing version")
+}
+
+func TestEventStoreCreateTopicDeclaresDeleteCleanupPolicy(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	store := NewEventStore("unused", "orders", "producer-1")
+	store.conn = client
+	done := make(chan error, 1)
+	go func() {
+		data, err := ReadWithLength(server)
+		if err != nil {
+			done <- err
+			return
+		}
+		_, command, err := util.DecodeMessage(data)
+		if err != nil {
+			done <- err
+			return
+		}
+		want := "CREATE topic=orders partitions=4 event_sourcing=true cleanup_policy=delete"
+		if command != want {
+			done <- fmt.Errorf("command = %q, want %q", command, want)
+			return
+		}
+		done <- WriteWithLength(server, []byte("OK topic=orders partitions=4 cleanup_policy=delete"))
+	}()
+
+	require.NoError(t, store.CreateTopic(4))
+	require.NoError(t, <-done)
 }

--- a/sdk/eventstore_test.go
+++ b/sdk/eventstore_test.go
@@ -181,12 +181,12 @@ func TestParseStreamVersionResponse_StrictContract(t *testing.T) {
 func TestEventStoreCreateTopicDeclaresDeleteCleanupPolicy(t *testing.T) {
 	client, server := net.Pipe()
 	defer func() { _ = client.Close() }()
-	defer func() { _ = server.Close() }()
 
 	store := NewEventStore("unused", "orders", "producer-1")
 	store.conn = client
 	done := make(chan error, 1)
 	go func() {
+		defer func() { _ = server.Close() }()
 		data, err := ReadWithLength(server)
 		if err != nil {
 			done <- err

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -191,7 +191,37 @@ func (p *Producer) nextPartition() int {
 	return idx
 }
 
+// TopicCleanupPolicy selects broker maintenance for a topic.
+type TopicCleanupPolicy string
+
+const (
+	TopicCleanupDelete        TopicCleanupPolicy = "delete"
+	TopicCleanupCompact       TopicCleanupPolicy = "compact"
+	TopicCleanupDeleteCompact TopicCleanupPolicy = "delete,compact"
+)
+
+// TopicOptions defines optional CREATE settings for a topic.
+type TopicOptions struct {
+	Partitions     int
+	CleanupPolicy  TopicCleanupPolicy
+	RetentionHours int
+	RetentionBytes int64
+	Partitioner    string
+	AuthPolicy     string
+	ReadACL        []string
+	WriteACL       []string
+}
+
 func (p *Producer) CreateTopic(topic string, partitions int) error {
+	return p.CreateTopicWithOptions(topic, TopicOptions{Partitions: partitions})
+}
+
+// CreateTopicWithOptions creates or updates a topic with explicit policy options.
+func (p *Producer) CreateTopicWithOptions(topic string, options TopicOptions) error {
+	createCmd, err := buildCreateTopicCommand(topic, options, p.config.EnableIdempotence)
+	if err != nil {
+		return err
+	}
 	if len(p.config.BrokerAddrs) == 0 {
 		return fmt.Errorf("no broker addresses available")
 	}
@@ -208,7 +238,6 @@ func (p *Producer) CreateTopic(topic string, partitions int) error {
 	if err := authenticateConfiguredClient(conn, p.config.Principal, p.config.AuthToken); err != nil {
 		return fmt.Errorf("authentication: %w", err)
 	}
-	createCmd := fmt.Sprintf("CREATE topic=%s partitions=%d idempotent=%t", topic, partitions, p.config.EnableIdempotence)
 	cmdBytes := EncodeMessage("admin", createCmd)
 
 	if err := WriteWithLength(conn, cmdBytes); err != nil {
@@ -228,8 +257,94 @@ func (p *Producer) CreateTopic(topic string, partitions int) error {
 		return fmt.Errorf("unexpected create response: %s", respStr)
 	}
 
-	LogInfo("create topic %s partition %d", topic, partitions)
+	LogInfo("create topic %s partition %d", topic, options.Partitions)
 	return nil
+}
+
+func buildCreateTopicCommand(topic string, options TopicOptions, idempotent bool) (string, error) {
+	if !isSafeTopicOptionValue(topic, false) {
+		return "", fmt.Errorf("invalid topic name %q", topic)
+	}
+	if options.Partitions <= 0 {
+		return "", fmt.Errorf("partitions must be positive")
+	}
+	if options.RetentionHours < 0 {
+		return "", fmt.Errorf("retention hours must be non-negative")
+	}
+	if options.RetentionBytes < 0 {
+		return "", fmt.Errorf("retention bytes must be non-negative")
+	}
+
+	cleanupPolicy, err := normalizeSDKCleanupPolicy(options.CleanupPolicy)
+	if err != nil {
+		return "", err
+	}
+	switch options.Partitioner {
+	case "", "hash_key", "round_robin":
+	default:
+		return "", fmt.Errorf("invalid partitioner %q", options.Partitioner)
+	}
+	switch options.AuthPolicy {
+	case "", "open", "deny_write", "deny_read", "acl":
+	default:
+		return "", fmt.Errorf("invalid auth policy %q", options.AuthPolicy)
+	}
+	for _, acl := range append(append([]string(nil), options.ReadACL...), options.WriteACL...) {
+		if !isSafeTopicOptionValue(acl, false) || strings.Contains(acl, ",") {
+			return "", fmt.Errorf("invalid ACL principal %q", acl)
+		}
+	}
+
+	command := fmt.Sprintf("CREATE topic=%s partitions=%d idempotent=%t", topic, options.Partitions, idempotent)
+	if cleanupPolicy != "" {
+		command += " cleanup_policy=" + cleanupPolicy
+	}
+	if options.RetentionHours != 0 {
+		command += fmt.Sprintf(" retention_hours=%d", options.RetentionHours)
+	}
+	if options.RetentionBytes != 0 {
+		command += fmt.Sprintf(" retention_bytes=%d", options.RetentionBytes)
+	}
+	if options.Partitioner != "" {
+		command += " partitioner=" + options.Partitioner
+	}
+	if options.AuthPolicy != "" {
+		command += " auth_policy=" + options.AuthPolicy
+	}
+	if len(options.ReadACL) > 0 {
+		command += " read_acl=" + strings.Join(options.ReadACL, ",")
+	}
+	if len(options.WriteACL) > 0 {
+		command += " write_acl=" + strings.Join(options.WriteACL, ",")
+	}
+	return command, nil
+}
+
+func normalizeSDKCleanupPolicy(value TopicCleanupPolicy) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(string(value))) {
+	case "":
+		return "", nil
+	case "delete":
+		return "delete", nil
+	case "compact":
+		return "compact", nil
+	case "delete,compact", "compact,delete":
+		return "delete,compact", nil
+	default:
+		return "", fmt.Errorf("invalid cleanup policy %q", value)
+	}
+}
+
+func isSafeTopicOptionValue(value string, allowEmpty bool) bool {
+	if value == "" {
+		return allowEmpty
+	}
+	for _, r := range value {
+		if r <= ' ' || r == '=' || r == '"' || r == '\\' {
+			return false
+		}
+	}
+	return true
 }
 
 // Send enqueues payload for delivery and returns the assigned sequence number.

--- a/sdk/topic_options_test.go
+++ b/sdk/topic_options_test.go
@@ -1,0 +1,56 @@
+package sdk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCreateTopicCommandWithOptions(t *testing.T) {
+	command, err := buildCreateTopicCommand("state", TopicOptions{
+		Partitions:     3,
+		CleanupPolicy:  "compact,delete",
+		RetentionHours: 24,
+		RetentionBytes: 1024,
+		Partitioner:    "hash_key",
+		AuthPolicy:     "acl",
+		ReadACL:        []string{"reader"},
+		WriteACL:       []string{"writer"},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "CREATE topic=state partitions=3 idempotent=true cleanup_policy=delete,compact retention_hours=24 retention_bytes=1024 partitioner=hash_key auth_policy=acl read_acl=reader write_acl=writer"
+	if command != want {
+		t.Fatalf("command = %q, want %q", command, want)
+	}
+}
+
+func TestBuildCreateTopicCommandRejectsUnsafeOrInvalidOptions(t *testing.T) {
+	tests := []TopicOptions{
+		{Partitions: 0},
+		{Partitions: 1, CleanupPolicy: "unknown"},
+		{Partitions: 1, RetentionHours: -1},
+		{Partitions: 1, RetentionBytes: -1},
+		{Partitions: 1, Partitioner: "random"},
+		{Partitions: 1, AuthPolicy: "unknown"},
+		{Partitions: 1, ReadACL: []string{"reader principal"}},
+	}
+	for _, options := range tests {
+		if _, err := buildCreateTopicCommand("state", options, false); err == nil {
+			t.Fatalf("expected options to fail: %+v", options)
+		}
+	}
+	if _, err := buildCreateTopicCommand("state command=DELETE", TopicOptions{Partitions: 1}, false); err == nil {
+		t.Fatal("unsafe topic name was accepted")
+	}
+}
+
+func TestBuildCreateTopicCommandOmitsInheritedValues(t *testing.T) {
+	command, err := buildCreateTopicCommand("state", TopicOptions{Partitions: 1}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(command, "cleanup_policy=") || strings.Contains(command, "retention_") {
+		t.Fatalf("inherited options unexpectedly serialized: %s", command)
+	}
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes

No linked issue.

This PR adds crash-safe keyed log compaction for standalone Cursus topics while preserving logical offsets, transaction metadata, and producer recovery state.

## Changes

- support `delete`, `compact`, and canonical `delete,compact` cleanup policies
- compact eligible closed segments without rewriting the active segment or renumbering offsets
- retain unkeyed records, transaction/control records, and producer recovery anchors
- add durable size-bound compaction sidecars, startup cleanup, sparse-index rebuilding, and fail-closed offset-gap validation
- serialize compaction with retention and truncation maintenance
- expose cleanup policy through `CREATE`, `METADATA`, protocol feature negotiation, and structured errors
- add Go SDK `CreateTopicWithOptions` support and keep event-sourcing topics explicitly uncompacted
- document selection, recovery, backup, operational, and delivery contracts

## Validation

- `go test ./pkg/disk -count=5`
- `go test -p=1 ./pkg/... ./sdk/... ./test/consumer/... ./test/publisher/... ./util -count=1`
- `go vet ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./pkg/disk`
- `git diff --check`

Docker Compose E2E was not run locally because the Docker daemon was unavailable. `golangci-lint run ./...` still reports 17 pre-existing findings outside this PR's changed code.

## Remaining risks

- compaction is intentionally rejected for distributed and event-sourcing topics
- standalone topic policy metadata must be redeclared by provisioning after broker restart
- sidecars bind compacted generations by version and file size rather than a full-file checksum
- tombstone expiry and per-topic dirty-ratio overrides are not part of this contract
- Java and Python SDKs do not yet expose the typed Go SDK topic-options convenience API

Checklist:

- [x] This PR proposes a new enhancement; no related issue is linked.
- [x] The PR title clearly states the change; no related issue is linked for automatic closing.
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.