### PR TITLE
feat: persist durable topic metadata

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -51,6 +51,9 @@ func main() {
 	}
 
 	tm := topic.NewTopicManager(cfg, dm, smAdapter)
+	if err := tm.RestoreTopics(); err != nil {
+		util.Fatal("❌ Failed to restore durable topic metadata: %v", err)
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	cd := coordinator.NewCoordinator(ctx, cfg, tm)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -31,6 +31,10 @@ func main() {
 		os.Exit(1)
 	}
 	tm := topic.NewTopicManager(cfg, dm, smAdapter)
+	if err := tm.RestoreTopics(); err != nil {
+		fmt.Println("❌ Failed to restore durable topic metadata:", err)
+		os.Exit(1)
+	}
 	cd := coordinator.NewCoordinator(context.Background(), cfg, tm)
 	tm.SetCoordinator(cd)
 

--- a/docs/core/storage/disk-format.md
+++ b/docs/core/storage/disk-format.md
@@ -83,6 +83,37 @@ Partition-owned side checkpoints include:
 
 Transaction visibility indexes are rebuilt from durable transaction records and markers. The durable transaction coordinator decision remains a separate metadata authority.
 
+## Standalone Topic Manifest
+
+A standalone broker stores the authoritative topic registry in `{log_dir}/__topic_metadata.json`. The current version 1 shape is:
+
+```json
+{
+  "version": 1,
+  "topics": [
+    {
+      "name": "orders",
+      "partitions": 4,
+      "idempotent": true,
+      "event_sourcing": false,
+      "policy": {
+        "cleanup_policy": "delete",
+        "partitioner": "hash_key",
+        "auth_policy": "acl",
+        "read_acl": ["game-server"],
+        "write_acl": ["game-server"],
+        "retention_hours": 168,
+        "retention_bytes": 0
+      }
+    }
+  ]
+}
+```
+
+The encoded manifest is limited to 16 MiB. Updates write a mode-`0600` same-directory temporary file, sync it, atomically replace the committed manifest, and sync the parent directory where supported. Startup reads only the committed path; abandoned `.tmp` files are not authoritative. Parsing disallows unknown fields and rejects duplicate names, invalid definitions, trailing content, and unsupported versions. The broker does not infer ACL or event-sourcing mode from segment filenames when a manifest is absent or invalid.
+
+Backups of a standalone broker must keep this manifest with topic partition directories, `__transaction_state.journal`, and the consumer offset log. Restoring only segment files cannot reconstruct the full topic policy.
+
 ## Standalone Transaction Journal
 
 A standalone broker stores coordinator snapshots in `{log_dir}/__transaction_state.journal`. This file is separate from partition segments. Each record uses the following versioned frame:

--- a/docs/core/storage/disk-format.md
+++ b/docs/core/storage/disk-format.md
@@ -110,7 +110,7 @@ A standalone broker stores the authoritative topic registry in `{log_dir}/__topi
 }
 ```
 
-The encoded manifest is limited to 16 MiB. Updates write a mode-`0600` same-directory temporary file, sync it, atomically replace the committed manifest, and sync the parent directory where supported. Startup reads only the committed path; abandoned `.tmp` files are not authoritative. Parsing disallows unknown fields and rejects duplicate names, invalid definitions, trailing content, and unsupported versions. The broker does not infer ACL or event-sourcing mode from segment filenames when a manifest is absent or invalid.
+The encoded manifest is limited to 16 MiB. Updates write a mode-`0600` same-directory temporary file, sync it, atomically replace the committed manifest, and sync the parent directory where supported. Startup reads only the committed path; abandoned `.tmp` files are not authoritative. Parsing disallows unknown fields and rejects duplicate names, invalid definitions, trailing content, and unsupported versions. A missing manifest with persisted topic logs, or a valid manifest that omits a persisted topic directory, is an integrity error. The broker does not infer ACL or event-sourcing mode from segment filenames when a manifest is absent or invalid.
 
 Backups of a standalone broker must keep this manifest with topic partition directories, `__transaction_state.journal`, and the consumer offset log. Restoring only segment files cannot reconstruct the full topic policy.
 

--- a/docs/core/storage/disk-persistence.md
+++ b/docs/core/storage/disk-persistence.md
@@ -76,7 +76,7 @@ HWM is persisted through a synced temporary checkpoint and restored with a clamp
 
 ## Startup Recovery
 
-Standalone startup first loads the versioned `__topic_metadata.json` manifest and recreates topic definitions/partition handlers before coordinator initialization. Corrupt, duplicate, unknown-version, or semantically invalid metadata fails startup. Distributed snapshot version 6 restores the same topic definitions from FSM state before committed HWM reconciliation; older snapshots reconstruct only the metadata those formats retained.
+Standalone startup first loads the versioned `__topic_metadata.json` manifest and recreates topic definitions/partition handlers before coordinator initialization. Corrupt, duplicate, unknown-version, or semantically invalid metadata fails startup. A missing manifest with persisted topic logs, or a manifest that omits a persisted topic directory, also fails startup rather than silently losing or recreating data; restore the compatible manifest or archive the orphaned storage before retrying. Distributed snapshot version 6 restores the same topic definitions from FSM state before committed HWM reconciliation; older snapshots reconstruct only the metadata those formats retained.
 
 For the active segment, recovery scans length prefixes and serialized records. Invalid lengths, decode failures, non-contiguous offsets, and partial tails stop recovery at the last valid boundary. The file is truncated and synced to that boundary before writes resume.
 

--- a/docs/core/storage/disk-persistence.md
+++ b/docs/core/storage/disk-persistence.md
@@ -76,6 +76,8 @@ HWM is persisted through a synced temporary checkpoint and restored with a clamp
 
 ## Startup Recovery
 
+Standalone startup first loads the versioned `__topic_metadata.json` manifest and recreates topic definitions/partition handlers before coordinator initialization. Corrupt, duplicate, unknown-version, or semantically invalid metadata fails startup. Distributed snapshot version 6 restores the same topic definitions from FSM state before committed HWM reconciliation; older snapshots reconstruct only the metadata those formats retained.
+
 For the active segment, recovery scans length prefixes and serialized records. Invalid lengths, decode failures, non-contiguous offsets, and partial tails stop recovery at the last valid boundary. The file is truncated and synced to that boundary before writes resume.
 
 After storage opens, higher layers rebuild producer sequence, event-stream, and transaction visibility indexes from durable state as needed. The consumer group coordinator restores offsets from the internal offset log. The transaction coordinator restores standalone state from `__transaction_state.journal` or distributed state from Raft metadata; neither coordinator infers its final decision from output record payloads alone.

--- a/docs/core/topic/topic-management.md
+++ b/docs/core/topic/topic-management.md
@@ -1,6 +1,6 @@
 # Topic Management
 
-`TopicManager` is the in-process registry and entry point for topic/partition operations. Durable group membership belongs to `Coordinator`; transaction lifecycle belongs to `transaction.Manager`; cluster metadata and leader ownership belong to the cluster subsystem.
+`TopicManager` is the in-process registry and entry point for topic/partition operations. Its topic definitions are durable in the standalone manifest or cluster FSM. Durable group membership belongs to `Coordinator`; transaction lifecycle belongs to `transaction.Manager`; partition leader ownership belongs to the cluster subsystem.
 
 ## TopicManager
 
@@ -28,11 +28,23 @@ It does not use a global payload-hash deduplication map. Retry safety comes from
 
 New and existing partitions receive the current transaction decision resolver so `read_committed` uses coordinator authority. Retention and cleanup policy are propagated to every partition handler. An existing event-sourcing topic remains protected even if a later idempotent create request omits or clears `event_sourcing`.
 
+Topic names use a portable storage contract: 1-249 ASCII bytes containing letters, digits, `.`, `_`, `-`, or `=`; `.` and `..` are reserved. This prevents a protocol topic identifier from escaping the broker-owned log root.
+
 `cleanup_policy` accepts `delete`, `compact`, and `delete,compact`. Compact policies are rejected when distribution is enabled or the topic is event-sourcing. Standalone compaction details are in [Log Compaction](../storage/log-compaction.md).
+
+For standalone create/update, new partition handlers are staged while the topic lock excludes publishers. The complete target definition is atomically persisted before policy or partition count becomes visible. A persistence failure closes/evicts staged handlers and leaves the live definition unchanged. In distributed mode the FSM retains existing partition leader epoch/HWM state on repeated create and allocates metadata only for newly added partitions.
+
+## Startup Recovery
+
+Standalone brokers load `{log_dir}/__topic_metadata.json` before coordinator initialization and static-group registration. The versioned manifest restores partition count, idempotent/event-sourcing flags, cleanup/retention, partitioner, auth policy, and ACLs. Unknown fields, duplicate topics, unsupported versions, invalid names, and malformed policy fail broker startup instead of silently weakening authorization or cleanup behavior.
+
+Brokers upgraded from versions without the manifest do not guess security or event-sourcing policy from segment filenames. Existing applications must issue their normal idempotent `CREATE` declarations once; each successful declaration adds the authoritative definition. The internal offset topic is recreated by the coordinator and then enters the manifest.
+
+Distributed brokers keep topic definitions in the FSM and snapshot format version 6. Snapshot restore rebuilds the topic registry before committed HWM reconciliation. Version 5 and older snapshots can reconstruct partition count/idempotent mode from partition metadata, using the historical default topic policy because those snapshots did not retain the richer definition.
 
 ## Delete
 
-`DeleteTopic` removes the topic from the registry, closes storage handlers through the provider when supported, and removes the broker-owned topic log directory after verifying the target remains under the configured log root. Deletion is destructive and must remain an authenticated admin operation.
+`DeleteTopicDurable` first commits removal from standalone metadata. It then removes the topic from the registry, stops partition workers, closes storage handlers, and removes the broker-owned topic log directory after verifying the target remains under the configured log root. A manifest failure leaves the topic live. Once the manifest removal commits, physical cleanup failures are logged for operator remediation but do not turn the logically successful deletion into an error response. Deletion is destructive and must remain an authenticated admin operation.
 
 ## Publish Entry Points
 
@@ -68,7 +80,7 @@ Only the partition data path may decide record visibility. Raw disk reads do not
 
 ## Thread Safety
 
-- `TopicManager.mu` protects the topic registry and resolver propagation.
+- `TopicManager.mu` protects the topic registry, resolver propagation, and whole-manifest definition snapshots.
 - `Topic.mu` protects partition/policy/embedded-group state and round-robin selection.
 - `Partition` uses dedicated locks for lifecycle/channels, producer state, transaction index, and disk operations.
 - storage handlers serialize metadata and I/O separately.

--- a/docs/core/topic/topic-management.md
+++ b/docs/core/topic/topic-management.md
@@ -38,7 +38,9 @@ For standalone create/update, new partition handlers are staged while the topic 
 
 Standalone brokers load `{log_dir}/__topic_metadata.json` before coordinator initialization and static-group registration. The versioned manifest restores partition count, idempotent/event-sourcing flags, cleanup/retention, partitioner, auth policy, and ACLs. Unknown fields, duplicate topics, unsupported versions, invalid names, and malformed policy fail broker startup instead of silently weakening authorization or cleanup behavior.
 
-Brokers upgraded from versions without the manifest do not guess security or event-sourcing policy from segment filenames. Existing applications must issue their normal idempotent `CREATE` declarations once; each successful declaration adds the authoritative definition. The internal offset topic is recreated by the coordinator and then enters the manifest.
+Brokers upgraded from versions without the manifest do not guess security or event-sourcing policy from segment filenames. If persisted partition logs exist without a manifest, or a manifest omits a persisted topic directory, startup fails and lists the orphaned topics. Operators must migrate or archive those directories and provide authoritative definitions before restart. A normal `CREATE` also rejects a name whose orphaned logs remain, preventing deleted data from being silently resurrected.
+
+The internal offset topic is recreated by the coordinator and then enters the manifest on a new data directory. Existing pre-manifest offset logs require the same explicit migration as application topics.
 
 Distributed brokers keep topic definitions in the FSM and snapshot format version 6. Snapshot restore rebuilds the topic registry before committed HWM reconciliation. Version 5 and older snapshots can reconstruct partition count/idempotent mode from partition metadata, using the historical default topic policy because those snapshots did not retain the richer definition.
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -179,7 +179,7 @@ CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [event_sourcing=<
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
-| topic | Yes | - | Topic name |
+| topic | Yes | - | Portable topic name: 1-249 ASCII bytes using letters, digits, `.`, `_`, `-`, or `=` |
 | partitions | No | 4 | Number of partitions |
 | idempotent | No | false | Enable producer dedup |
 | event_sourcing | No | false | Enable aggregate stream commands; requires non-compacted history |
@@ -194,13 +194,19 @@ CREATE topic=<name> [partitions=<N>] [idempotent=<true|false>] [event_sourcing=<
 
 Response: `OK topic=<name> partitions=<N> cleanup_policy=<policy> partitioner=<hash_key|round_robin> auth_policy=<open|deny_write|deny_read|acl> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>`
 
-`compact` and `delete,compact` are accepted only by standalone, non-event-sourcing topics. Unsupported combinations return `ERROR: invalid_topic_policy ...` or `ERROR: unsupported_topic_policy ...`. Repeating `CREATE` for an existing event-sourcing topic cannot use a false `event_sourcing` argument to bypass this validation.
+Topic names are a portable on-disk identifier: 1-249 ASCII bytes containing only letters, digits, `.`, `_`, `-`, or `=`; `.` and `..` are reserved. Invalid names return `ERROR: invalid_topic_name ...`.
+
+A successful standalone `CREATE` means the versioned topic definition has been atomically replaced and synced in `{log_dir}/__topic_metadata.json` before the new policy or partition count is exposed to publishers. Broker restart restores partition count, idempotent/event-sourcing mode, partitioner, retention, cleanup policy, auth policy, and ACLs from this manifest. Distributed mode commits the same definition through the cluster FSM and includes it in snapshot version 6.
+
+`compact` and `delete,compact` are accepted only by standalone, non-event-sourcing topics. Unsupported combinations return `ERROR: invalid_topic_policy ...` or `ERROR: unsupported_topic_policy ...`. Repeating `CREATE` for an existing event-sourcing topic cannot use a false `event_sourcing` argument to bypass this validation. Repeating `CREATE` also preserves existing partition leader epochs and committed HWMs; only newly added partitions receive new assignments.
 
 **DELETE**
 ```
 DELETE topic=<name>
 ```
 Response: `OK topic=<name> deleted=true`
+
+Standalone deletion first commits removal from the durable manifest, then closes partition workers/handlers and removes topic data. A manifest failure returns `ERROR: delete_topic_failed ...` and leaves the topic registered. After the manifest commit, physical cleanup errors are logged but the response remains successful because the topic is no longer authoritative. Distributed deletion is committed through the FSM.
 
 **LIST**
 ```
@@ -305,7 +311,7 @@ METADATA topic=<name>
 
 Response: `OK topic=<name> partitions=<N> leaders=<host:port>,<host:port>,... epochs=<csv> cleanup_policy=<policy> partitioner=<policy> auth_policy=<policy> read_acl=<csv> write_acl=<csv> retention_hours=<N> retention_bytes=<N>`
 
-Returns partition leaders/epochs and the authoritative in-memory topic policy. Leader addresses are in partition order (P0, P1, P2, ...).
+Returns partition leaders/epochs and the authoritative durable topic policy restored from the standalone manifest or cluster FSM. Leader addresses are in partition order (P0, P1, P2, ...).
 
 Any broker can answer this command. Addresses are the advertised client addresses from the FSM broker registry.
 
@@ -359,7 +365,7 @@ Response: `OK member=<actual-id> generation=<N>`
 
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
-| topic | Yes | - | Topic name |
+| topic | Yes | - | Portable topic name: 1-249 ASCII bytes using letters, digits, `.`, `_`, `-`, or `=` |
 | group | Yes | - | Consumer group name |
 | member | Yes | - | Consumer member ID (with suffix) |
 | generation | No | - | Current generation number; if supplied, stale generations return ERROR: GEN_MISMATCH ... |
@@ -513,7 +519,7 @@ missing, an entry is malformed, or the same partition appears more than once.
 
 Cursus exposes a broker-managed transaction coordinator for consume-process-produce workflows. In distributed mode, transaction commands are routed by `transactional_id` using the coordinator key `txn:<transactional_id>`. Clients can discover the owner with `FIND_COORDINATOR transactional_id=<id>` and must retry on `ERROR: NOT_COORDINATOR host=<host> port=<port>`.
 
-Standalone brokers append coordinator snapshots to `<log_dir>/__transaction_state.journal` and fsync each accepted transition. One encoded journal snapshot is limited to 32 MiB. Recovery truncates a torn or checksum-corrupt final journal record, rejects non-tail corruption, restores the latest state for each transactional id, and retries durable `committing` work before the client listener becomes ready. Distributed brokers replicate the same snapshots through the Raft FSM as `TXN_SYNC`. Transaction state entered the schema in version 4; current brokers write FSM snapshot version 5, which also carries committed partition watermarks.
+Standalone brokers append coordinator snapshots to `<log_dir>/__transaction_state.journal` and fsync each accepted transition. One encoded journal snapshot is limited to 32 MiB. Recovery truncates a torn or checksum-corrupt final journal record, rejects non-tail corruption, restores the latest state for each transactional id, and retries durable `committing` work before the client listener becomes ready. Distributed brokers replicate the same snapshots through the Raft FSM as `TXN_SYNC`. Transaction state entered the schema in version 4, committed partition watermarks in version 5, and durable topic definitions in the current version 6.
 
 Clients should first call `INIT_PRODUCER_ID` for a `transactional_id`; the broker returns the authoritative `(producerId, epoch)` session and bumps `epoch` on re-initialization to fence older producers. The coordinator fences stale producers by `(transactional_id, producerId, epoch)`: lower epochs are rejected, and staged operations must use the same producer and epoch that opened the transaction. After `transactional_id_expiration_ms`, completed transactions discard staged message/offset payloads but retain a compact epoch tombstone. The tombstone participates in standalone journal and distributed metadata snapshots, preventing an older producer session from being revived. Active `open` and `committing` transactions are not expired by the cleanup path.
 
@@ -618,7 +624,7 @@ READ_STREAM topic=<name> key=<aggregate_key> [from_version=<N>]
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
-| topic | Yes | - | Topic name |
+| topic | Yes | - | Portable topic name: 1-249 ASCII bytes using letters, digits, `.`, `_`, `-`, or `=` |
 | key | Yes | - | Aggregate ID |
 | from_version | No | 1 | Positive starting version; a usable snapshot advances the event batch to snapshot version + 1 |
 
@@ -646,7 +652,7 @@ STREAM_VERSION topic=<name> key=<aggregate_key>
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
-| topic | Yes | - | Topic name |
+| topic | Yes | - | Portable topic name: 1-249 ASCII bytes using letters, digits, `.`, `_`, `-`, or `=` |
 | key | Yes | - | Aggregate ID |
 
 Response: `OK version=<N>` (for example, `OK version=6`). Returns `OK version=0` if the aggregate does not exist. Older brokers returned a plain integer; clients may keep that only as a legacy fallback.
@@ -657,7 +663,7 @@ SAVE_SNAPSHOT topic=<name> key=<aggregate_key> version=<N> message=<payload>
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
-| topic | Yes | - | Topic name |
+| topic | Yes | - | Portable topic name: 1-249 ASCII bytes using letters, digits, `.`, `_`, `-`, or `=` |
 | key | Yes | - | Aggregate ID |
 | version | Yes | - | Aggregate version this snapshot represents (must be <= current version) |
 | message | Yes | - | Serialized aggregate state (captures rest of line) |
@@ -676,7 +682,7 @@ READ_SNAPSHOT topic=<name> key=<aggregate_key>
 ```
 | Param | Required | Default | Description |
 |-------|----------|---------|-------------|
-| topic | Yes | - | Topic name |
+| topic | Yes | - | Portable topic name: 1-249 ASCII bytes using letters, digits, `.`, `_`, `-`, or `=` |
 | key | Yes | - | Aggregate ID |
 
 Success response: `OK snapshot=<json>`
@@ -854,6 +860,7 @@ SDKs should parse the code and fields first, use `class` for broad handling, and
 
 | Error | Cause | Client Action |
 |-------|-------|---------------|
+| `invalid_topic_name topic=<X>` | Topic name violates the portable storage contract | Use 1-249 ASCII bytes containing letters, digits, `.`, `_`, `-`, or `=` |
 | `topic_not_found topic=<X>` | Topic not created | CREATE topic first |
 | `PARTITION_NOT_FOUND <N>` | Invalid partition ID | Check DESCRIBE for valid IDs |
 | `TOPIC_NOT_FOUND <X>` | Topic not found | CREATE topic first |
@@ -937,7 +944,7 @@ Set `isIdempotent=true` on PUBLISH or in binary batch header.
 - Broker tracks the last seen `(epoch, seqNum)` per `(producerId)` per partition
 - Disk-backed partitions persist producer sequence checkpoints, rebuild producer state from partition logs on broker restart, and use that state to make transactional commit recovery idempotent
 - Distributed FSM snapshots also include producer sequence state for replicated message commands
-- Producer epochs entered FSM snapshot version 3, transaction state version 4, and committed partition watermarks version 5. Current brokers write version 5. Do not run a mixed-version rolling upgrade with binaries that cannot decode version 5; upgrade the cluster together or use an explicitly documented compatibility procedure.
+- Producer epochs entered FSM snapshot version 3, transaction state version 4, committed partition watermarks version 5, and durable topic definitions version 6. Current brokers write version 6. Do not run a mixed-version rolling upgrade with binaries that cannot decode version 6; upgrade the cluster together or use an explicitly documented compatibility procedure.
 - Producer state expires from memory after `producer_state_ttl_ms` of inactivity (default 30 minutes); durable checkpoints retain the last persisted sequence until the partition data is removed
 
 ---

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -73,6 +73,7 @@ Common errors:
 
 ```text
 ERROR: missing_topic expected="CREATE topic=<name> [partitions=<N>]"
+ERROR: invalid_topic_name topic=<name> reason="..."
 ERROR: invalid_partitions reason="must be a positive integer"
 ERROR: invalid_replication_factor reason="must be a positive integer"
 ERROR: invalid_topic_policy field=cleanup_policy reason="..."
@@ -96,6 +97,7 @@ Common errors:
 
 ```text
 ERROR: missing_topic expected="DELETE topic=<name>"
+ERROR: invalid_topic_name topic=<name> reason="..."
 ERROR: topic_not_found topic=<name>
 ERROR: delete_topic_failed reason="..."
 ```
@@ -158,7 +160,7 @@ Because `message=` captures the rest of the line, put optional parameters before
 
 Transaction metadata fields are not accepted on client `PUBLISH`; use the transaction commands for transactional records. Direct `transactional_id`, `transaction_state`, or `transaction_marker` injection returns `ERROR: transaction_metadata_forbidden command=PUBLISH`.
 
-For `acks=1` or `acks=all`, success is a JSON ack response with `status:"OK"`. Text `PUBLISH` may include `partition=<N>` to target a partition explicitly; otherwise the topic partition policy selects the partition. Idempotent publish uses `(producerId, epoch, seqNum)` per partition: each new `(producerId, epoch)` sequence starts at `seqNum=1`, higher epochs fence older producer sessions, lower epochs are rejected as stale, and `seqNum=0` disables dedup for that message. Producer epochs entered FSM snapshot version 3; current brokers write version 5 with transaction state and committed partition watermarks. Avoid mixed-version rolling upgrades with binaries that cannot decode version 5. For `acks=0`, success is:
+For `acks=1` or `acks=all`, success is a JSON ack response with `status:"OK"`. Text `PUBLISH` may include `partition=<N>` to target a partition explicitly; otherwise the topic partition policy selects the partition. Idempotent publish uses `(producerId, epoch, seqNum)` per partition: each new `(producerId, epoch)` sequence starts at `seqNum=1`, higher epochs fence older producer sessions, lower epochs are rejected as stale, and `seqNum=0` disables dedup for that message. Producer epochs entered FSM snapshot version 3; current brokers write version 6 with transaction state, committed partition watermarks, and durable topic definitions. Avoid mixed-version rolling upgrades with binaries that cannot decode version 6. For `acks=0`, success is:
 
 ```text
 OK

--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -148,7 +148,7 @@ err := producer.CreateTopicWithOptions("player-state", sdk.TopicOptions{
 })
 ```
 
-The SDK canonicalizes `compact,delete` to `delete,compact` and rejects unsafe command values, negative retention, or unknown policy enums before opening the command connection. Compact policies require a standalone, non-event-sourcing topic. `EventStore.CreateTopic` explicitly declares `cleanup_policy=delete`.
+The SDK canonicalizes `compact,delete` to `delete,compact` and validates the portable topic-name contract and rejects unsafe command values, negative retention, or unknown policy enums before opening a broker connection. Compact policies require a standalone, non-event-sourcing topic. `EventStore.CreateTopic` explicitly declares `cleanup_policy=delete`.
 
 ## Go Transactional Producer
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -114,7 +114,9 @@ The configuration is represented by the Config struct in the codebase, which org
 | `enable_benchmark`   | bool       | false          | Enable benchmark mode for testing               |
 | `cleanup_interval`   | int        | 300            | Log cleanup interval (seconds)                 |
 
-In standalone mode, `log_dir` also contains `__transaction_state.journal`. The broker fsyncs this append-only coordinator journal before acknowledging transaction state transitions and repairs only a torn or checksum-corrupt final record during startup. One encoded snapshot record is limited to 32 MiB, so transaction batches must remain bounded. Include the journal in backup and restore procedures.
+In standalone mode, `log_dir` also contains `__topic_metadata.json` and `__transaction_state.journal`. The versioned topic manifest is atomically replaced before create/update success exposes a new topic definition and is loaded before coordinator/static-group initialization. Invalid or unsupported manifest content fails startup; the broker does not fall back to guessed ACL, event-sourcing, retention, or cleanup settings. Brokers upgraded from an older release write definitions as applications reissue their idempotent `CREATE` declarations.
+
+The broker fsyncs the append-only transaction coordinator journal before acknowledging transaction state transitions and repairs only a torn or checksum-corrupt final record during startup. One encoded snapshot record is limited to 32 MiB, so transaction batches must remain bounded. Include the topic manifest, journal, consumer offset log, and partition directories in one backup and restore procedure.
 
 The health and metrics listeners are unauthenticated operations endpoints. Restrict both ports to a trusted network. `/live` reports process liveness, while `/ready` and the compatible `/health` endpoint include storage and distributed leader checks. See [Broker Observability](../reference/observability.md).
 

--- a/pkg/cluster/replication/fsm/fsm.go
+++ b/pkg/cluster/replication/fsm/fsm.go
@@ -242,14 +242,13 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 		}
 		restoredTopicState = legacyTopicState(state.PartitionMetadata)
 	}
-	definitions, err := topicDefinitionsFromState(restoredTopicState)
+	definitions, err := validateTopicState(restoredTopicState, state.PartitionMetadata)
 	if err != nil {
 		return fmt.Errorf("restore topic definitions: %w", err)
 	}
-	if state.Version >= 6 {
-		definitions, err = validateTopicState(restoredTopicState, state.PartitionMetadata)
-		if err != nil {
-			return fmt.Errorf("restore topic definitions: %w", err)
+	if f.tm != nil {
+		if err := f.tm.RestoreDefinitions(definitions); err != nil {
+			return fmt.Errorf("restore topic registry: %w", err)
 		}
 	}
 
@@ -282,12 +281,6 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 	}
 
 	f.mu.Unlock()
-
-	if f.tm != nil {
-		if err := f.tm.RestoreDefinitions(definitions); err != nil {
-			return fmt.Errorf("restore topic registry: %w", err)
-		}
-	}
 	if state.Version >= 5 {
 		f.reconcileCommittedPartitions()
 	}

--- a/pkg/cluster/replication/fsm/fsm.go
+++ b/pkg/cluster/replication/fsm/fsm.go
@@ -63,6 +63,7 @@ type BrokerFSMState struct {
 	ProducerState     map[string]map[int]map[string]ProducerSequence `json:"producerState"`
 	GroupState        map[string]*coordinator.GroupStateSnapshot     `json:"groupState,omitempty"`
 	TransactionState  map[string]*transaction.Snapshot               `json:"transactionState,omitempty"`
+	TopicState        map[string]*topic.Definition                   `json:"topicState,omitempty"`
 }
 
 type BrokerFSM struct {
@@ -79,6 +80,7 @@ type BrokerFSM struct {
 	cd                       *coordinator.Coordinator
 	txn                      *transaction.Manager
 	restoredTransactionState map[string]*transaction.Snapshot
+	topicState               map[string]*topic.Definition
 }
 
 func NewBrokerFSM(tm *topic.TopicManager, cd *coordinator.Coordinator) *BrokerFSM {
@@ -88,6 +90,7 @@ func NewBrokerFSM(tm *topic.TopicManager, cd *coordinator.Coordinator) *BrokerFS
 		brokers:           make(map[string]*BrokerInfo),
 		partitionMetadata: make(map[string]*PartitionMetadata),
 		producerState:     make(map[string]map[int]map[string]ProducerSequence),
+		topicState:        make(map[string]*topic.Definition),
 		tm:                tm,
 		cd:                cd,
 	}
@@ -226,8 +229,28 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 		util.Info("FSM Restore: Validating snapshot Version 4 (with transaction state)")
 	case 5:
 		util.Info("FSM Restore: Validating snapshot Version 5 (with committed partition watermarks)")
+	case 6:
+		util.Info("FSM Restore: Validating snapshot Version 6 (with durable topic definitions)")
 	default:
 		return fmt.Errorf("unknown snapshot version: %d", state.Version)
+	}
+
+	restoredTopicState := copyTopicState(state.TopicState)
+	if len(restoredTopicState) == 0 && len(state.PartitionMetadata) > 0 {
+		if state.Version >= 6 {
+			return fmt.Errorf("snapshot version %d is missing topic state", state.Version)
+		}
+		restoredTopicState = legacyTopicState(state.PartitionMetadata)
+	}
+	definitions, err := topicDefinitionsFromState(restoredTopicState)
+	if err != nil {
+		return fmt.Errorf("restore topic definitions: %w", err)
+	}
+	if state.Version >= 6 {
+		definitions, err = validateTopicState(restoredTopicState, state.PartitionMetadata)
+		if err != nil {
+			return fmt.Errorf("restore topic definitions: %w", err)
+		}
 	}
 
 	f.mu.Lock()
@@ -235,6 +258,7 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 	f.logs = state.Logs
 	f.brokers = state.Brokers
 	f.partitionMetadata = state.PartitionMetadata
+	f.topicState = restoredTopicState
 	f.applied = state.Applied
 
 	f.producerState = state.ProducerState
@@ -258,6 +282,12 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 	}
 
 	f.mu.Unlock()
+
+	if f.tm != nil {
+		if err := f.tm.RestoreDefinitions(definitions); err != nil {
+			return fmt.Errorf("restore topic registry: %w", err)
+		}
+	}
 	if state.Version >= 5 {
 		f.reconcileCommittedPartitions()
 	}
@@ -342,6 +372,14 @@ func (f *BrokerFSM) Snapshot() (raft.FSMSnapshot, error) {
 		producerStateCopy[topic] = partitionMap
 	}
 
+	topicStateCopy := copyTopicState(f.topicState)
+	if len(topicStateCopy) == 0 && len(metadataCopy) > 0 {
+		topicStateCopy = legacyTopicState(metadataCopy)
+	}
+	if _, err := validateTopicState(topicStateCopy, metadataCopy); err != nil {
+		return nil, fmt.Errorf("snapshot topic definitions: %w", err)
+	}
+
 	var groupState map[string]*coordinator.GroupStateSnapshot
 	if f.cd != nil {
 		groupState = f.cd.ExportState()
@@ -360,6 +398,7 @@ func (f *BrokerFSM) Snapshot() (raft.FSMSnapshot, error) {
 		producerState:     producerStateCopy,
 		groupState:        groupState,
 		transactionState:  transactionState,
+		topicState:        topicStateCopy,
 	}, nil
 }
 

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -58,17 +58,17 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 	topicCmd.Policy = definition.Policy
 
 	f.mu.Lock()
-	if f.topicState == nil {
-		f.topicState = make(map[string]*topic.Definition)
-	}
+	defer f.mu.Unlock()
+
+	stagedTopics := copyTopicState(f.topicState)
+	stagedPartitions := copyPartitionMetadataState(f.partitionMetadata)
 	currentPartitions := 0
-	currentTopic := f.topicState[topicCmd.Name]
+	currentTopic := stagedTopics[topicCmd.Name]
 	if currentTopic == nil {
-		currentTopic = legacyTopicState(f.partitionMetadata)[topicCmd.Name]
+		currentTopic = legacyTopicState(stagedPartitions)[topicCmd.Name]
 	}
 	if currentTopic != nil {
 		if topicCmd.Partitions < currentTopic.Partitions {
-			f.mu.Unlock()
 			return fmt.Errorf("cannot decrease partition count for topic %q: %d -> %d", topicCmd.Name, currentTopic.Partitions, topicCmd.Partitions)
 		}
 		currentPartitions = currentTopic.Partitions
@@ -85,13 +85,11 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 	sort.Strings(brokers)
 
 	if len(brokers) == 0 {
-		f.mu.Unlock()
 		util.Error("FSM: No active brokers available for topic creation")
 		return fmt.Errorf("no active brokers")
 	}
 
 	if topicCmd.Partitions <= 0 {
-		f.mu.Unlock()
 		util.Error("FSM: Invalid partition count %d for topic %s", topicCmd.Partitions, topicCmd.Name)
 		return fmt.Errorf("invalid partition count: %d", topicCmd.Partitions)
 	}
@@ -105,7 +103,6 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 			}
 		}
 		if !found {
-			f.mu.Unlock()
 			util.Error("FSM: Explicit leader %s not in active broker set %v", topicCmd.LeaderID, brokers)
 			return fmt.Errorf("leader %s not in active broker set", topicCmd.LeaderID)
 		}
@@ -126,14 +123,13 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 
 	for i := 0; i < currentPartitions; i++ {
 		key := topicCmd.Name + "-" + strconv.Itoa(i)
-		if f.partitionMetadata[key] == nil {
-			f.mu.Unlock()
+		if stagedPartitions[key] == nil {
 			return fmt.Errorf("topic %q is missing partition metadata %d", topicCmd.Name, i)
 		}
 	}
 	for i := 0; i < currentPartitions; i++ {
 		key := topicCmd.Name + "-" + strconv.Itoa(i)
-		f.partitionMetadata[key].PartitionCount = topicCmd.Partitions
+		stagedPartitions[key].PartitionCount = topicCmd.Partitions
 	}
 
 	for i := currentPartitions; i < topicCmd.Partitions; i++ {
@@ -144,7 +140,6 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 		if assignedLeader == "" {
 			replicas = ring.GetN(key, replicationFactor)
 			if len(replicas) == 0 {
-				f.mu.Unlock()
 				return fmt.Errorf("no replicas assigned for partition %s", key)
 			}
 			assignedLeader = replicas[0]
@@ -166,7 +161,7 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 
 		isrCopy := append([]string(nil), replicas...)
 
-		f.partitionMetadata[key] = &PartitionMetadata{
+		stagedPartitions[key] = &PartitionMetadata{
 			PartitionCount: topicCmd.Partitions,
 			Leader:         assignedLeader,
 			LeaderEpoch:    1,
@@ -179,9 +174,8 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 
 	definition.Idempotent = topicCmd.Idempotent
 	definition.EventSourcing = topicCmd.EventSourcing
-	f.topicState[topicCmd.Name] = copyTopicDefinition(&definition)
+	stagedTopics[topicCmd.Name] = copyTopicDefinition(&definition)
 	tm := f.tm
-	f.mu.Unlock()
 
 	if tm != nil {
 		if err := tm.CreateTopicWithPolicy(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent, topicCmd.EventSourcing, topicCmd.Policy); err != nil {
@@ -189,6 +183,8 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 			return err
 		}
 	}
+	f.partitionMetadata = stagedPartitions
+	f.topicState = stagedTopics
 	util.Info("FSM: Created topic '%s' with %d partitions", topicCmd.Name, topicCmd.Partitions)
 
 	return nil
@@ -202,8 +198,35 @@ func (f *BrokerFSM) applyTopicDeleteCommand(jsonData string) interface{} {
 		util.Error("FSM: Failed to unmarshal topic delete command: %v", err)
 		return err
 	}
+	if err := topic.ValidateName(payload.Topic); err != nil {
+		return fmt.Errorf("invalid topic name: %w", err)
+	}
 
 	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	found := f.topicState[payload.Topic] != nil
+	for key := range f.partitionMetadata {
+		if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("%w: %s", topic.ErrTopicNotFound, payload.Topic)
+	}
+
+	tm := f.tm
+	if tm != nil {
+		deleted, err := tm.DeleteTopicDurable(payload.Topic)
+		if err != nil {
+			return fmt.Errorf("delete local topic %q: %w", payload.Topic, err)
+		}
+		if !deleted {
+			return fmt.Errorf("%w: %s", topic.ErrTopicNotFound, payload.Topic)
+		}
+	} else if !found {
+		return fmt.Errorf("%w: %s", topic.ErrTopicNotFound, payload.Topic)
+	}
 
 	for key := range f.partitionMetadata {
 		if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
@@ -211,13 +234,6 @@ func (f *BrokerFSM) applyTopicDeleteCommand(jsonData string) interface{} {
 		}
 	}
 	delete(f.topicState, payload.Topic)
-
-	tm := f.tm
-	f.mu.Unlock()
-
-	if tm != nil {
-		tm.DeleteTopic(payload.Topic)
-	}
 	util.Info("FSM: Deleted topic '%s'", payload.Topic)
 
 	return nil

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/util"
 )
@@ -37,8 +38,43 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 		util.Error("FSM: Failed to unmarshal topic command: %v", err)
 		return err
 	}
+	definition, err := (topic.Definition{
+		Name:          topicCmd.Name,
+		Partitions:    topicCmd.Partitions,
+		Idempotent:    topicCmd.Idempotent,
+		EventSourcing: topicCmd.EventSourcing,
+		Policy:        topicCmd.Policy,
+	}).Normalize()
+	if err != nil {
+		return fmt.Errorf("invalid topic definition: %w", err)
+	}
+	if config.HasCleanupPolicy(definition.Policy.CleanupPolicy, config.CleanupPolicyCompact) {
+		return fmt.Errorf("cleanup policy compact is not supported in distributed mode")
+	}
+	topicCmd.Name = definition.Name
+	topicCmd.Partitions = definition.Partitions
+	topicCmd.Idempotent = definition.Idempotent
+	topicCmd.EventSourcing = definition.EventSourcing
+	topicCmd.Policy = definition.Policy
 
 	f.mu.Lock()
+	if f.topicState == nil {
+		f.topicState = make(map[string]*topic.Definition)
+	}
+	currentPartitions := 0
+	currentTopic := f.topicState[topicCmd.Name]
+	if currentTopic == nil {
+		currentTopic = legacyTopicState(f.partitionMetadata)[topicCmd.Name]
+	}
+	if currentTopic != nil {
+		if topicCmd.Partitions < currentTopic.Partitions {
+			f.mu.Unlock()
+			return fmt.Errorf("cannot decrease partition count for topic %q: %d -> %d", topicCmd.Name, currentTopic.Partitions, topicCmd.Partitions)
+		}
+		currentPartitions = currentTopic.Partitions
+		topicCmd.Idempotent = currentTopic.Idempotent
+		topicCmd.EventSourcing = currentTopic.EventSourcing
+	}
 
 	var brokers []string
 	for id, info := range f.brokers {
@@ -83,11 +119,24 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 		util.Warn("FSM: Requested RF %d exceeds active brokers %d. Capping to %d", replicationFactor, len(brokers), len(brokers))
 		replicationFactor = len(brokers)
 	}
+	topicCmd.ReplicationFactor = replicationFactor
 
 	ring := util.NewConsistentHashRing(150, nil)
 	ring.Add(brokers...)
 
-	for i := 0; i < topicCmd.Partitions; i++ {
+	for i := 0; i < currentPartitions; i++ {
+		key := topicCmd.Name + "-" + strconv.Itoa(i)
+		if f.partitionMetadata[key] == nil {
+			f.mu.Unlock()
+			return fmt.Errorf("topic %q is missing partition metadata %d", topicCmd.Name, i)
+		}
+	}
+	for i := 0; i < currentPartitions; i++ {
+		key := topicCmd.Name + "-" + strconv.Itoa(i)
+		f.partitionMetadata[key].PartitionCount = topicCmd.Partitions
+	}
+
+	for i := currentPartitions; i < topicCmd.Partitions; i++ {
 		key := topicCmd.Name + "-" + strconv.Itoa(i)
 
 		assignedLeader := topicCmd.LeaderID
@@ -128,12 +177,16 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 		util.Info("FSM: Assigned leader %s to partition %s (replicas=%v)", assignedLeader, key, replicas)
 	}
 
+	definition.Idempotent = topicCmd.Idempotent
+	definition.EventSourcing = topicCmd.EventSourcing
+	f.topicState[topicCmd.Name] = copyTopicDefinition(&definition)
 	tm := f.tm
 	f.mu.Unlock()
 
 	if tm != nil {
 		if err := tm.CreateTopicWithPolicy(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent, topicCmd.EventSourcing, topicCmd.Policy); err != nil {
 			util.Error("FSM: Failed to create topic '%s' in local manager: %v", topicCmd.Name, err)
+			return err
 		}
 	}
 	util.Info("FSM: Created topic '%s' with %d partitions", topicCmd.Name, topicCmd.Partitions)
@@ -157,6 +210,7 @@ func (f *BrokerFSM) applyTopicDeleteCommand(jsonData string) interface{} {
 			delete(f.partitionMetadata, key)
 		}
 	}
+	delete(f.topicState, payload.Topic)
 
 	tm := f.tm
 	f.mu.Unlock()

--- a/pkg/cluster/replication/fsm/fsm_snapshot.go
+++ b/pkg/cluster/replication/fsm/fsm_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/pkg/transaction"
 	"github.com/cursus-io/cursus/util"
 	"github.com/hashicorp/raft"
@@ -17,11 +18,12 @@ type BrokerFSMSnapshot struct {
 	producerState     map[string]map[int]map[string]ProducerSequence
 	groupState        map[string]*coordinator.GroupStateSnapshot
 	transactionState  map[string]*transaction.Snapshot
+	topicState        map[string]*topic.Definition
 }
 
 func (s *BrokerFSMSnapshot) Persist(sink raft.SnapshotSink) error {
 	state := BrokerFSMState{
-		Version:           5,
+		Version:           6,
 		Applied:           s.applied,
 		Logs:              s.logs,
 		Brokers:           s.brokers,
@@ -29,6 +31,7 @@ func (s *BrokerFSMSnapshot) Persist(sink raft.SnapshotSink) error {
 		ProducerState:     s.producerState,
 		GroupState:        s.groupState,
 		TransactionState:  s.transactionState,
+		TopicState:        s.topicState,
 	}
 
 	util.Debug("Persisting snapshot data")

--- a/pkg/cluster/replication/fsm/fsm_test.go
+++ b/pkg/cluster/replication/fsm/fsm_test.go
@@ -192,7 +192,7 @@ func TestBrokerFSM_PartitionCommitIsMonotonicAndEpochFenced(t *testing.T) {
 
 func TestBrokerFSM_SnapshotRestoresCommittedPartitionWatermark(t *testing.T) {
 	f := newTestFSM()
-	metadata := PartitionMetadata{Leader: "node-1", LeaderEpoch: 2, CommittedHWM: 19}
+	metadata := PartitionMetadata{Leader: "node-1", LeaderEpoch: 2, CommittedHWM: 19, PartitionCount: 1}
 	data, err := json.Marshal(metadata)
 	require.NoError(t, err)
 	require.Nil(t, f.Apply(&raft.Log{Data: []byte("PARTITION:orders-0:" + string(data)), Index: 7}))
@@ -245,7 +245,7 @@ func TestBrokerFSM_Apply_UpdatesAppliedIndex(t *testing.T) {
 func TestBrokerFSM_Snapshot_Restore(t *testing.T) {
 	fsm := newTestFSM()
 	fsm.brokers["b1"] = &BrokerInfo{ID: "b1", Addr: "a1"}
-	fsm.partitionMetadata["t1-0"] = &PartitionMetadata{Leader: "l1"}
+	fsm.partitionMetadata["t1-0"] = &PartitionMetadata{Leader: "l1", PartitionCount: 1}
 	fsm.logs[5] = &ReplicationEntry{Topic: "t1"}
 	fsm.applied = 5
 

--- a/pkg/cluster/replication/fsm/fsm_topic_delete_test.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_delete_test.go
@@ -1,0 +1,32 @@
+package fsm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrokerFSMDeleteMissingStateDoesNotDeleteLocalTopic(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := topic.NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+
+	f := NewBrokerFSM(manager, nil)
+	payload, err := json.Marshal(map[string]string{"topic": "orders"})
+	require.NoError(t, err)
+
+	result := f.Apply(&raft.Log{Data: []byte("TOPIC_DELETE:" + string(payload)), Index: 1})
+	applyErr, ok := result.(error)
+	require.True(t, ok)
+	require.ErrorIs(t, applyErr, topic.ErrTopicNotFound)
+	require.NotNil(t, manager.GetTopic("orders"))
+}

--- a/pkg/cluster/replication/fsm/fsm_topic_integrity_test.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_integrity_test.go
@@ -1,0 +1,142 @@
+package fsm
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+type failingTopicHandlerProvider struct{}
+
+func (failingTopicHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	return nil, errors.New("open partition failed")
+}
+
+func TestBrokerFSMTopicCreateFailureLeavesMetadataUnchanged(t *testing.T) {
+	manager := topic.NewTopicManager(config.DefaultConfig(), failingTopicHandlerProvider{}, nil)
+	f := NewBrokerFSM(manager, nil)
+	registerActiveBroker(t, f, "broker-1")
+
+	command, err := json.Marshal(TopicCommand{
+		Name:              "orders",
+		Partitions:        1,
+		ReplicationFactor: 1,
+		Policy:            topic.DefaultPolicy(),
+	})
+	require.NoError(t, err)
+
+	result := f.Apply(&raft.Log{Data: []byte("TOPIC:" + string(command)), Index: 2})
+	applyErr, ok := result.(error)
+	require.True(t, ok)
+	require.ErrorContains(t, applyErr, "open partition failed")
+	require.Nil(t, f.GetPartitionMetadata("orders-0"))
+	require.Nil(t, f.topicState["orders"])
+	require.Nil(t, manager.GetTopic("orders"))
+}
+
+func TestBrokerFSMDeleteFailurePreservesMetadataAndRegistry(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(cfg.LogDir, topic.TopicMetadataFileName), 0o750))
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := topic.NewTopicManager(cfg, dm, nil)
+	definition := topic.Definition{Name: "orders", Partitions: 1, Policy: topic.DefaultPolicy()}
+	require.NoError(t, manager.RestoreDefinitions([]topic.Definition{definition}))
+	t.Cleanup(func() {
+		if current := manager.GetTopic("orders"); current != nil {
+			for _, partition := range current.Partitions {
+				partition.Close()
+			}
+		}
+	})
+
+	f := NewBrokerFSM(manager, nil)
+	f.topicState["orders"] = copyTopicDefinition(&definition)
+	f.partitionMetadata["orders-0"] = &PartitionMetadata{PartitionCount: 1}
+	payload, err := json.Marshal(map[string]string{"topic": "orders"})
+	require.NoError(t, err)
+
+	result := f.Apply(&raft.Log{Data: []byte("TOPIC_DELETE:" + string(payload)), Index: 1})
+	applyErr, ok := result.(error)
+	require.True(t, ok)
+	require.ErrorContains(t, applyErr, "delete local topic")
+	require.NotNil(t, f.GetPartitionMetadata("orders-0"))
+	require.NotNil(t, f.topicState["orders"])
+	require.NotNil(t, manager.GetTopic("orders"))
+}
+
+func TestBrokerFSMDeleteMissingTopicReturnsNotFound(t *testing.T) {
+	f := NewBrokerFSM(nil, nil)
+	result := f.Apply(&raft.Log{Data: []byte(`TOPIC_DELETE:{"topic":"missing"}`), Index: 1})
+	applyErr, ok := result.(error)
+	require.True(t, ok)
+	require.ErrorIs(t, applyErr, topic.ErrTopicNotFound)
+}
+
+func TestBrokerFSMRestoreRejectsIncompleteLegacyPartitionMetadata(t *testing.T) {
+	state := BrokerFSMState{
+		Version: 5,
+		PartitionMetadata: map[string]*PartitionMetadata{
+			"orders-0": {PartitionCount: 2},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	err = newTestFSM().Restore(io.NopCloser(bytes.NewReader(data)))
+	require.ErrorContains(t, err, "missing partition metadata 1")
+}
+
+func TestBrokerFSMRestoreRejectsTopicMetadataConflicts(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *PartitionMetadata
+		want     string
+	}{
+		{
+			name:     "partition count",
+			metadata: &PartitionMetadata{PartitionCount: 2, Idempotent: true},
+			want:     "declares partition count 2",
+		},
+		{
+			name:     "idempotent mode",
+			metadata: &PartitionMetadata{PartitionCount: 1, Idempotent: false},
+			want:     "idempotent mode conflicts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := BrokerFSMState{
+				Version: 6,
+				TopicState: map[string]*topic.Definition{
+					"orders": {
+						Name:       "orders",
+						Partitions: 1,
+						Idempotent: true,
+						Policy:     topic.DefaultPolicy(),
+					},
+				},
+				PartitionMetadata: map[string]*PartitionMetadata{"orders-0": tt.metadata},
+			}
+			data, err := json.Marshal(state)
+			require.NoError(t, err)
+
+			err = newTestFSM().Restore(io.NopCloser(bytes.NewReader(data)))
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}

--- a/pkg/cluster/replication/fsm/fsm_topic_state.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_state.go
@@ -1,0 +1,135 @@
+package fsm
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+func copyTopicDefinition(definition *topic.Definition) *topic.Definition {
+	if definition == nil {
+		return nil
+	}
+	cloned := *definition
+	cloned.Policy.ReadACL = append([]string(nil), definition.Policy.ReadACL...)
+	cloned.Policy.WriteACL = append([]string(nil), definition.Policy.WriteACL...)
+	return &cloned
+}
+
+func copyTopicState(state map[string]*topic.Definition) map[string]*topic.Definition {
+	cloned := make(map[string]*topic.Definition, len(state))
+	for name, definition := range state {
+		cloned[name] = copyTopicDefinition(definition)
+	}
+	return cloned
+}
+
+func topicDefinitionsFromState(state map[string]*topic.Definition) ([]topic.Definition, error) {
+	definitions := make([]topic.Definition, 0, len(state))
+	for name, raw := range state {
+		if raw == nil {
+			return nil, fmt.Errorf("topic state %q is nil", name)
+		}
+		definition, err := raw.Normalize()
+		if err != nil {
+			return nil, fmt.Errorf("invalid topic state %q: %w", name, err)
+		}
+		if definition.Name != name {
+			return nil, fmt.Errorf("topic state key %q does not match name %q", name, definition.Name)
+		}
+		definitions = append(definitions, definition)
+	}
+	sort.Slice(definitions, func(i, j int) bool { return definitions[i].Name < definitions[j].Name })
+	return definitions, nil
+}
+
+func validateTopicState(
+	state map[string]*topic.Definition,
+	metadata map[string]*PartitionMetadata,
+) ([]topic.Definition, error) {
+	definitions, err := topicDefinitionsFromState(state)
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]topic.Definition, len(definitions))
+	for _, definition := range definitions {
+		byName[definition.Name] = definition
+		for partition := 0; partition < definition.Partitions; partition++ {
+			key := definition.Name + "-" + strconv.Itoa(partition)
+			if metadata[key] == nil {
+				return nil, fmt.Errorf("topic state %q is missing partition metadata %d", definition.Name, partition)
+			}
+		}
+	}
+
+	for key, partitionMetadata := range metadata {
+		if partitionMetadata == nil {
+			return nil, fmt.Errorf("partition metadata %q is nil", key)
+		}
+		separator := strings.LastIndex(key, "-")
+		if separator <= 0 {
+			return nil, fmt.Errorf("partition metadata key %q is invalid", key)
+		}
+		partition, parseErr := strconv.Atoi(key[separator+1:])
+		if parseErr != nil || partition < 0 {
+			return nil, fmt.Errorf("partition metadata key %q is invalid", key)
+		}
+		name := key[:separator]
+		definition, exists := byName[name]
+		if !exists {
+			return nil, fmt.Errorf("partition metadata %q has no topic definition", key)
+		}
+		if partition >= definition.Partitions {
+			return nil, fmt.Errorf(
+				"partition metadata %q exceeds topic %q partition count %d",
+				key,
+				name,
+				definition.Partitions,
+			)
+		}
+	}
+
+	return definitions, nil
+}
+
+func legacyTopicState(metadata map[string]*PartitionMetadata) map[string]*topic.Definition {
+	state := make(map[string]*topic.Definition)
+	for key, partitionMetadata := range metadata {
+		if partitionMetadata == nil {
+			continue
+		}
+		separator := strings.LastIndex(key, "-")
+		if separator <= 0 {
+			continue
+		}
+		partition, err := strconv.Atoi(key[separator+1:])
+		if err != nil || partition < 0 {
+			continue
+		}
+		name := key[:separator]
+		partitions := partitionMetadata.PartitionCount
+		if partitions <= partition {
+			partitions = partition + 1
+		}
+		current := state[name]
+		if current == nil {
+			current = &topic.Definition{
+				Name:       name,
+				Partitions: partitions,
+				Idempotent: partitionMetadata.Idempotent,
+				Policy:     topic.DefaultPolicy(),
+			}
+			state[name] = current
+			continue
+		}
+		if partitions > current.Partitions {
+			current.Partitions = partitions
+		}
+		current.Idempotent = current.Idempotent || partitionMetadata.Idempotent
+	}
+	return state
+}

--- a/pkg/cluster/replication/fsm/fsm_topic_state.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_state.go
@@ -27,6 +27,21 @@ func copyTopicState(state map[string]*topic.Definition) map[string]*topic.Defini
 	return cloned
 }
 
+func copyPartitionMetadataState(metadata map[string]*PartitionMetadata) map[string]*PartitionMetadata {
+	cloned := make(map[string]*PartitionMetadata, len(metadata))
+	for key, current := range metadata {
+		if current == nil {
+			cloned[key] = nil
+			continue
+		}
+		copy := *current
+		copy.Replicas = append([]string(nil), current.Replicas...)
+		copy.ISR = append([]string(nil), current.ISR...)
+		cloned[key] = &copy
+	}
+	return cloned
+}
+
 func topicDefinitionsFromState(state map[string]*topic.Definition) ([]topic.Definition, error) {
 	definitions := make([]topic.Definition, 0, len(state))
 	for name, raw := range state {
@@ -82,6 +97,22 @@ func validateTopicState(
 		definition, exists := byName[name]
 		if !exists {
 			return nil, fmt.Errorf("partition metadata %q has no topic definition", key)
+		}
+		if partitionMetadata.PartitionCount != definition.Partitions {
+			return nil, fmt.Errorf(
+				"partition metadata %q declares partition count %d; topic %q declares %d",
+				key,
+				partitionMetadata.PartitionCount,
+				name,
+				definition.Partitions,
+			)
+		}
+		if partitionMetadata.Idempotent != definition.Idempotent {
+			return nil, fmt.Errorf(
+				"partition metadata %q idempotent mode conflicts with topic %q",
+				key,
+				name,
+			)
 		}
 		if partition >= definition.Partitions {
 			return nil, fmt.Errorf(

--- a/pkg/cluster/replication/fsm/fsm_topic_state_test.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_state_test.go
@@ -1,0 +1,169 @@
+package fsm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrokerFSMSnapshotRestoresTopicDefinition(t *testing.T) {
+	f := newTestFSM()
+	registerActiveBroker(t, f, "broker-1")
+	policy := topic.Policy{
+		CleanupPolicy:  "delete",
+		Partitioner:    topic.PartitionerRoundRobin,
+		AuthPolicy:     topic.AuthPolicyACL,
+		ReadACL:        []string{"reader"},
+		WriteACL:       []string{"writer"},
+		RetentionHours: 48,
+		RetentionBytes: 8192,
+	}
+	command := TopicCommand{
+		Name:              "orders",
+		Partitions:        2,
+		Idempotent:        true,
+		EventSourcing:     false,
+		ReplicationFactor: 1,
+		Policy:            policy,
+	}
+	data, err := json.Marshal(command)
+	require.NoError(t, err)
+	require.Nil(t, f.Apply(&raft.Log{Data: []byte("TOPIC:" + string(data)), Index: 2}))
+
+	snapshot, err := f.Snapshot()
+	require.NoError(t, err)
+	buffer := new(bytes.Buffer)
+	require.NoError(t, snapshot.Persist(&MockSnapshotSink{Writer: buffer}))
+
+	restored := newTestFSM()
+	require.NoError(t, restored.Restore(io.NopCloser(bytes.NewReader(buffer.Bytes()))))
+	restoredTopic := restored.tm.GetTopic("orders")
+	require.NotNil(t, restoredTopic)
+	require.Len(t, restoredTopic.Partitions, 2)
+	require.True(t, restoredTopic.IsIdempotent)
+	require.False(t, restoredTopic.IsEventSourcing)
+	require.Equal(t, topic.PartitionerRoundRobin, restoredTopic.Policy.Partitioner)
+	require.Equal(t, topic.AuthPolicyACL, restoredTopic.Policy.AuthPolicy)
+	require.Equal(t, []string{"reader"}, restoredTopic.Policy.ReadACL)
+	require.Equal(t, []string{"writer"}, restoredTopic.Policy.WriteACL)
+	require.Equal(t, 48, restoredTopic.Policy.RetentionHours)
+	require.Equal(t, int64(8192), restoredTopic.Policy.RetentionBytes)
+}
+
+func TestBrokerFSMRepeatedCreatePreservesExistingPartitionState(t *testing.T) {
+	f := newTestFSM()
+	registerActiveBroker(t, f, "broker-1")
+	initial := TopicCommand{Name: "orders", Partitions: 1, ReplicationFactor: 1, Policy: topic.DefaultPolicy()}
+	data, err := json.Marshal(initial)
+	require.NoError(t, err)
+	require.Nil(t, f.Apply(&raft.Log{Data: []byte("TOPIC:" + string(data)), Index: 2}))
+
+	f.mu.Lock()
+	f.partitionMetadata["orders-0"].CommittedHWM = 41
+	f.partitionMetadata["orders-0"].LeaderEpoch = 7
+	f.mu.Unlock()
+
+	updated := initial
+	updated.Partitions = 2
+	updated.Policy.RetentionHours = 24
+	data, err = json.Marshal(updated)
+	require.NoError(t, err)
+	require.Nil(t, f.Apply(&raft.Log{Data: []byte("TOPIC:" + string(data)), Index: 3}))
+
+	existing := f.GetPartitionMetadata("orders-0")
+	require.Equal(t, uint64(41), existing.CommittedHWM)
+	require.Equal(t, 7, existing.LeaderEpoch)
+	require.Equal(t, 2, existing.PartitionCount)
+	require.NotNil(t, f.GetPartitionMetadata("orders-1"))
+	require.Equal(t, 24, f.tm.GetTopic("orders").Policy.RetentionHours)
+}
+
+func TestBrokerFSMRestoreMigratesLegacyPartitionMetadata(t *testing.T) {
+	state := BrokerFSMState{
+		Version: 5,
+		PartitionMetadata: map[string]*PartitionMetadata{
+			"legacy-topic-0": {PartitionCount: 2, Idempotent: true},
+			"legacy-topic-1": {PartitionCount: 2, Idempotent: true},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	restored := newTestFSM()
+	require.NoError(t, restored.Restore(io.NopCloser(bytes.NewReader(data))))
+	restoredTopic := restored.tm.GetTopic("legacy-topic")
+	require.NotNil(t, restoredTopic)
+	require.Len(t, restoredTopic.Partitions, 2)
+	require.True(t, restoredTopic.IsIdempotent)
+	require.Equal(t, topic.DefaultPolicy(), restoredTopic.Policy)
+}
+
+func TestBrokerFSMRestoreRejectsVersionSixWithoutTopicState(t *testing.T) {
+	state := BrokerFSMState{
+		Version: 6,
+		PartitionMetadata: map[string]*PartitionMetadata{
+			"orders-0": {PartitionCount: 1},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	err = newTestFSM().Restore(io.NopCloser(bytes.NewReader(data)))
+	require.ErrorContains(t, err, "missing topic state")
+}
+
+func TestBrokerFSMRestoreRejectsMissingPartitionMetadata(t *testing.T) {
+	state := BrokerFSMState{
+		Version: 6,
+		TopicState: map[string]*topic.Definition{
+			"orders": {
+				Name:       "orders",
+				Partitions: 2,
+				Policy:     topic.DefaultPolicy(),
+			},
+		},
+		PartitionMetadata: map[string]*PartitionMetadata{
+			"orders-0": {PartitionCount: 2},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	err = newTestFSM().Restore(io.NopCloser(bytes.NewReader(data)))
+	require.ErrorContains(t, err, "missing partition metadata 1")
+}
+
+func TestBrokerFSMRestoreRejectsPartitionWithoutTopicDefinition(t *testing.T) {
+	state := BrokerFSMState{
+		Version: 6,
+		TopicState: map[string]*topic.Definition{
+			"orders": {
+				Name:       "orders",
+				Partitions: 1,
+				Policy:     topic.DefaultPolicy(),
+			},
+		},
+		PartitionMetadata: map[string]*PartitionMetadata{
+			"orders-0": {PartitionCount: 1},
+			"audit-0":  {PartitionCount: 1},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	err = newTestFSM().Restore(io.NopCloser(bytes.NewReader(data)))
+	require.ErrorContains(t, err, "has no topic definition")
+}
+
+func registerActiveBroker(t *testing.T, f *BrokerFSM, id string) {
+	t.Helper()
+	payload, err := json.Marshal(BrokerInfo{ID: id, Addr: "127.0.0.1:9000", Status: "active"})
+	require.NoError(t, err)
+	require.Nil(t, f.Apply(&raft.Log{Data: []byte(fmt.Sprintf("REGISTER:%s", payload)), Index: 1}))
+}

--- a/pkg/config/storage_metadata.go
+++ b/pkg/config/storage_metadata.go
@@ -1,0 +1,4 @@
+package config
+
+// TopicMetadataFileName is the broker-owned standalone topic manifest.
+const TopicMetadataFileName = "__topic_metadata.json"

--- a/pkg/controller/auth_test.go
+++ b/pkg/controller/auth_test.go
@@ -54,8 +54,16 @@ func TestSASLACLGuardsPublishAndConsume(t *testing.T) {
 	}
 
 	server, client := net.Pipe()
-	defer server.Close()
-	defer client.Close()
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close consume server pipe: %v", err)
+		}
+	})
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close consume client pipe: %v", err)
+		}
+	})
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -44,6 +44,10 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 		return "ERROR: missing_topic expected=\"CREATE topic=<name> [partitions=<N>]\""
 	}
 
+	if err := topic.ValidateName(topicName); err != nil {
+		return fmt.Sprintf("ERROR: invalid_topic_name topic=%q reason=%q", topicName, err.Error())
+	}
+
 	partitions := 4 // default
 	if partStr, ok := args["partitions"]; ok {
 		n, err := strconv.Atoi(partStr)
@@ -187,37 +191,43 @@ func (ch *CommandHandler) handleDelete(cmd string) string {
 		return "ERROR: missing_topic expected=\"DELETE topic=<name>\""
 	}
 
+	if err := topic.ValidateName(topicName); err != nil {
+		return fmt.Sprintf("ERROR: invalid_topic_name topic=%q reason=%q", topicName, err.Error())
+	}
+
 	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
 			return resp
 		}
 
-		if ch.ESHandler != nil {
-			if err := ch.ESHandler.DeleteTopic(topicName); err != nil {
-				util.Warn("Failed to close event sourcing metadata for deleted topic %s: %v", topicName, err)
-			}
-		}
-
 		payload := map[string]interface{}{
 			"topic": topicName,
 		}
-
-		_, err := ch.applyAndWait("TOPIC_DELETE", payload)
-		if err != nil {
+		if _, err := ch.applyAndWait("TOPIC_DELETE", payload); err != nil {
 			return fmt.Sprintf("ERROR: delete_topic_failed reason=%q", err.Error())
 		}
+		ch.closeEventSourcingTopic(topicName)
 		return fmt.Sprintf("OK topic=%s deleted=true", topicName)
 	}
 
-	if ch.ESHandler != nil {
-		if err := ch.ESHandler.DeleteTopic(topicName); err != nil {
-			util.Warn("Failed to close event sourcing metadata for deleted topic %s: %v", topicName, err)
-		}
+	deleted, err := ch.TopicManager.DeleteTopicDurable(topicName)
+	if err != nil {
+		return fmt.Sprintf("ERROR: delete_topic_failed topic=%s reason=%q", topicName, err.Error())
 	}
-	if ch.TopicManager.DeleteTopic(topicName) {
-		return fmt.Sprintf("OK topic=%s deleted=true", topicName)
+	if !deleted {
+		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
 	}
-	return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
+	ch.closeEventSourcingTopic(topicName)
+	return fmt.Sprintf("OK topic=%s deleted=true", topicName)
+}
+
+func (ch *CommandHandler) closeEventSourcingTopic(topicName string) {
+	if ch.ESHandler == nil {
+		return
+	}
+	if err := ch.ESHandler.DeleteTopic(topicName); err != nil {
+		util.Warn("Failed to close event sourcing metadata for deleted topic %s: %v", topicName, err)
+	}
 }
 
 // handleList processes LIST command

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -204,6 +205,9 @@ func (ch *CommandHandler) handleDelete(cmd string) string {
 			"topic": topicName,
 		}
 		if _, err := ch.applyAndWait("TOPIC_DELETE", payload); err != nil {
+			if errors.Is(err, topic.ErrTopicNotFound) {
+				return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
+			}
 			return fmt.Sprintf("ERROR: delete_topic_failed reason=%q", err.Error())
 		}
 		ch.closeEventSourcingTopic(topicName)

--- a/pkg/controller/topic_name_test.go
+++ b/pkg/controller/topic_name_test.go
@@ -1,0 +1,23 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicCommandsRejectNonPortableNames(t *testing.T) {
+	handler, manager := newTestHandler(t)
+	context := NewClientContext("default-group", 0)
+
+	for _, command := range []string{
+		"CREATE topic=../escape partitions=1",
+		`CREATE topic=orders\\2026 partitions=1`,
+		"DELETE topic=../escape",
+	} {
+		response := handler.HandleCommand(command, context)
+		require.True(t, strings.HasPrefix(response, "ERROR: invalid_topic_name"), response)
+	}
+	require.Empty(t, manager.ListTopics())
+}

--- a/pkg/coordinator/coordinator_durable_external_test.go
+++ b/pkg/coordinator/coordinator_durable_external_test.go
@@ -33,6 +33,7 @@ func TestCoordinator_DurableOffsetReplayFromDisk(t *testing.T) {
 
 	restartedDM := disk.NewDiskManager(cfg)
 	restartedTM := topic.NewTopicManager(cfg, restartedDM, nil)
+	require.NoError(t, restartedTM.RestoreTopics())
 	restarted := coordinator.NewCoordinator(ctx, cfg, restartedTM)
 	defer restartedDM.CloseAllHandlers()
 

--- a/pkg/disk/manager.go
+++ b/pkg/disk/manager.go
@@ -32,6 +32,14 @@ func NewDiskManager(cfg *config.Config) *DiskManager {
 	}
 }
 
+// TopicMetadataPath returns the broker-owned standalone topic manifest path.
+func (dm *DiskManager) TopicMetadataPath() string {
+	if dm == nil || dm.cfg == nil || strings.TrimSpace(dm.cfg.LogDir) == "" {
+		return ""
+	}
+	return filepath.Join(dm.cfg.LogDir, config.TopicMetadataFileName)
+}
+
 // GetHandler returns a StorageHandler for a given name or creates one if missing.
 func (dm *DiskManager) GetHandler(topic string, partitionID int) (types.StorageHandler, error) {
 	dm.mu.Lock()
@@ -151,6 +159,22 @@ func (dm *DiskManager) CloseTopicHandlers(topic string) {
 		}
 		delete(dm.handlers, name)
 	}
+}
+
+// ClosePartitionHandler closes and evicts one staged partition handler.
+func (dm *DiskManager) ClosePartitionHandler(topic string, partitionID int) {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	key := diskHandlerKey(topic, partitionID)
+	handler := dm.handlers[key]
+	if handler == nil {
+		return
+	}
+	if err := handler.Close(); err != nil {
+		util.Warn("Failed to close DiskHandler for %s: %v", key, err)
+	}
+	delete(dm.handlers, key)
 }
 
 func diskHandlerKey(topic string, partitionID int) string {

--- a/pkg/protocol/errors.go
+++ b/pkg/protocol/errors.go
@@ -96,7 +96,7 @@ func buildErrorRegistry() map[string]ErrorClassification {
 		"invalid_transaction_state", "invalid_txn_offsets",
 		"invalid_retention_bytes", "invalid_retention_hours", "invalid_schema_version", "invalid_seq_num",
 		"invalid_snapshot_catchup_response", "invalid_snapshot_payload", "invalid_stream_syntax",
-		"invalid_topic_policy", "invalid_version", "invalid_from_version", "malformed_input", "missing_generation", "missing_group", "missing_key",
+		"invalid_topic_name", "invalid_topic_policy", "invalid_version", "invalid_from_version", "malformed_input", "missing_generation", "missing_group", "missing_key",
 		"unsupported_topic_policy",
 		"missing_broker", "missing_leader_fence", "missing_member", "missing_message", "missing_offset", "missing_partition", "missing_payload",
 		"missing_coordinator_key", "missing_ownership_params", "missing_producer_id", "missing_protocol_version",

--- a/pkg/topic/atomic_definition_test.go
+++ b/pkg/topic/atomic_definition_test.go
@@ -1,0 +1,32 @@
+package topic
+
+import (
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddPartitionsDoesNotExposePartialInitialization(t *testing.T) {
+	cfg := config.DefaultConfig()
+	provider := new(MockHandlerProvider)
+	initial := new(MockStorageHandler)
+	initial.On("GetLatestOffset").Return(uint64(0)).Once()
+	provider.On("GetHandler", "orders", 0).Return(initial, nil).Once()
+
+	created, err := NewTopic("orders", 1, provider, cfg, nil, false, false)
+	assert.NoError(t, err)
+	defer created.Partitions[0].Close()
+
+	staged := new(MockStorageHandler)
+	staged.On("GetLatestOffset").Return(uint64(0)).Once()
+	staged.On("Close").Return(nil).Once()
+	provider.On("GetHandler", "orders", 1).Return(staged, nil).Once()
+	provider.On("GetHandler", "orders", 2).Return(nil, assert.AnError).Once()
+
+	err = created.AddPartitions(2, provider)
+	assert.Error(t, err)
+	assert.Len(t, created.Partitions, 1)
+	provider.AssertExpectations(t)
+	staged.AssertExpectations(t)
+}

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -32,6 +32,7 @@ type TopicManager struct {
 	StreamManager StreamManager
 	coordinator   *coordinator.Coordinator
 	txnResolver   TransactionDecisionResolver
+	metadataStore *topicMetadataStore
 }
 
 // HandlerProvider defines an interface to provide disk handlers.
@@ -68,6 +69,7 @@ func NewTopicManager(cfg *config.Config, hp HandlerProvider, sm StreamManager) *
 		hp:            hp,
 		cfg:           cfg,
 		StreamManager: sm,
+		metadataStore: newTopicMetadataStore(cfg, hp),
 	}
 	return tm
 }
@@ -81,11 +83,17 @@ func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent 
 }
 
 func (tm *TopicManager) CreateTopicWithPolicy(name string, partitionCount int, idempotent bool, eventSourcing bool, policy Policy) error {
-	normalizedPolicy, err := policy.Normalize()
+	definition, err := (Definition{
+		Name:          name,
+		Partitions:    partitionCount,
+		Idempotent:    idempotent,
+		EventSourcing: eventSourcing,
+		Policy:        policy,
+	}).Normalize()
 	if err != nil {
 		return err
 	}
-	if err := validateCleanupPolicyForTopic(normalizedPolicy, tm.cfg, eventSourcing); err != nil {
+	if err := validateCleanupPolicyForTopic(definition.Policy, tm.cfg, eventSourcing); err != nil {
 		return err
 	}
 
@@ -93,38 +101,49 @@ func (tm *TopicManager) CreateTopicWithPolicy(name string, partitionCount int, i
 	defer tm.mu.Unlock()
 
 	if existing, ok := tm.topics[name]; ok {
-		if err := validateCleanupPolicyForTopic(normalizedPolicy, tm.cfg, existing.IsEventSourcing); err != nil {
+		current := existing.Definition()
+		definition.Idempotent = current.Idempotent
+		definition.EventSourcing = current.EventSourcing
+		if err := validateCleanupPolicyForTopic(definition.Policy, tm.cfg, current.EventSourcing); err != nil {
 			return err
 		}
-		current := len(existing.Partitions)
-		switch {
-		case partitionCount < current:
-			util.Error("cannot decrease partitions for topic '%s' (%d -> %d)", name, current, partitionCount)
-			return fmt.Errorf("cannot decrease partition count for topic '%s': %d -> %d", name, current, partitionCount)
-		case partitionCount > current:
-			existing.ApplyPolicy(normalizedPolicy)
-			if err := existing.AddPartitions(partitionCount-current, tm.hp); err != nil {
-				return fmt.Errorf("failed to add partitions to topic '%s': %w", name, err)
-			}
-			util.Info("topic '%s' partitions increased: %d -> %d", name, current, len(existing.Partitions))
-			return nil
-		default:
-			existing.ApplyPolicy(normalizedPolicy)
-			util.Info("topic '%s' already exists with %d partitions", name, current)
-			return nil
+		if partitionCount < current.Partitions {
+			util.Error("cannot decrease partitions for topic '%s' (%d -> %d)", name, current.Partitions, partitionCount)
+			return fmt.Errorf("cannot decrease partition count for topic '%s': %d -> %d", name, current.Partitions, partitionCount)
 		}
+		if err := existing.applyDefinition(partitionCount, definition.Policy, tm.hp, tm.persistDefinitionLocked); err != nil {
+			return fmt.Errorf("update topic '%s': %w", name, err)
+		}
+		if partitionCount > current.Partitions {
+			util.Info("topic '%s' partitions increased: %d -> %d", name, current.Partitions, partitionCount)
+		} else {
+			util.Info("topic '%s' already exists with %d partitions", name, current.Partitions)
+		}
+		return nil
 	}
 
-	t, err := NewTopicWithPolicy(name, partitionCount, tm.hp, tm.cfg, tm.StreamManager, idempotent, eventSourcing, normalizedPolicy)
+	created, err := NewTopicWithPolicy(
+		name,
+		partitionCount,
+		tm.hp,
+		tm.cfg,
+		tm.StreamManager,
+		idempotent,
+		eventSourcing,
+		definition.Policy,
+	)
 	if err != nil {
 		util.Error("failed to create topic '%s': %v", name, err)
 		return fmt.Errorf("failed to create topic '%s': %w", name, err)
 	}
-	t.SetTransactionDecisionResolver(tm.txnResolver)
-	tm.topics[name] = t
+	created.SetTransactionDecisionResolver(tm.txnResolver)
+	if err := tm.persistDefinitionLocked(definition); err != nil {
+		closePartiallyInitializedTopic(name, tm.hp, created.Partitions)
+		return err
+	}
+	tm.topics[name] = created
 	return nil
 }
-
 func (tm *TopicManager) GetTopic(name string) *Topic {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
@@ -377,22 +396,52 @@ func (tm *TopicManager) Stop() {
 }
 
 func (tm *TopicManager) DeleteTopic(name string) bool {
+	deleted, err := tm.DeleteTopicDurable(name)
+	if err != nil {
+		util.Warn("Failed to durably delete topic %s: %v", name, err)
+		return false
+	}
+	return deleted
+}
+
+// DeleteTopicDurable commits the metadata deletion before removing local data.
+func (tm *TopicManager) DeleteTopicDurable(name string) (bool, error) {
+	if err := ValidateName(name); err != nil {
+		return false, fmt.Errorf("invalid topic name: %w", err)
+	}
+
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
-	if _, ok := tm.topics[name]; !ok {
-		return false
+
+	current := tm.topics[name]
+	if current == nil {
+		return false, nil
+	}
+	if err := tm.persistRemovalLocked(name); err != nil {
+		return false, err
 	}
 
 	delete(tm.topics, name)
+	for _, partition := range current.Partitions {
+		partition.Close()
+	}
 	if closer, ok := tm.hp.(topicHandlerCloser); ok {
 		closer.CloseTopicHandlers(name)
+	} else {
+		for _, partition := range current.Partitions {
+			if err := partition.dh.Close(); err != nil {
+				util.Warn("Failed to close storage handler for deleted topic %s[%d]: %v", name, partition.ID(), err)
+			}
+		}
 	}
 	if err := tm.deleteTopicLogDirLocked(name); err != nil {
-		util.Warn("Failed to delete topic log directory for %s: %v", name, err)
+		// The durable definition removal is already committed. Keep the command
+		// result aligned with the logical state and leave physical cleanup for an
+		// operator or a later retry instead of reporting a false rollback.
+		util.Warn("Failed to clean log directory for deleted topic %s: %v", name, err)
 	}
-	return true
+	return true, nil
 }
-
 func (tm *TopicManager) deleteTopicLogDirLocked(name string) error {
 	if tm.cfg == nil || strings.TrimSpace(tm.cfg.LogDir) == "" {
 		return nil

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -1,6 +1,7 @@
 package topic
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,8 @@ import (
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/cursus-io/cursus/util"
 )
+
+var ErrTopicNotFound = errors.New("topic not found")
 
 type StreamManager interface {
 	AddStream(key string, streamConn *stream.StreamConnection, readFn func(offset uint64, max int) ([]types.Message, error), legacyCommitInterval time.Duration) error
@@ -120,6 +123,9 @@ func (tm *TopicManager) CreateTopicWithPolicy(name string, partitionCount int, i
 			util.Info("topic '%s' already exists with %d partitions", name, current.Partitions)
 		}
 		return nil
+	}
+	if err := tm.rejectOrphanedStorageLocked(name); err != nil {
+		return err
 	}
 
 	created, err := NewTopicWithPolicy(

--- a/pkg/topic/metadata.go
+++ b/pkg/topic/metadata.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/util"
 )
 
 const (
@@ -108,6 +109,16 @@ func (s *topicMetadataStore) Load() (_ []Definition, err error) {
 	// #nosec G304 -- the path is supplied by the broker-owned storage provider.
 	file, err := os.Open(s.path)
 	if errors.Is(err, os.ErrNotExist) {
+		orphaned, scanErr := s.orphanedTopicDirectories(nil)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if len(orphaned) > 0 {
+			return nil, fmt.Errorf(
+				"topic metadata manifest is missing while persisted topic storage exists: %s",
+				strings.Join(orphaned, ","),
+			)
+		}
 		return nil, nil
 	}
 	if err != nil {
@@ -156,6 +167,16 @@ func (s *topicMetadataStore) Load() (_ []Definition, err error) {
 		definitions = append(definitions, definition)
 	}
 	sort.Slice(definitions, func(i, j int) bool { return definitions[i].Name < definitions[j].Name })
+	orphaned, err := s.orphanedTopicDirectories(seen)
+	if err != nil {
+		return nil, err
+	}
+	if len(orphaned) > 0 {
+		return nil, fmt.Errorf(
+			"topic metadata manifest omits persisted topic storage: %s",
+			strings.Join(orphaned, ","),
+		)
+	}
 	return definitions, nil
 }
 
@@ -216,8 +237,11 @@ func (s *topicMetadataStore) Save(definitions []Definition) (err error) {
 	if err := replaceCheckpointFile(tmp, s.path); err != nil {
 		return fmt.Errorf("replace topic metadata: %w", err)
 	}
-	if err := syncTopicMetadataDirectory(dir); err != nil {
-		return fmt.Errorf("sync topic metadata directory: %w", err)
+	if err := syncTopicMetadataDirectoryFn(dir); err != nil {
+		return &topicMetadataSaveError{
+			committed: true,
+			err:       fmt.Errorf("sync topic metadata directory: %w", err),
+		}
 	}
 	return nil
 }
@@ -238,6 +262,8 @@ func writeMetadataFile(file *os.File, data []byte) error {
 	}
 	return nil
 }
+
+var syncTopicMetadataDirectoryFn = syncTopicMetadataDirectory
 
 func syncTopicMetadataDirectory(path string) error {
 	if runtime.GOOS == "windows" {
@@ -373,6 +399,10 @@ func (tm *TopicManager) persistDefinitionLocked(override Definition) error {
 	}
 	definitions := tm.definitionsLocked(&override, "")
 	if err := tm.metadataStore.Save(definitions); err != nil {
+		if topicMetadataWriteCommitted(err) {
+			util.Warn("Topic metadata definition %q committed with durability uncertainty: %v", override.Name, err)
+			return nil
+		}
 		return fmt.Errorf("persist topic definition %q: %w", override.Name, err)
 	}
 	return nil
@@ -383,6 +413,10 @@ func (tm *TopicManager) persistRemovalLocked(name string) error {
 		return nil
 	}
 	if err := tm.metadataStore.Save(tm.definitionsLocked(nil, name)); err != nil {
+		if topicMetadataWriteCommitted(err) {
+			util.Warn("Topic metadata deletion %q committed with durability uncertainty: %v", name, err)
+			return nil
+		}
 		return fmt.Errorf("persist topic deletion %q: %w", name, err)
 	}
 	return nil

--- a/pkg/topic/metadata.go
+++ b/pkg/topic/metadata.go
@@ -1,0 +1,410 @@
+package topic
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/cursus-io/cursus/pkg/config"
+)
+
+const (
+	topicMetadataFormatVersion = 1
+	maxTopicMetadataBytes      = 16 << 20
+	maxTopicNameBytes          = 249
+	TopicMetadataFileName      = config.TopicMetadataFileName
+)
+
+// Definition is the durable broker contract required to recreate a topic.
+type Definition struct {
+	Name          string `json:"name"`
+	Partitions    int    `json:"partitions"`
+	Idempotent    bool   `json:"idempotent"`
+	EventSourcing bool   `json:"event_sourcing"`
+	Policy        Policy `json:"policy"`
+}
+
+// Normalize validates and canonicalizes a durable topic definition.
+func (d Definition) Normalize() (Definition, error) {
+	if err := ValidateName(d.Name); err != nil {
+		return d, err
+	}
+	if d.Partitions <= 0 {
+		return d, fmt.Errorf("partitions must be > 0")
+	}
+	policy, err := d.Policy.Normalize()
+	if err != nil {
+		return d, err
+	}
+	d.Policy = policy
+	d.Policy.ReadACL = append([]string(nil), policy.ReadACL...)
+	d.Policy.WriteACL = append([]string(nil), policy.WriteACL...)
+	return d, nil
+}
+
+// ValidateName restricts topic names to the portable on-disk name contract.
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("topic name is empty")
+	}
+	if len(name) > maxTopicNameBytes {
+		return fmt.Errorf("topic name exceeds %d bytes", maxTopicNameBytes)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid topic name %q", name)
+	}
+	for _, char := range name {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= 'A' && char <= 'Z':
+		case char >= '0' && char <= '9':
+		case char == '.', char == '_', char == '-', char == '=':
+		default:
+			return fmt.Errorf("topic name %q contains unsupported characters", name)
+		}
+	}
+	return nil
+}
+
+type metadataPathProvider interface {
+	TopicMetadataPath() string
+}
+
+type topicMetadataManifest struct {
+	Version int          `json:"version"`
+	Topics  []Definition `json:"topics"`
+}
+
+type topicMetadataStore struct {
+	path string
+}
+
+func newTopicMetadataStore(cfg *config.Config, provider HandlerProvider) *topicMetadataStore {
+	if cfg == nil || cfg.EnabledDistribution || provider == nil {
+		return nil
+	}
+	pathProvider, ok := provider.(metadataPathProvider)
+	if !ok {
+		return nil
+	}
+	path := strings.TrimSpace(pathProvider.TopicMetadataPath())
+	if path == "" {
+		return nil
+	}
+	return &topicMetadataStore{path: filepath.Clean(path)}
+}
+
+func (s *topicMetadataStore) Load() (_ []Definition, err error) {
+	if s == nil {
+		return nil, nil
+	}
+	// #nosec G304 -- the path is supplied by the broker-owned storage provider.
+	file, err := os.Open(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open topic metadata: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat topic metadata: %w", err)
+	}
+	if info.Size() > maxTopicMetadataBytes {
+		return nil, fmt.Errorf("topic metadata size %d exceeds limit %d", info.Size(), maxTopicMetadataBytes)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, maxTopicMetadataBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read topic metadata: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest topicMetadataManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode topic metadata: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("decode topic metadata trailing content")
+	}
+	if manifest.Version != topicMetadataFormatVersion {
+		return nil, fmt.Errorf("unsupported topic metadata version %d", manifest.Version)
+	}
+
+	seen := make(map[string]struct{}, len(manifest.Topics))
+	definitions := make([]Definition, 0, len(manifest.Topics))
+	for _, raw := range manifest.Topics {
+		definition, err := raw.Normalize()
+		if err != nil {
+			return nil, fmt.Errorf("invalid topic metadata for %q: %w", raw.Name, err)
+		}
+		if _, exists := seen[definition.Name]; exists {
+			return nil, fmt.Errorf("duplicate topic metadata for %q", definition.Name)
+		}
+		seen[definition.Name] = struct{}{}
+		definitions = append(definitions, definition)
+	}
+	sort.Slice(definitions, func(i, j int) bool { return definitions[i].Name < definitions[j].Name })
+	return definitions, nil
+}
+
+func (s *topicMetadataStore) Save(definitions []Definition) (err error) {
+	if s == nil {
+		return nil
+	}
+	normalized := make([]Definition, 0, len(definitions))
+	seen := make(map[string]struct{}, len(definitions))
+	for _, raw := range definitions {
+		definition, normalizeErr := raw.Normalize()
+		if normalizeErr != nil {
+			return fmt.Errorf("invalid topic metadata for %q: %w", raw.Name, normalizeErr)
+		}
+		if _, exists := seen[definition.Name]; exists {
+			return fmt.Errorf("duplicate topic metadata for %q", definition.Name)
+		}
+		seen[definition.Name] = struct{}{}
+		normalized = append(normalized, definition)
+	}
+	sort.Slice(normalized, func(i, j int) bool { return normalized[i].Name < normalized[j].Name })
+
+	data, err := json.MarshalIndent(topicMetadataManifest{
+		Version: topicMetadataFormatVersion,
+		Topics:  normalized,
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal topic metadata: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxTopicMetadataBytes {
+		return fmt.Errorf("topic metadata size %d exceeds limit %d", len(data), maxTopicMetadataBytes)
+	}
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create topic metadata directory: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	defer func() {
+		if removeErr := os.Remove(tmp); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, fmt.Errorf("remove topic metadata temporary file: %w", removeErr))
+		}
+	}()
+
+	// #nosec G304 -- the path is supplied by the broker-owned storage provider.
+	file, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("open topic metadata temporary file: %w", err)
+	}
+	if err := writeMetadataFile(file, data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close topic metadata temporary file: %w", err)
+	}
+	if err := replaceCheckpointFile(tmp, s.path); err != nil {
+		return fmt.Errorf("replace topic metadata: %w", err)
+	}
+	if err := syncTopicMetadataDirectory(dir); err != nil {
+		return fmt.Errorf("sync topic metadata directory: %w", err)
+	}
+	return nil
+}
+
+func writeMetadataFile(file *os.File, data []byte) error {
+	for len(data) > 0 {
+		written, err := file.Write(data)
+		if err != nil {
+			return fmt.Errorf("write topic metadata temporary file: %w", err)
+		}
+		if written == 0 {
+			return fmt.Errorf("write topic metadata temporary file: %w", io.ErrShortWrite)
+		}
+		data = data[written:]
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync topic metadata temporary file: %w", err)
+	}
+	return nil
+}
+
+func syncTopicMetadataDirectory(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	// #nosec G304 -- the path is supplied by the broker-owned storage provider.
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := dir.Sync()
+	return errors.Join(syncErr, dir.Close())
+}
+
+// RestoreTopics loads the standalone manifest and recreates its topic registry.
+func (tm *TopicManager) RestoreTopics() error {
+	if tm == nil || tm.metadataStore == nil {
+		return nil
+	}
+	definitions, err := tm.metadataStore.Load()
+	if err != nil {
+		return fmt.Errorf("load durable topic metadata: %w", err)
+	}
+	if err := tm.RestoreDefinitions(definitions); err != nil {
+		return fmt.Errorf("restore durable topics: %w", err)
+	}
+	return nil
+}
+
+// RestoreDefinitions recreates authoritative topic definitions without
+// rewriting the source metadata while recovery is in progress.
+func (tm *TopicManager) RestoreDefinitions(definitions []Definition) error {
+	normalized := make([]Definition, 0, len(definitions))
+	seen := make(map[string]struct{}, len(definitions))
+	for _, raw := range definitions {
+		definition, err := raw.Normalize()
+		if err != nil {
+			return fmt.Errorf("invalid definition for %q: %w", raw.Name, err)
+		}
+		if err := validateCleanupPolicyForTopic(definition.Policy, tm.cfg, definition.EventSourcing); err != nil {
+			return fmt.Errorf("invalid definition for %q: %w", definition.Name, err)
+		}
+		if _, exists := seen[definition.Name]; exists {
+			return fmt.Errorf("duplicate definition for %q", definition.Name)
+		}
+		seen[definition.Name] = struct{}{}
+		normalized = append(normalized, definition)
+	}
+	sort.Slice(normalized, func(i, j int) bool { return normalized[i].Name < normalized[j].Name })
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	for _, definition := range normalized {
+		if existing := tm.topics[definition.Name]; existing != nil {
+			current := existing.Definition()
+			if current.Idempotent != definition.Idempotent || current.EventSourcing != definition.EventSourcing {
+				return fmt.Errorf(
+					"topic %q mode mismatch: idempotent=%t/%t event_sourcing=%t/%t",
+					definition.Name,
+					current.Idempotent,
+					definition.Idempotent,
+					current.EventSourcing,
+					definition.EventSourcing,
+				)
+			}
+			if definition.Partitions < current.Partitions {
+				return fmt.Errorf(
+					"topic %q partition metadata regressed: current=%d restored=%d",
+					definition.Name,
+					current.Partitions,
+					definition.Partitions,
+				)
+			}
+		}
+	}
+
+	created := make([]string, 0, len(normalized))
+	for _, definition := range normalized {
+		if existing := tm.topics[definition.Name]; existing != nil {
+			if err := existing.applyDefinition(definition.Partitions, definition.Policy, tm.hp, nil); err != nil {
+				tm.rollbackRestoredTopicsLocked(created)
+				return fmt.Errorf("restore topic %q: %w", definition.Name, err)
+			}
+			continue
+		}
+
+		restored, err := NewTopicWithPolicy(
+			definition.Name,
+			definition.Partitions,
+			tm.hp,
+			tm.cfg,
+			tm.StreamManager,
+			definition.Idempotent,
+			definition.EventSourcing,
+			definition.Policy,
+		)
+		if err != nil {
+			tm.rollbackRestoredTopicsLocked(created)
+			return fmt.Errorf("restore topic %q: %w", definition.Name, err)
+		}
+		restored.SetTransactionDecisionResolver(tm.txnResolver)
+		tm.topics[definition.Name] = restored
+		created = append(created, definition.Name)
+	}
+	return nil
+}
+
+func (tm *TopicManager) rollbackRestoredTopicsLocked(names []string) {
+	for _, name := range names {
+		restored := tm.topics[name]
+		if restored == nil {
+			continue
+		}
+		closePartiallyInitializedTopic(name, tm.hp, restored.Partitions)
+		delete(tm.topics, name)
+	}
+}
+
+// ExportDefinitions returns a deterministic detached snapshot of topic state.
+func (tm *TopicManager) ExportDefinitions() []Definition {
+	if tm == nil {
+		return nil
+	}
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	return tm.definitionsLocked(nil, "")
+}
+
+func (tm *TopicManager) persistDefinitionLocked(override Definition) error {
+	if tm.metadataStore == nil {
+		return nil
+	}
+	definitions := tm.definitionsLocked(&override, "")
+	if err := tm.metadataStore.Save(definitions); err != nil {
+		return fmt.Errorf("persist topic definition %q: %w", override.Name, err)
+	}
+	return nil
+}
+
+func (tm *TopicManager) persistRemovalLocked(name string) error {
+	if tm.metadataStore == nil {
+		return nil
+	}
+	if err := tm.metadataStore.Save(tm.definitionsLocked(nil, name)); err != nil {
+		return fmt.Errorf("persist topic deletion %q: %w", name, err)
+	}
+	return nil
+}
+
+func (tm *TopicManager) definitionsLocked(override *Definition, removed string) []Definition {
+	definitions := make([]Definition, 0, len(tm.topics)+1)
+	overrideAdded := false
+	for name, current := range tm.topics {
+		if name == removed {
+			continue
+		}
+		if override != nil && name == override.Name {
+			definitions = append(definitions, *override)
+			overrideAdded = true
+			continue
+		}
+		definitions = append(definitions, current.Definition())
+	}
+	if override != nil && !overrideAdded && override.Name != removed {
+		definitions = append(definitions, *override)
+	}
+	sort.Slice(definitions, func(i, j int) bool { return definitions[i].Name < definitions[j].Name })
+	return definitions
+}

--- a/pkg/topic/metadata_consistency.go
+++ b/pkg/topic/metadata_consistency.go
@@ -1,0 +1,103 @@
+package topic
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type topicMetadataSaveError struct {
+	committed bool
+	err       error
+}
+
+func (e *topicMetadataSaveError) Error() string {
+	return e.err.Error()
+}
+
+func (e *topicMetadataSaveError) Unwrap() error {
+	return e.err
+}
+
+func topicMetadataWriteCommitted(err error) bool {
+	var saveErr *topicMetadataSaveError
+	return errors.As(err, &saveErr) && saveErr.committed
+}
+
+func (s *topicMetadataStore) orphanedTopicDirectories(manifestTopics map[string]struct{}) ([]string, error) {
+	root := filepath.Dir(s.path)
+	entries, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan topic storage root: %w", err)
+	}
+
+	orphaned := make([]string, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if _, exists := manifestTopics[name]; exists {
+			continue
+		}
+		if ValidateName(name) != nil {
+			continue
+		}
+		persisted, inspectErr := hasPersistedPartitionLog(filepath.Join(root, name))
+		if inspectErr != nil {
+			return nil, fmt.Errorf("inspect topic storage %q: %w", name, inspectErr)
+		}
+		if persisted {
+			orphaned = append(orphaned, name)
+		}
+	}
+	sort.Strings(orphaned)
+	return orphaned, nil
+}
+
+func hasPersistedPartitionLog(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "partition_") || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		remainder := strings.TrimPrefix(entry.Name(), "partition_")
+		separator := strings.Index(remainder, "_segment_")
+		if separator <= 0 {
+			continue
+		}
+		partition, parseErr := strconv.Atoi(remainder[:separator])
+		if parseErr == nil && partition >= 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (tm *TopicManager) rejectOrphanedStorageLocked(name string) error {
+	if tm.metadataStore == nil {
+		return nil
+	}
+	provider, ok := tm.hp.(existingPartitionProvider)
+	if !ok {
+		return nil
+	}
+	partitions, err := provider.ExistingPartitionCount(name)
+	if err != nil {
+		return fmt.Errorf("inspect persisted topic storage %q: %w", name, err)
+	}
+	if partitions > 0 {
+		return fmt.Errorf("topic %q has persisted storage without an active durable definition", name)
+	}
+	return nil
+}

--- a/pkg/topic/metadata_consistency_test.go
+++ b/pkg/topic/metadata_consistency_test.go
@@ -1,0 +1,121 @@
+package topic
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicMetadataMissingManifestRejectsPersistedTopicStorage(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	writePersistedTopicLog(t, cfg.LogDir, "legacy")
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := NewTopicManager(cfg, dm, nil)
+
+	err := manager.RestoreTopics()
+	require.ErrorContains(t, err, "manifest is missing")
+	require.ErrorContains(t, err, "legacy")
+	require.Empty(t, manager.ListTopics())
+}
+
+func TestTopicMetadataManifestRejectsUnlistedTopicStorage(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+
+	dm := disk.NewDiskManager(cfg)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("declared", 1, false, false))
+	closeTopicManager(manager)
+	dm.CloseAllHandlers()
+	writePersistedTopicLog(t, cfg.LogDir, "orphaned")
+
+	restartedDM := disk.NewDiskManager(cfg)
+	t.Cleanup(restartedDM.CloseAllHandlers)
+	restarted := NewTopicManager(cfg, restartedDM, nil)
+	err := restarted.RestoreTopics()
+	require.ErrorContains(t, err, "manifest omits persisted topic storage")
+	require.ErrorContains(t, err, "orphaned")
+	require.Empty(t, restarted.ListTopics())
+}
+
+func TestTopicCreateRejectsOrphanedStorage(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	writePersistedTopicLog(t, cfg.LogDir, "orders")
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := NewTopicManager(cfg, dm, nil)
+
+	err := manager.CreateTopic("orders", 1, false, false)
+	require.ErrorContains(t, err, "persisted storage without an active durable definition")
+	require.Nil(t, manager.GetTopic("orders"))
+}
+
+func TestTopicMetadataDirectorySyncFailureKeepsCreateAligned(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+
+	dm := disk.NewDiskManager(cfg)
+	manager := NewTopicManager(cfg, dm, nil)
+	originalSync := syncTopicMetadataDirectoryFn
+	syncTopicMetadataDirectoryFn = func(string) error { return errors.New("directory sync failed") }
+	t.Cleanup(func() { syncTopicMetadataDirectoryFn = originalSync })
+
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+	require.NotNil(t, manager.GetTopic("orders"))
+	syncTopicMetadataDirectoryFn = originalSync
+	closeTopicManager(manager)
+	dm.CloseAllHandlers()
+
+	restartedDM := disk.NewDiskManager(cfg)
+	t.Cleanup(restartedDM.CloseAllHandlers)
+	restarted := NewTopicManager(cfg, restartedDM, nil)
+	require.NoError(t, restarted.RestoreTopics())
+	defer closeTopicManager(restarted)
+	require.NotNil(t, restarted.GetTopic("orders"))
+}
+
+func TestTopicMetadataDirectorySyncFailureKeepsDeletionAligned(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+
+	dm := disk.NewDiskManager(cfg)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+	originalSync := syncTopicMetadataDirectoryFn
+	syncTopicMetadataDirectoryFn = func(string) error { return errors.New("directory sync failed") }
+	t.Cleanup(func() { syncTopicMetadataDirectoryFn = originalSync })
+
+	deleted, err := manager.DeleteTopicDurable("orders")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	require.Nil(t, manager.GetTopic("orders"))
+	syncTopicMetadataDirectoryFn = originalSync
+	dm.CloseAllHandlers()
+
+	restartedDM := disk.NewDiskManager(cfg)
+	t.Cleanup(restartedDM.CloseAllHandlers)
+	restarted := NewTopicManager(cfg, restartedDM, nil)
+	require.NoError(t, restarted.RestoreTopics())
+	require.Nil(t, restarted.GetTopic("orders"))
+}
+
+func writePersistedTopicLog(t *testing.T, root, name string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "partition_0_segment_00000000000000000000.log"),
+		nil,
+		0o600,
+	))
+}

--- a/pkg/topic/metadata_test.go
+++ b/pkg/topic/metadata_test.go
@@ -1,0 +1,163 @@
+package topic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStandaloneTopicMetadataRestoresDefinitionAndData(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+
+	dm := disk.NewDiskManager(cfg)
+	manager := NewTopicManager(cfg, dm, nil)
+	policy := Policy{
+		CleanupPolicy:  config.CleanupPolicyCompact,
+		Partitioner:    PartitionerRoundRobin,
+		AuthPolicy:     AuthPolicyACL,
+		ReadACL:        []string{"reader"},
+		WriteACL:       []string{"writer"},
+		RetentionHours: 12,
+		RetentionBytes: 4096,
+	}
+	require.NoError(t, manager.CreateTopicWithPolicy("orders", 2, true, false, policy))
+	require.NoError(t, manager.CreateTopic("events", 1, false, true))
+	require.NoError(t, manager.PublishToPartitionWithAck("orders", 1, &types.Message{Payload: "persisted"}))
+	closeTopicManager(manager)
+	dm.CloseAllHandlers()
+
+	restartedDM := disk.NewDiskManager(cfg)
+	defer restartedDM.CloseAllHandlers()
+	restarted := NewTopicManager(cfg, restartedDM, nil)
+	require.NoError(t, restarted.RestoreTopics())
+	defer closeTopicManager(restarted)
+
+	restored := restarted.GetTopic("orders")
+	require.NotNil(t, restored)
+	require.Equal(t, 2, len(restored.Partitions))
+	require.True(t, restored.IsIdempotent)
+	require.False(t, restored.IsEventSourcing)
+	require.Equal(t, config.CleanupPolicyCompact, restored.Policy.CleanupPolicy)
+	require.Equal(t, PartitionerRoundRobin, restored.Policy.Partitioner)
+	require.Equal(t, AuthPolicyACL, restored.Policy.AuthPolicy)
+	require.Equal(t, []string{"reader"}, restored.Policy.ReadACL)
+	require.Equal(t, []string{"writer"}, restored.Policy.WriteACL)
+	require.Equal(t, 12, restored.Policy.RetentionHours)
+	require.Equal(t, int64(4096), restored.Policy.RetentionBytes)
+	require.True(t, restarted.GetTopic("events").IsEventSourcing)
+	require.Equal(t, config.CleanupPolicyDelete, restarted.GetTopic("events").Policy.CleanupPolicy)
+
+	messages, err := restarted.ReadTopicPartition("orders", 1, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "persisted", messages[0].Payload)
+
+	handler, err := restartedDM.GetHandler("orders", 1)
+	require.NoError(t, err)
+	require.Equal(t, config.CleanupPolicyCompact, handler.(*disk.DiskHandler).CleanupPolicy())
+}
+
+func TestStandaloneTopicMetadataPersistsGrowthAndDeletion(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+
+	dm := disk.NewDiskManager(cfg)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("sessions", 1, false, false))
+	updated := DefaultPolicy()
+	updated.RetentionHours = 24
+	require.NoError(t, manager.CreateTopicWithPolicy("sessions", 3, false, false, updated))
+	require.NoError(t, manager.CreateTopic("deleted", 1, false, false))
+	deleted, err := manager.DeleteTopicDurable("deleted")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	closeTopicManager(manager)
+	dm.CloseAllHandlers()
+
+	restartedDM := disk.NewDiskManager(cfg)
+	defer restartedDM.CloseAllHandlers()
+	restarted := NewTopicManager(cfg, restartedDM, nil)
+	require.NoError(t, restarted.RestoreTopics())
+	defer closeTopicManager(restarted)
+	require.Nil(t, restarted.GetTopic("deleted"))
+	require.Equal(t, 3, len(restarted.GetTopic("sessions").Partitions))
+	require.Equal(t, 24, restarted.GetTopic("sessions").Policy.RetentionHours)
+}
+
+func TestStandaloneTopicMetadataCorruptionFailsClosed(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cfg.LogDir, TopicMetadataFileName),
+		[]byte(`{"version":1,"topics":[],"unexpected":true}`),
+		0o600,
+	))
+
+	dm := disk.NewDiskManager(cfg)
+	defer dm.CloseAllHandlers()
+	manager := NewTopicManager(cfg, dm, nil)
+	err := manager.RestoreTopics()
+	require.ErrorContains(t, err, "unknown field")
+	require.Empty(t, manager.ListTopics())
+}
+
+func TestTopicMetadataFailureDoesNotExposePolicyOrPartitionUpdate(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.RetentionCheckIntervalMS = 60_000
+	cfg.CompactionCheckIntervalMS = 60_000
+
+	dm := disk.NewDiskManager(cfg)
+	defer dm.CloseAllHandlers()
+	manager := NewTopicManager(cfg, dm, nil)
+	defer closeTopicManager(manager)
+	require.NoError(t, manager.CreateTopic("state", 1, false, false))
+
+	blockedPath := filepath.Join(cfg.LogDir, "blocked-metadata-target")
+	require.NoError(t, os.Mkdir(blockedPath, 0o750))
+	manager.metadataStore.path = blockedPath
+	compact := DefaultPolicy()
+	compact.CleanupPolicy = config.CleanupPolicyCompact
+	err := manager.CreateTopicWithPolicy("state", 2, false, false, compact)
+	require.Error(t, err)
+
+	current := manager.GetTopic("state")
+	require.Equal(t, 1, len(current.Partitions))
+	require.Equal(t, config.CleanupPolicyDelete, current.Policy.CleanupPolicy)
+}
+
+func TestValidateNameUsesPortableDiskContract(t *testing.T) {
+	for _, name := range []string{"orders", "orders.v2", "orders-v2", "__consumer_offsets", "exactly-once-acks=all_broker_failure"} {
+		require.NoError(t, ValidateName(name))
+	}
+	for _, name := range []string{"", ".", "..", "orders/2026", `orders\\2026`, "orders 2026", "한글"} {
+		require.Error(t, ValidateName(name), name)
+	}
+}
+
+func TestDeleteTopicDurableRejectsInvalidNameBeforeLookup(t *testing.T) {
+	manager := NewTopicManager(config.DefaultConfig(), nil, nil)
+
+	deleted, err := manager.DeleteTopicDurable("../escape")
+	require.False(t, deleted)
+	require.ErrorContains(t, err, "invalid topic name")
+}
+
+func closeTopicManager(manager *TopicManager) {
+	for _, name := range manager.ListTopics() {
+		current := manager.GetTopic(name)
+		for _, partition := range current.Partitions {
+			partition.Close()
+		}
+	}
+}

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -1142,7 +1142,11 @@ func syncParentDir(path string) {
 		util.Warn("failed to open HWM checkpoint directory %s: %v", path, err)
 		return
 	}
-	defer dir.Close()
+	defer func() {
+		if closeErr := dir.Close(); closeErr != nil {
+			util.Warn("failed to close HWM checkpoint directory %s: %v", path, closeErr)
+		}
+	}()
 	if err := dir.Sync(); err != nil {
 		util.Warn("failed to sync HWM checkpoint directory %s: %v", path, err)
 	}

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -55,6 +55,10 @@ type policyHandlerProvider interface {
 	GetHandlerWithPolicy(topic string, partitionID int, cleanupPolicy string, retentionHours int, retentionBytes int64) (types.StorageHandler, error)
 }
 
+type partitionHandlerCloser interface {
+	ClosePartitionHandler(topic string, partitionID int)
+}
+
 func getHandlerWithStoragePolicy(provider HandlerProvider, topic string, partitionID int, policy Policy) (types.StorageHandler, error) {
 	if policyProvider, ok := provider.(policyHandlerProvider); ok {
 		return policyProvider.GetHandlerWithPolicy(topic, partitionID, policy.CleanupPolicy, policy.RetentionHours, policy.RetentionBytes)
@@ -164,27 +168,100 @@ func (t *Topic) GetPartitionForMessage(msg types.Message) int {
 	return t.getPartitionIndex(msg, len(t.Partitions))
 }
 
-// AddPartitions extends the topic with new partitions.
-// Returns an error if any partition fails to initialize; partitions created
-// before the failure are kept.
+// AddPartitions atomically extends the topic with new partitions.
+// A staging failure closes every newly prepared partition and leaves the
+// visible partition count unchanged.
 func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
+	if extra < 0 {
+		return fmt.Errorf("partition increment must be >= 0")
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.applyDefinitionLocked(len(t.Partitions)+extra, t.Policy, hp, nil)
+}
 
-	for i := 0; i < extra; i++ {
-		idx := len(t.Partitions)
-		dh, err := getHandlerWithStoragePolicy(hp, t.Name, idx, t.Policy)
+// Definition returns a detached durable definition for the topic.
+func (t *Topic) Definition() Definition {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.definitionLocked()
+}
+
+func (t *Topic) definitionLocked() Definition {
+	policy := t.Policy
+	policy.ReadACL = append([]string(nil), policy.ReadACL...)
+	policy.WriteACL = append([]string(nil), policy.WriteACL...)
+	return Definition{
+		Name:          t.Name,
+		Partitions:    len(t.Partitions),
+		Idempotent:    t.IsIdempotent,
+		EventSourcing: t.IsEventSourcing,
+		Policy:        policy,
+	}
+}
+
+// applyDefinition stages new partitions and commits durable metadata before
+// exposing the new policy or partition count to publishers.
+func (t *Topic) applyDefinition(partitionCount int, policy Policy, hp HandlerProvider, persist func(Definition) error) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.applyDefinitionLocked(partitionCount, policy, hp, persist)
+}
+
+func (t *Topic) applyDefinitionLocked(partitionCount int, policy Policy, hp HandlerProvider, persist func(Definition) error) error {
+	current := len(t.Partitions)
+	if partitionCount < current {
+		return fmt.Errorf("cannot decrease partition count for topic '%s': %d -> %d", t.Name, current, partitionCount)
+	}
+
+	staged := make([]*Partition, 0, partitionCount-current)
+	for idx := current; idx < partitionCount; idx++ {
+		dh, err := getHandlerWithStoragePolicy(hp, t.Name, idx, policy)
 		if err != nil {
+			closePreparedPartitions(t.Name, hp, staged)
 			return fmt.Errorf("failed to attach partition %d for topic '%s': %w", idx, t.Name, err)
 		}
-		newP := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
-		newP.SetTransactionDecisionResolver(t.txnResolver)
-		newP.isIdempotent = t.IsIdempotent
-		newP.RecoverProducerStateFromLog()
-		newP.StartProducerStateMaintenance()
-		t.Partitions = append(t.Partitions, newP)
+		partition := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
+		partition.SetTransactionDecisionResolver(t.txnResolver)
+		partition.isIdempotent = t.IsIdempotent
+		partition.RecoverProducerStateFromLog()
+		partition.StartProducerStateMaintenance()
+		staged = append(staged, partition)
 	}
+
+	definition := t.definitionLocked()
+	definition.Partitions = partitionCount
+	definition.Policy = policy
+	if persist != nil {
+		if err := persist(definition); err != nil {
+			closePreparedPartitions(t.Name, hp, staged)
+			return err
+		}
+	}
+
+	for _, partition := range t.Partitions {
+		applyStoragePolicy(partition.dh, policy)
+	}
+	t.Policy = policy
+	t.Partitions = append(t.Partitions, staged...)
 	return nil
+}
+
+func closePreparedPartitions(topicName string, provider HandlerProvider, partitions []*Partition) {
+	for _, partition := range partitions {
+		partition.Close()
+	}
+	if closer, ok := provider.(partitionHandlerCloser); ok {
+		for _, partition := range partitions {
+			closer.ClosePartitionHandler(topicName, partition.ID())
+		}
+		return
+	}
+	for _, partition := range partitions {
+		if err := partition.dh.Close(); err != nil {
+			util.Warn("Failed to close staged storage handler for %s[%d]: %v", topicName, partition.ID(), err)
+		}
+	}
 }
 
 func (t *Topic) ApplyPolicy(policy Policy) {

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -98,6 +98,9 @@ func (c *Consumer) Done() <-chan struct{} {
 
 // Start joins the consumer group, begins consuming, and blocks until Close is called.
 func (c *Consumer) Start(handler func(Message) error) error {
+	if err := validateSDKTopicName(c.config.Topic); err != nil {
+		return err
+	}
 	c.MessageHandler = handler
 
 	if coordAddr, err := c.findCoordinator(); err == nil {

--- a/sdk/consumer_client.go
+++ b/sdk/consumer_client.go
@@ -152,8 +152,8 @@ func (c *ConsumerClient) ConnectWithFailover() (net.Conn, string, error) {
 
 // ListOffsets queries the broker for retained and readable offsets on a topic.
 func (c *ConsumerClient) ListOffsets(topic string, partition ...int) ([]PartitionOffsetRange, error) {
-	if topic == "" {
-		return nil, fmt.Errorf("topic is required")
+	if err := validateSDKTopicName(topic); err != nil {
+		return nil, err
 	}
 	if len(partition) > 1 {
 		return nil, fmt.Errorf("at most one partition can be requested")

--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -68,6 +68,10 @@ func NewEventStore(addr, topic, producerID string) *EventStore {
 
 // getConn returns an existing or new TCP connection.
 func (es *EventStore) getConn() (net.Conn, error) {
+	if err := validateSDKTopicName(es.topic); err != nil {
+		return nil, err
+	}
+
 	es.mu.Lock()
 	if es.conn != nil {
 		c := es.conn

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -70,6 +70,12 @@ type Producer struct {
 }
 
 func NewProducer(cfg *PublisherConfig) (*Producer, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("publisher config is required")
+	}
+	if err := validateSDKTopicName(cfg.Topic); err != nil {
+		return nil, err
+	}
 	if cfg.EnableMetrics {
 		initMetrics()
 	}
@@ -262,8 +268,8 @@ func (p *Producer) CreateTopicWithOptions(topic string, options TopicOptions) er
 }
 
 func buildCreateTopicCommand(topic string, options TopicOptions, idempotent bool) (string, error) {
-	if !isSafeTopicOptionValue(topic, false) {
-		return "", fmt.Errorf("invalid topic name %q", topic)
+	if err := validateSDKTopicName(topic); err != nil {
+		return "", err
 	}
 	if options.Partitions <= 0 {
 		return "", fmt.Errorf("partitions must be positive")
@@ -318,6 +324,23 @@ func buildCreateTopicCommand(topic string, options TopicOptions, idempotent bool
 		command += " write_acl=" + strings.Join(options.WriteACL, ",")
 	}
 	return command, nil
+}
+
+func validateSDKTopicName(name string) error {
+	if name == "" || len(name) > 249 || name == "." || name == ".." {
+		return fmt.Errorf("invalid topic name %q", name)
+	}
+	for _, char := range name {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= 'A' && char <= 'Z':
+		case char >= '0' && char <= '9':
+		case char == '.', char == '_', char == '-', char == '=':
+		default:
+			return fmt.Errorf("invalid topic name %q", name)
+		}
+	}
+	return nil
 }
 
 func normalizeSDKCleanupPolicy(value TopicCleanupPolicy) (string, error) {

--- a/sdk/topic_name_contract_test.go
+++ b/sdk/topic_name_contract_test.go
@@ -1,0 +1,46 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSDKTopicEntryPointsRejectInvalidNameBeforeNetwork(t *testing.T) {
+	publisherConfig := NewDefaultPublisherConfig()
+	publisherConfig.Topic = "../escape"
+	_, err := NewProducer(publisherConfig)
+	require.ErrorContains(t, err, "invalid topic name")
+
+	consumerConfig := NewDefaultConsumerConfig()
+	consumerConfig.Topic = "../escape"
+	consumer, err := NewConsumer(consumerConfig)
+	require.NoError(t, err)
+	defer consumer.mainCancel()
+	require.ErrorContains(t, consumer.Start(func(Message) error { return nil }), "invalid topic name")
+
+	store := NewEventStore("127.0.0.1:1", "../escape", "producer")
+	require.ErrorContains(t, store.CreateTopic(1), "invalid topic name")
+
+	client := &ConsumerClient{}
+	_, err = client.ListOffsets("../escape")
+	require.ErrorContains(t, err, "invalid topic name")
+
+	err = client.TransactionalPublish("txn", "../escape", 0, Message{
+		ProducerID: "producer",
+		SeqNum:     1,
+	})
+	require.ErrorContains(t, err, "invalid topic name")
+
+	_, err = buildSendOffsetsToTransactionCommand(
+		"txn",
+		"producer",
+		"../escape",
+		"group",
+		"member",
+		1,
+		1,
+		map[int]uint64{0: 1},
+	)
+	require.ErrorContains(t, err, "invalid topic name")
+}

--- a/sdk/topic_options_test.go
+++ b/sdk/topic_options_test.go
@@ -45,6 +45,35 @@ func TestBuildCreateTopicCommandRejectsUnsafeOrInvalidOptions(t *testing.T) {
 	}
 }
 
+func TestBuildCreateTopicCommandUsesPortableTopicNameContract(t *testing.T) {
+	for _, name := range []string{
+		"orders",
+		"orders.v2",
+		"orders-v2",
+		"__consumer_offsets",
+		"exactly-once-acks=all_broker_failure",
+	} {
+		if _, err := buildCreateTopicCommand(name, TopicOptions{Partitions: 1}, false); err != nil {
+			t.Fatalf("valid topic name %q was rejected: %v", name, err)
+		}
+	}
+
+	for _, name := range []string{
+		"",
+		".",
+		"..",
+		"orders/2026",
+		"orders\\2026",
+		"orders 2026",
+		"한글",
+		strings.Repeat("a", 250),
+	} {
+		if _, err := buildCreateTopicCommand(name, TopicOptions{Partitions: 1}, false); err == nil {
+			t.Fatalf("invalid topic name %q was accepted", name)
+		}
+	}
+}
+
 func TestBuildCreateTopicCommandOmitsInheritedValues(t *testing.T) {
 	command, err := buildCreateTopicCommand("state", TopicOptions{Partitions: 1}, false)
 	if err != nil {

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -160,7 +160,7 @@ func (c *ConsumerClient) TransactionalPublish(transactionalID, topic string, par
 	if err := validateTransactionOwner(transactionalID, msg.ProducerID); err != nil {
 		return err
 	}
-	if err := validateTransactionToken("topic", topic); err != nil {
+	if err := validateSDKTopicName(topic); err != nil {
 		return err
 	}
 	if partition < -1 {
@@ -201,7 +201,7 @@ func buildSendOffsetsToTransactionCommand(transactionalID, producerID, topic, gr
 	if err := validateTransactionOwner(transactionalID, producerID); err != nil {
 		return "", err
 	}
-	if err := validateTransactionToken("topic", topic); err != nil {
+	if err := validateSDKTopicName(topic); err != nil {
 		return "", err
 	}
 	if err := validateTransactionToken("group", group); err != nil {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes

No linked issue.

This PR makes topic definitions durable across standalone broker restarts and cluster snapshot recovery. It persists partition counts, idempotence, event-sourcing mode, and topic policy as one authoritative definition, and aligns broker and Go SDK topic-name validation.

## Changes

- add a versioned, crash-safe standalone topic metadata manifest with atomic replacement and fail-closed recovery
- restore topic definitions before coordinator and static-group startup
- make standalone `CREATE` and `DELETE` update metadata atomically with runtime topic state
- persist complete topic definitions in cluster FSM snapshots and restore legacy snapshot versions safely
- preserve existing high-water marks and leader epochs when increasing cluster partition counts
- reject unsafe or non-portable topic names with the structured `invalid_topic_name` error
- apply the same topic-name contract throughout the Go SDK before network I/O
- document standalone manifests, cluster snapshot v6, recovery behavior, and the protocol/API contract

## Validation

- `go test ./pkg/... ./sdk/... ./util -count=1`
- `go vet ./...`
- `golangci-lint run --new-from-rev=HEAD ./...` (`0 issues`)
- `go test ./test/e2e -run TestExactlyOnceWithFailures -count=1 -v`
  - `acks=1` network-failure scenario passed
  - `acks=all` broker restart restored a topic containing `=` and consumed all 50 records with zero duplicates
  - `acks=0` expected no-guarantee scenario passed
- `git diff --check`

## Remaining risks

- brokers upgrading from an older standalone data directory have no manifest to infer policy from; provisioning must reissue the idempotent `CREATE` definition once
- snapshot v6 should be deployed as a coordinated cluster upgrade because older binaries do not understand the new topic-state section
- the separate three-node `TestLeaderFailover` recovered the topic definition and elected a new leader, but reproduced an existing publish-path timeout with 17 of 20 quorum publishes; this is outside the PR CI `make e2e` path and remains replication reliability follow-up work
- Java and Python SDKs do not require a wire change, but may add the same local topic-name validation for earlier client feedback

Checklist:

- [x] This PR proposes a new enhancement; no related issue is linked.
- [x] The PR title clearly states the change; no related issue is linked for automatic closing.
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.
