### PR TITLE
fix: stop election monitor on channel close

### DIFF
--- a/pkg/cluster/controller/election.go
+++ b/pkg/cluster/controller/election.go
@@ -37,7 +37,11 @@ func (ce *ControllerElection) monitorLeadership() {
 		case <-ce.ctx.Done():
 			util.Info("Leadership monitor stopping")
 			return
-		case isLeader := <-notifyCh:
+		case isLeader, ok := <-notifyCh:
+			if !ok {
+				util.Info("Leadership notification channel closed")
+				return
+			}
 			if isLeader {
 				util.Info("This node is now the Cluster Leader")
 			} else {

--- a/pkg/cluster/controller/election_lifecycle_test.go
+++ b/pkg/cluster/controller/election_lifecycle_test.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type closedLeaderChannelRaftManager struct {
+	RaftManager
+	leaderCh <-chan bool
+}
+
+func (m closedLeaderChannelRaftManager) LeaderCh() <-chan bool {
+	return m.leaderCh
+}
+
+func TestControllerElectionMonitorStopsWhenLeaderChannelCloses(t *testing.T) {
+	leaderCh := make(chan bool)
+	close(leaderCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	election := &ControllerElection{
+		rm:     closedLeaderChannelRaftManager{leaderCh: leaderCh},
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	done := make(chan struct{})
+	go func() {
+		election.monitorLeadership()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("leadership monitor did not stop after notification channel closed")
+	}
+}


### PR DESCRIPTION
Fixes

Summary:
- Stop election monitoring cleanly when the leader channel closes.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.