### PR TITLE
fix: make stream replacement lifecycle safe

### DIFF
--- a/pkg/stream/connection.go
+++ b/pkg/stream/connection.go
@@ -15,6 +15,7 @@ const (
 	StreamControlPrefix                 = "STREAM_CONTROL"
 	StreamControlTypeClose              = "CLOSE"
 	StreamControlReasonStopped          = "stopped"
+	StreamControlReasonReplaced         = "replaced"
 	StreamControlReasonRemoved          = "removed"
 	StreamControlReasonTimeout          = "timeout"
 	StreamControlReasonError            = "error"

--- a/pkg/stream/manager.go
+++ b/pkg/stream/manager.go
@@ -31,48 +31,60 @@ func (sm *StreamManager) AddStream(key string, stream *StreamConnection,
 	readFn func(offset uint64, max int) ([]types.Message, error),
 	legacyCommitInterval time.Duration,
 ) error {
-
 	sm.mu.Lock()
-	defer sm.mu.Unlock()
-
-	if len(sm.streams) >= sm.maxConn {
+	previous, exists := sm.streams[key]
+	if !exists && len(sm.streams) >= sm.maxConn {
+		sm.mu.Unlock()
 		return fmt.Errorf("maximum connections (%d) reached", sm.maxConn)
 	}
-
 	sm.streams[key] = stream
+	sm.mu.Unlock()
+
+	if previous != nil && previous != stream {
+		previous.StopWithReason(StreamControlReasonReplaced)
+	}
 	go stream.Run(readFn, legacyCommitInterval)
 	go sm.monitorConnection(key, stream)
-
 	return nil
 }
 
 func (sm *StreamManager) RemoveStream(key string) {
 	sm.mu.Lock()
-	defer sm.mu.Unlock()
-
-	if stream, ok := sm.streams[key]; ok {
+	stream, ok := sm.streams[key]
+	if ok {
 		delete(sm.streams, key)
+	}
+	sm.mu.Unlock()
+	if ok {
 		stream.StopWithReason(StreamControlReasonRemoved)
 	}
+}
+
+func (sm *StreamManager) removeStreamIfCurrent(key string, stream *StreamConnection) bool {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	current, ok := sm.streams[key]
+	if !ok || current != stream {
+		return false
+	}
+	delete(sm.streams, key)
+	return true
 }
 
 func (sm *StreamManager) monitorConnection(key string, stream *StreamConnection) {
 	ticker := time.NewTicker(sm.heartbeat)
 	defer ticker.Stop()
-
 	for {
 		select {
 		case <-stream.stopCh:
-			sm.mu.Lock()
-			delete(sm.streams, key)
-			sm.mu.Unlock()
+			sm.removeStreamIfCurrent(key, stream)
+			stream.closeConn()
 			return
 		case <-ticker.C:
 			if time.Since(stream.LastActive()) > sm.timeout {
-				sm.mu.Lock()
-				delete(sm.streams, key)
-				sm.mu.Unlock()
+				sm.removeStreamIfCurrent(key, stream)
 				stream.StopWithReason(StreamControlReasonTimeout)
+				stream.closeConn()
 				return
 			}
 		}
@@ -92,14 +104,12 @@ func (sm *StreamManager) StopStream(key string) {
 	if !ok {
 		return
 	}
-
 	stream.StopWithReason(StreamControlReasonStopped)
 }
 
 func (sm *StreamManager) GetStreamsForPartition(topic string, partitionID int) []*StreamConnection {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-
 	var streams []*StreamConnection
 	for _, stream := range sm.streams {
 		if stream.topic == topic && stream.partition == partitionID {

--- a/pkg/stream/manager_test.go
+++ b/pkg/stream/manager_test.go
@@ -38,6 +38,46 @@ func TestAddRemoveStream(t *testing.T) {
 	}
 }
 
+func TestAddStreamReplacesSameKeyWithoutOldMonitorDeletingReplacement(t *testing.T) {
+	sm := NewStreamManager(2, time.Hour, 5*time.Millisecond)
+
+	conn1, peer1 := net.Pipe()
+	defer func() { _ = peer1.Close() }()
+	stream1 := NewStreamConnection(conn1, "topic", 0, "group", 0)
+
+	const key = "topic:0:group"
+	if err := sm.AddStream(key, stream1, readFn, DefaultStreamCommitInterval); err != nil {
+		t.Fatalf("failed to add initial stream: %v", err)
+	}
+
+	conn2, peer2 := net.Pipe()
+	defer func() { _ = peer2.Close() }()
+	stream2 := NewStreamConnection(conn2, "topic", 0, "group", 0)
+	if err := sm.AddStream(key, stream2, readFn, DefaultStreamCommitInterval); err != nil {
+		t.Fatalf("failed to replace stream: %v", err)
+	}
+	defer sm.RemoveStream(key)
+
+	select {
+	case <-stream1.stopCh:
+	case <-time.After(time.Second):
+		t.Fatal("replaced stream was not stopped")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for stream1.Conn() != nil && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if stream1.Conn() != nil {
+		t.Fatal("replaced stream connection was not closed")
+	}
+
+	streams := sm.GetStreamsForPartition("topic", 0)
+	if len(streams) != 1 || streams[0] != stream2 {
+		t.Fatalf("expected replacement stream to remain registered, got %v", streams)
+	}
+}
+
 func TestMaxConnections(t *testing.T) {
 	sm := NewStreamManager(1, time.Second, 100*time.Millisecond)
 


### PR DESCRIPTION
Fixes

Summary:
- Prevent replaced stream monitors from removing the active stream registration.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.