### PR TITLE
fix: preserve offsets after failed sync append

### DIFF
--- a/pkg/disk/append_offset_test.go
+++ b/pkg/disk/append_offset_test.go
@@ -1,0 +1,104 @@
+package disk_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/types"
+)
+
+func TestAppendMessageSyncFailureDoesNotConsumeOffset(t *testing.T) {
+	dh := setupDiskHandler(t)
+	defer func() { _ = dh.Close() }()
+
+	first := types.Message{Payload: "first"}
+	firstOffset, err := dh.AppendMessageSync("testTopic", 0, &first)
+	if err != nil {
+		t.Fatalf("first append failed: %v", err)
+	}
+	if firstOffset != 0 {
+		t.Fatalf("expected first offset 0, got %d", firstOffset)
+	}
+
+	failed := types.Message{Payload: "must-not-be-written"}
+	if _, err := dh.AppendMessageSync("testTopic", -1, &failed); err == nil {
+		t.Fatal("expected invalid partition append to fail")
+	}
+	if got := dh.GetAbsoluteOffset(); got != 1 {
+		t.Fatalf("failed append consumed an offset: got tail %d, want 1", got)
+	}
+
+	second := types.Message{Payload: "second"}
+	secondOffset, err := dh.AppendMessageSync("testTopic", 0, &second)
+	if err != nil {
+		t.Fatalf("second append failed: %v", err)
+	}
+	if secondOffset != 1 {
+		t.Fatalf("expected failed offset to be reused, got %d, want 1", secondOffset)
+	}
+
+	messages, err := dh.ReadMessages(0, 2)
+	if err != nil {
+		t.Fatalf("read messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	for i, message := range messages {
+		if message.Offset != uint64(i) {
+			t.Fatalf("message %d has offset %d", i, message.Offset)
+		}
+	}
+}
+
+func TestAppendMessageSyncConcurrentOffsetsAreContiguous(t *testing.T) {
+	dh := setupDiskHandler(t)
+	defer func() { _ = dh.Close() }()
+
+	const writers = 32
+	start := make(chan struct{})
+	offsets := make(chan uint64, writers)
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			msg := types.Message{Payload: fmt.Sprintf("message-%d", i)}
+			offset, err := dh.AppendMessageSync("testTopic", 0, &msg)
+			if err != nil {
+				errs <- err
+				return
+			}
+			offsets <- offset
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(offsets)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent append failed: %v", err)
+	}
+	seen := make([]bool, writers)
+	for offset := range offsets {
+		if offset >= writers {
+			t.Fatalf("offset %d is outside expected range", offset)
+		}
+		if seen[offset] {
+			t.Fatalf("duplicate offset %d", offset)
+		}
+		seen[offset] = true
+	}
+	for offset, present := range seen {
+		if !present {
+			t.Fatalf("missing offset %d", offset)
+		}
+	}
+	if got := dh.GetAbsoluteOffset(); got != writers {
+		t.Fatalf("got tail %d, want %d", got, writers)
+	}
+}

--- a/pkg/disk/handler.go
+++ b/pkg/disk/handler.go
@@ -70,6 +70,9 @@ type DiskHandler struct {
 	mu                sync.Mutex // metadata(offset, segment), file handler(d.file)
 	ioMu              sync.Mutex // bufio.Writer, flush
 
+	// appendMu serializes automatic offset allocation through its write.
+	appendMu sync.Mutex
+
 	file   *os.File
 	writer *bufio.Writer
 
@@ -258,18 +261,22 @@ func newDiskHandler(cfg *config.Config, topicName string, partitionID int, clean
 }
 
 func (d *DiskHandler) AppendMessageSync(topic string, partition int, msg *types.Message) (uint64, error) {
-	offset := atomic.AddUint64(&d.AbsoluteOffset, 1) - 1
-
+	d.appendMu.Lock()
+	defer d.appendMu.Unlock()
+	offset := atomic.LoadUint64(&d.AbsoluteOffset)
 	msg.Offset = offset
 	if err := d.WriteDirect(topic, partition, *msg); err != nil {
 		return 0, fmt.Errorf("WriteDirect failed: %w", err)
 	}
+	atomic.StoreUint64(&d.AbsoluteOffset, offset+1)
 	return offset, nil
 }
 
 // AppendMessageWithOffset writes a message with a pre-assigned offset (for follower replication).
 // Unlike AppendMessage/AppendMessageSync, it does NOT allocate a new offset.
 func (d *DiskHandler) AppendMessageWithOffset(topic string, partition int, msg *types.Message) error {
+	d.appendMu.Lock()
+	defer d.appendMu.Unlock()
 	if err := d.WriteDirect(topic, partition, *msg); err != nil {
 		return fmt.Errorf("WriteDirect failed: %w", err)
 	}
@@ -291,7 +298,9 @@ func (d *DiskHandler) AppendMessage(topic string, partition int, msg *types.Mess
 	if partition < 0 || partition > math.MaxInt32 {
 		return 0, fmt.Errorf("partition out of int32 range: %d", partition)
 	}
+	d.appendMu.Lock()
 	offset := atomic.AddUint64(&d.AbsoluteOffset, 1) - 1
+	d.appendMu.Unlock()
 
 	msg.Offset = offset
 	diskMsg := types.DiskMessage{


### PR DESCRIPTION
Fixes

Summary:
- Serialize synchronous appends so a failed write cannot leave a permanent offset hole.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.