### PR TITLE
fix: clean up topic deletion lifecycle

### DIFF
--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -3,8 +3,8 @@ package fsm
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cursus-io/cursus/util"
@@ -148,19 +148,22 @@ func (f *BrokerFSM) applyTopicDeleteCommand(jsonData string) interface{} {
 	}
 
 	f.mu.Lock()
+	tm := f.tm
+	f.mu.Unlock()
 
+	if tm != nil {
+		if _, err := tm.DeleteTopic(payload.Topic); err != nil {
+			return err
+		}
+	}
+
+	f.mu.Lock()
 	for key := range f.partitionMetadata {
 		if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
 			delete(f.partitionMetadata, key)
 		}
 	}
-
-	tm := f.tm
 	f.mu.Unlock()
-
-	if tm != nil {
-		tm.DeleteTopic(payload.Topic)
-	}
 	util.Info("FSM: Deleted topic '%s'", payload.Topic)
 
 	return nil

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -146,7 +146,11 @@ func (ch *CommandHandler) handleDelete(cmd string) string {
 		return fmt.Sprintf("🗑️ Topic '%s' deleted across cluster", topicName)
 	}
 
-	if ch.TopicManager.DeleteTopic(topicName) {
+	deleted, err := ch.TopicManager.DeleteTopic(topicName)
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+	if deleted {
 		return fmt.Sprintf("🗑️ Topic '%s' deleted", topicName)
 	}
 	return fmt.Sprintf("topic '%s' not found", topicName)

--- a/pkg/disk/topic_lifecycle.go
+++ b/pkg/disk/topic_lifecycle.go
@@ -1,0 +1,68 @@
+package disk
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// DeleteTopic closes every handler owned by topic and removes its persisted log.
+// The manager lock prevents a concurrent GetHandler from recreating a handler
+// while deletion is in progress.
+func (dm *DiskManager) DeleteTopic(topic string) error {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+
+	var errs []error
+	for key, dh := range dm.handlers {
+		if !diskHandlerKeyMatchesTopic(key, topic) {
+			continue
+		}
+		if err := dh.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close handler %s: %w", key, err))
+		}
+		delete(dm.handlers, key)
+	}
+
+	topicDir, err := dm.topicLogDir(topic)
+	if err != nil {
+		errs = append(errs, err)
+	} else if err := os.RemoveAll(topicDir); err != nil {
+		errs = append(errs, fmt.Errorf("remove topic log directory %s: %w", topicDir, err))
+	}
+	return errors.Join(errs...)
+}
+
+func (dm *DiskManager) topicLogDir(topic string) (string, error) {
+	root, err := filepath.Abs(dm.cfg.LogDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve log root: %w", err)
+	}
+	target, err := filepath.Abs(filepath.Join(root, topic))
+	if err != nil {
+		return "", fmt.Errorf("resolve topic log directory: %w", err)
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", fmt.Errorf("compare topic log directory: %w", err)
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("refusing to delete topic path outside log root: %s", target)
+	}
+	return target, nil
+}
+
+func diskHandlerKeyMatchesTopic(key, topic string) bool {
+	if !strings.HasPrefix(key, topic+"_") {
+		return false
+	}
+	partition := strings.TrimPrefix(key, topic+"_")
+	if partition == "" {
+		return false
+	}
+	_, err := strconv.Atoi(partition)
+	return err == nil
+}

--- a/pkg/topic/delete_lifecycle_test.go
+++ b/pkg/topic/delete_lifecycle_test.go
@@ -1,0 +1,110 @@
+package topic
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/types"
+)
+
+func TestDeleteTopicRecreateStartsWithCleanStorage(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	dm := disk.NewDiskManager(cfg)
+	tm := NewTopicManager(cfg, dm, nil)
+	defer dm.CloseAllHandlers()
+
+	const topicName = "recreate-topic"
+	if err := tm.CreateTopic(topicName, 1, true, false); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	stale := tm.GetTopic(topicName)
+	if err := tm.PublishWithAck(topicName, &types.Message{Payload: "before-delete"}); err != nil {
+		t.Fatalf("publish before delete: %v", err)
+	}
+
+	deleted, err := tm.DeleteTopic(topicName)
+	if err != nil {
+		t.Fatalf("delete topic: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected topic to be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.LogDir, topicName)); !os.IsNotExist(err) {
+		t.Fatalf("topic log directory still exists, stat error: %v", err)
+	}
+	if err := stale.PublishSync(types.Message{Payload: "stale"}); err == nil {
+		t.Fatal("stale topic accepted a publish after deletion")
+	}
+
+	if err := tm.CreateTopic(topicName, 1, true, false); err != nil {
+		t.Fatalf("recreate topic: %v", err)
+	}
+	if recreated := tm.GetTopic(topicName); recreated == stale {
+		t.Fatal("recreated topic reused the closed topic instance")
+	}
+	if got := tm.GetLastOffset(topicName, 0); got != 0 {
+		t.Fatalf("recreated topic retained old offset: got %d, want 0", got)
+	}
+	if err := tm.PublishWithAck(topicName, &types.Message{Payload: "after-recreate"}); err != nil {
+		t.Fatalf("publish after recreate: %v", err)
+	}
+	if got := tm.GetLastOffset(topicName, 0); got != 1 {
+		t.Fatalf("recreated topic did not start clean: got tail %d, want 1", got)
+	}
+}
+
+type failingTopicLifecycleProvider struct {
+	handler   types.StorageHandler
+	deleteErr error
+}
+
+func (p *failingTopicLifecycleProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	return p.handler, nil
+}
+
+func (p *failingTopicLifecycleProvider) DeleteTopic(string) error {
+	return p.deleteErr
+}
+
+func TestDeleteTopicStorageFailureIsReturnedAndRetryable(t *testing.T) {
+	handler := new(MockStorageHandler)
+	handler.On("GetLatestOffset").Return(uint64(0))
+	provider := &failingTopicLifecycleProvider{
+		handler:   handler,
+		deleteErr: errors.New("storage unavailable"),
+	}
+	tm := NewTopicManager(config.DefaultConfig(), provider, nil)
+	if err := tm.CreateTopic("orders", 1, false, false); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+
+	deleted, err := tm.DeleteTopic("orders")
+	if err == nil {
+		t.Fatal("expected storage deletion error")
+	}
+	if deleted {
+		t.Fatal("topic reported deleted despite storage failure")
+	}
+	current := tm.GetTopic("orders")
+	if current == nil || !current.IsClosed() {
+		t.Fatal("failed deletion must retain a closed topic for retry")
+	}
+	if err := tm.CreateTopic("orders", 1, false, false); err == nil {
+		t.Fatal("recreate succeeded while deletion was incomplete")
+	}
+
+	provider.deleteErr = nil
+	deleted, err = tm.DeleteTopic("orders")
+	if err != nil {
+		t.Fatalf("retry delete: %v", err)
+	}
+	if !deleted || tm.GetTopic("orders") != nil {
+		t.Fatal("retry did not finish topic deletion")
+	}
+	handler.AssertExpectations(t)
+}

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -36,6 +36,10 @@ type HandlerProvider interface {
 	GetHandler(topic string, partitionID int) (types.StorageHandler, error)
 }
 
+type topicStorageLifecycle interface {
+	DeleteTopic(topic string) error
+}
+
 func (tm *TopicManager) SetCoordinator(cd *coordinator.Coordinator) {
 	tm.coordinator = cd
 }
@@ -56,6 +60,9 @@ func (tm *TopicManager) CreateTopic(name string, partitionCount int, idempotent 
 	defer tm.mu.Unlock()
 
 	if existing, ok := tm.topics[name]; ok {
+		if existing.IsClosed() {
+			return fmt.Errorf("topic '%s' is closed pending successful deletion", name)
+		}
 		current := len(existing.Partitions)
 		switch {
 		case partitionCount < current:
@@ -285,14 +292,23 @@ func (tm *TopicManager) Stop() {
 	close(tm.stopCh)
 }
 
-func (tm *TopicManager) DeleteTopic(name string) bool {
+func (tm *TopicManager) DeleteTopic(name string) (bool, error) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
-	if _, ok := tm.topics[name]; ok {
-		delete(tm.topics, name)
-		return true
+
+	current, ok := tm.topics[name]
+	if !ok {
+		return false, nil
 	}
-	return false
+
+	current.Close()
+	if lifecycle, ok := tm.hp.(topicStorageLifecycle); ok {
+		if err := lifecycle.DeleteTopic(name); err != nil {
+			return false, fmt.Errorf("delete storage for topic '%s': %w", name, err)
+		}
+	}
+	delete(tm.topics, name)
+	return true, nil
 }
 
 func (tm *TopicManager) ListTopics() []string {

--- a/pkg/topic/manager_ext_test.go
+++ b/pkg/topic/manager_ext_test.go
@@ -148,11 +148,14 @@ func TestTopicManager_DeleteAndList(t *testing.T) {
 	assert.Contains(t, topics, "t1")
 	assert.Contains(t, topics, "t2")
 
-	assert.True(t, tm.DeleteTopic("t1"))
-	assert.False(t, tm.DeleteTopic("non-existent"))
+	deleted, err := tm.DeleteTopic("t1")
+	assert.NoError(t, err)
+	assert.True(t, deleted)
+	deleted, err = tm.DeleteTopic("non-existent")
+	assert.NoError(t, err)
+	assert.False(t, deleted)
 	assert.Len(t, tm.ListTopics(), 1)
 }
-
 
 func TestTopicManager_Flush(t *testing.T) {
 	hp := new(MockHandlerProvider)

--- a/pkg/topic/partition.go
+++ b/pkg/topic/partition.go
@@ -33,6 +33,7 @@ type Partition struct {
 	producerState sync.Map // map[string]*producerEntry
 	isIdempotent  bool
 	closeCh       chan struct{}
+	cleanupWG     sync.WaitGroup
 }
 
 // NewPartition creates a partition instance.
@@ -379,12 +380,14 @@ func (p *Partition) UpdateLEO(leo uint64) {
 // Close shuts down the partition.
 func (p *Partition) Close() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if p.closed {
+		p.mu.Unlock()
 		return
 	}
 	p.closed = true
 	close(p.closeCh)
+	p.mu.Unlock()
+	p.cleanupWG.Wait()
 }
 
 const producerStateTTL = 30 * time.Minute
@@ -402,6 +405,7 @@ func (p *Partition) cleanStaleProducers() {
 
 // runProducerCleanup periodically evicts stale producer state to bound memory usage.
 func (p *Partition) runProducerCleanup() {
+	defer p.cleanupWG.Done()
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 	for {
@@ -412,4 +416,9 @@ func (p *Partition) runProducerCleanup() {
 			return
 		}
 	}
+}
+
+func (p *Partition) startProducerCleanup() {
+	p.cleanupWG.Add(1)
+	go p.runProducerCleanup()
 }

--- a/pkg/topic/topic.go
+++ b/pkg/topic/topic.go
@@ -16,15 +16,16 @@ const DefaultConsumerBufSize = 1000
 
 // Topic represents a logical message stream divided into partitions and consumer groups.
 type Topic struct {
-	Name           string
-	Partitions     []*Partition
-	counter        uint64
-	consumerGroups map[string]*types.ConsumerGroup
-	mu             sync.RWMutex
-	cfg            *config.Config
-	streamManager    StreamManager
-	IsIdempotent     bool
-	IsEventSourcing  bool
+	Name            string
+	Partitions      []*Partition
+	counter         uint64
+	consumerGroups  map[string]*types.ConsumerGroup
+	mu              sync.RWMutex
+	cfg             *config.Config
+	streamManager   StreamManager
+	IsIdempotent    bool
+	IsEventSourcing bool
+	closed          bool
 }
 
 // NewTopic initializes a topic with partitions.
@@ -38,14 +39,14 @@ func NewTopic(name string, partitionCount int, hp HandlerProvider, cfg *config.C
 		p := NewPartition(i, name, dh, sm, cfg)
 		p.isIdempotent = idempotent
 		if idempotent {
-			go p.runProducerCleanup()
+			p.startProducerCleanup()
 		}
 		partitions[i] = p
 	}
 	return &Topic{
-		Name:           name,
-		Partitions:     partitions,
-		consumerGroups: make(map[string]*types.ConsumerGroup),
+		Name:            name,
+		Partitions:      partitions,
+		consumerGroups:  make(map[string]*types.ConsumerGroup),
 		cfg:             cfg,
 		streamManager:   sm,
 		IsIdempotent:    idempotent,
@@ -76,6 +77,9 @@ func (t *Topic) GetPartitionForMessage(msg types.Message) int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
+	if t.closed {
+		return -1
+	}
 	return t.getPartitionIndex(msg, len(t.Partitions))
 }
 
@@ -86,6 +90,9 @@ func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	if t.closed {
+		return fmt.Errorf("topic '%s' is closed", t.Name)
+	}
 	for i := 0; i < extra; i++ {
 		idx := len(t.Partitions)
 		dh, err := hp.GetHandler(t.Name, idx)
@@ -95,7 +102,7 @@ func (t *Topic) AddPartitions(extra int, hp HandlerProvider) error {
 		newP := NewPartition(idx, t.Name, dh, t.streamManager, t.cfg)
 		newP.isIdempotent = t.IsIdempotent
 		if t.IsIdempotent {
-			go newP.runProducerCleanup()
+			newP.startProducerCleanup()
 		}
 		t.Partitions = append(t.Partitions, newP)
 	}
@@ -148,6 +155,9 @@ func (t *Topic) Publish(msg types.Message) error {
 	defer t.mu.RUnlock()
 
 	idx := t.getPartitionIndex(msg, len(t.Partitions))
+	if t.closed {
+		return fmt.Errorf("topic '%s' is closed", t.Name)
+	}
 	if idx == -1 {
 		return fmt.Errorf("no partitions available for topic '%s'", t.Name)
 	}
@@ -164,6 +174,9 @@ func (t *Topic) PublishSync(msg types.Message) error {
 	defer t.mu.RUnlock()
 
 	idx := t.getPartitionIndex(msg, len(t.Partitions))
+	if t.closed {
+		return fmt.Errorf("topic '%s' is closed", t.Name)
+	}
 	if idx == -1 {
 		return fmt.Errorf("no partitions available for topic '%s'", t.Name)
 	}
@@ -183,6 +196,9 @@ func (t *Topic) PublishBatchSync(msgs []types.Message) error {
 	defer t.mu.RUnlock()
 
 	partitionsLen := len(t.Partitions)
+	if t.closed {
+		return fmt.Errorf("topic '%s' is closed", t.Name)
+	}
 	partitioned := make(map[int][]types.Message)
 	for _, msg := range msgs {
 		idx := t.getPartitionIndex(msg, partitionsLen)
@@ -203,6 +219,9 @@ func (t *Topic) GetPartition(partitionID int) (*Partition, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
+	if t.closed {
+		return nil, fmt.Errorf("topic '%s' is closed", t.Name)
+	}
 	if partitionID < 0 || partitionID >= len(t.Partitions) {
 		return nil, fmt.Errorf("partition %d out of range for topic '%s' (0-%d)", partitionID, t.Name, len(t.Partitions)-1)
 	}
@@ -237,4 +256,29 @@ func (t *Topic) NewMessageSignal(partition int) <-chan struct{} {
 		return nil
 	}
 	return t.Partitions[partition].newMessageCh
+}
+
+// Close prevents new topic operations and waits for partition maintenance
+// goroutines to stop. Storage ownership remains with the HandlerProvider.
+func (t *Topic) Close() {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return
+	}
+	t.closed = true
+	partitions := append([]*Partition(nil), t.Partitions...)
+	t.mu.Unlock()
+
+	for _, partition := range partitions {
+		if partition != nil {
+			partition.Close()
+		}
+	}
+}
+
+func (t *Topic) IsClosed() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.closed
 }


### PR DESCRIPTION
Fixes

Summary:
- Wait for topic shutdown and propagate storage deletion failures safely.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.