### PR TITLE
fix: bound decompression output size

### DIFF
--- a/util/compress.go
+++ b/util/compress.go
@@ -3,12 +3,18 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"fmt"
 	"io"
 
-	"github.com/pierrec/lz4/v4"
 	snappy "github.com/eapache/go-xerial-snappy"
+	mastersnappy "github.com/golang/snappy"
+	"github.com/pierrec/lz4/v4"
 )
+
+var xerialSnappyHeader = []byte{130, 83, 78, 65, 80, 80, 89, 0}
+
+const xerialSnappyFrameHeaderSize = 16
 
 // CompressMessage compresses a message if enabled
 func CompressMessage(data []byte, compressionType string) ([]byte, error) {
@@ -46,8 +52,12 @@ func CompressMessage(data []byte, compressionType string) ([]byte, error) {
 	}
 }
 
-// DecompressMessage decompresses a message if enabled
+// DecompressMessage decompresses a message if enabled.
 func DecompressMessage(data []byte, compressionType string) ([]byte, error) {
+	if len(data) > MaxMessageSize {
+		return nil, fmt.Errorf("compressed message size %d exceeds maximum %d", len(data), MaxMessageSize)
+	}
+
 	switch compressionType {
 	case "gzip":
 		gr, err := gzip.NewReader(bytes.NewReader(data))
@@ -59,14 +69,17 @@ func DecompressMessage(data []byte, compressionType string) ([]byte, error) {
 				Error("failed to close gr: %v", err)
 			}
 		}()
-		return io.ReadAll(gr)
+		return readAllDecompressed(gr)
 
 	case "snappy":
+		if err := validateSnappyDecodedSize(data); err != nil {
+			return nil, err
+		}
 		return snappy.Decode(data)
 
 	case "lz4":
 		reader := lz4.NewReader(bytes.NewReader(data))
-		return io.ReadAll(reader)
+		return readAllDecompressed(reader)
 
 	case "none", "":
 		return data, nil
@@ -74,4 +87,63 @@ func DecompressMessage(data []byte, compressionType string) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unsupported compression type: %s", compressionType)
 	}
+}
+
+func readAllDecompressed(reader io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, int64(MaxMessageSize)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxMessageSize {
+		return nil, decompressedSizeError(len(data))
+	}
+	return data, nil
+}
+
+func validateSnappyDecodedSize(data []byte) error {
+	if len(data) < len(xerialSnappyHeader) || !bytes.Equal(data[:len(xerialSnappyHeader)], xerialSnappyHeader) {
+		decodedSize, err := mastersnappy.DecodedLen(data)
+		if err != nil {
+			return err
+		}
+		if decodedSize > MaxMessageSize {
+			return decompressedSizeError(decodedSize)
+		}
+		return nil
+	}
+
+	if len(data) < xerialSnappyFrameHeaderSize {
+		return fmt.Errorf("malformed xerial snappy framing: header is %d bytes", len(data))
+	}
+
+	totalDecoded := 0
+	for position := xerialSnappyFrameHeaderSize; position < len(data); {
+		if len(data)-position < 4 {
+			return fmt.Errorf("malformed xerial snappy framing: truncated block size")
+		}
+
+		compressedSize := int(binary.BigEndian.Uint32(data[position : position+4]))
+		position += 4
+		if compressedSize > len(data)-position {
+			return fmt.Errorf("malformed xerial snappy framing: truncated block")
+		}
+
+		nextPosition := position + compressedSize
+		decodedSize, err := mastersnappy.DecodedLen(data[position:nextPosition])
+		if err != nil {
+			return err
+		}
+		if decodedSize > MaxMessageSize-totalDecoded {
+			return decompressedSizeError(totalDecoded + decodedSize)
+		}
+
+		totalDecoded += decodedSize
+		position = nextPosition
+	}
+
+	return nil
+}
+
+func decompressedSizeError(size int) error {
+	return fmt.Errorf("decompressed message size %d exceeds maximum %d", size, MaxMessageSize)
 }

--- a/util/compress_test.go
+++ b/util/compress_test.go
@@ -3,10 +3,12 @@ package util_test
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/cursus-io/cursus/util"
+	xerialsnappy "github.com/eapache/go-xerial-snappy"
 )
 
 // TestCompressMessage_AllTypes tests all supported compression types
@@ -226,5 +228,65 @@ func TestConcurrentCompression(t *testing.T) {
 
 	for err := range errCh {
 		t.Error(err)
+	}
+}
+
+func TestDecompressMessageOutputLimit(t *testing.T) {
+	compressors := map[string]func([]byte) ([]byte, error){
+		"gzip": func(data []byte) ([]byte, error) {
+			return util.CompressMessage(data, "gzip")
+		},
+		"lz4": func(data []byte) ([]byte, error) {
+			return util.CompressMessage(data, "lz4")
+		},
+		"snappy": func(data []byte) ([]byte, error) {
+			return util.CompressMessage(data, "snappy")
+		},
+		"snappy-xerial": func(data []byte) ([]byte, error) {
+			return xerialsnappy.EncodeStream(nil, data), nil
+		},
+		"none": func(data []byte) ([]byte, error) {
+			return data, nil
+		},
+	}
+
+	for name, compress := range compressors {
+		name, compress := name, compress
+		compressionType := name
+		if name == "snappy-xerial" {
+			compressionType = "snappy"
+		}
+
+		t.Run(name+"/at-limit", func(t *testing.T) {
+			original := bytes.Repeat([]byte{'x'}, util.MaxMessageSize)
+			compressed, err := compress(original)
+			if err != nil {
+				t.Fatalf("compress at limit: %v", err)
+			}
+
+			decompressed, err := util.DecompressMessage(compressed, compressionType)
+			if err != nil {
+				t.Fatalf("decompress at limit: %v", err)
+			}
+			if !bytes.Equal(decompressed, original) {
+				t.Fatalf("decompressed data mismatch: got %d bytes, want %d", len(decompressed), len(original))
+			}
+		})
+
+		t.Run(name+"/over-limit", func(t *testing.T) {
+			original := bytes.Repeat([]byte{'x'}, util.MaxMessageSize+1)
+			compressed, err := compress(original)
+			if err != nil {
+				t.Fatalf("compress over limit: %v", err)
+			}
+
+			decompressed, err := util.DecompressMessage(compressed, compressionType)
+			if err == nil {
+				t.Fatalf("expected over-limit error, got %d decoded bytes", len(decompressed))
+			}
+			if !strings.Contains(err.Error(), "exceeds maximum") {
+				t.Fatalf("unexpected over-limit error: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes

Summary:
- Apply decoded-output limits across compression codecs to prevent decompression bombs.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.