### PR TITLE
fix: initialize fsm maps after restore

### DIFF
--- a/pkg/cluster/replication/fsm/fsm.go
+++ b/pkg/cluster/replication/fsm/fsm.go
@@ -193,6 +193,18 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 		f.producerState = make(map[string]map[int]map[string]int64)
 	}
 
+	if f.logs == nil {
+		f.logs = make(map[uint64]*ReplicationEntry)
+	}
+	if f.brokers == nil {
+		f.brokers = make(map[string]*BrokerInfo)
+	}
+	if f.partitionMetadata == nil {
+		f.partitionMetadata = make(map[string]*PartitionMetadata)
+	}
+	if f.notifiers == nil {
+		f.notifiers = make(map[string]chan interface{})
+	}
 	if state.GroupState != nil && f.cd != nil {
 		f.cd.ImportState(state.GroupState)
 		util.Info("FSM Restore: Restored %d consumer groups from snapshot", len(state.GroupState))

--- a/pkg/cluster/replication/fsm/fsm_restore_invariants_test.go
+++ b/pkg/cluster/replication/fsm/fsm_restore_invariants_test.go
@@ -1,0 +1,50 @@
+package fsm
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrokerFSMRestoreInitializesMapInvariants(t *testing.T) {
+	for _, version := range []int{0, 2} {
+		t.Run(fmt.Sprintf("version_%d", version), func(t *testing.T) {
+			brokerFSM := NewBrokerFSM(nil, nil)
+			snapshot := fmt.Sprintf(`{"version":%d}`, version)
+			require.NoError(t, brokerFSM.Restore(io.NopCloser(strings.NewReader(snapshot))))
+
+			brokerFSM.mu.RLock()
+			require.NotNil(t, brokerFSM.logs)
+			require.NotNil(t, brokerFSM.brokers)
+			require.NotNil(t, brokerFSM.partitionMetadata)
+			require.NotNil(t, brokerFSM.producerState)
+			require.NotNil(t, brokerFSM.notifiers)
+			brokerFSM.mu.RUnlock()
+
+			var registerResult interface{}
+			require.NotPanics(t, func() {
+				registerResult = brokerFSM.Apply(&raft.Log{
+					Index: 1,
+					Data:  []byte(`REGISTER:{"id":"node-1","addr":"127.0.0.1:9000","status":"active"}`),
+				})
+			})
+			require.Nil(t, registerResult)
+			require.Equal(t, "node-1", brokerFSM.GetBroker("node-1").ID)
+
+			var partitionResult interface{}
+			require.NotPanics(t, func() {
+				partitionResult = brokerFSM.Apply(&raft.Log{
+					Index: 2,
+					Data: []byte(`PARTITION:orders-0:{"leader":"node-1","replicas":["node-1"],` +
+						`"isr":["node-1"],"leader_epoch":1,"partition_count":1}`),
+				})
+			})
+			require.Nil(t, partitionResult)
+			require.Equal(t, "node-1", brokerFSM.GetPartitionMetadata("orders-0").Leader)
+		})
+	}
+}


### PR DESCRIPTION
Fixes

Summary:
- Ensure FSM maps are initialized after restoring legacy or minimal snapshots.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.