### PR TITLE
fix: serialize event store requests

### DIFF
--- a/sdk/eventstore.go
+++ b/sdk/eventstore.go
@@ -53,6 +53,7 @@ type EventStore struct {
 	topic      string
 	producerID string
 	addr       string
+	requestMu  sync.Mutex
 	mu         sync.Mutex
 	conn       net.Conn
 }
@@ -88,9 +89,10 @@ func (es *EventStore) getConn() (net.Conn, error) {
 	es.mu.Lock()
 	if es.conn != nil {
 		// Another goroutine connected while we were dialing.
+		existing := es.conn
 		es.mu.Unlock()
 		_ = conn.Close()
-		return es.conn, nil
+		return existing, nil
 	}
 	es.conn = conn
 	es.mu.Unlock()
@@ -109,6 +111,9 @@ func (es *EventStore) resetConn() {
 
 // sendCommand sends a text command and returns the response string.
 func (es *EventStore) sendCommand(cmd string) (string, error) {
+	es.requestMu.Lock()
+	defer es.requestMu.Unlock()
+
 	conn, err := es.getConn()
 	if err != nil {
 		return "", err
@@ -234,6 +239,9 @@ func (es *EventStore) ReadStream(key string) (*StreamData, error) {
 // ReadStreamFrom reads events starting from a specific version.
 // If fromVersion is 0, the broker auto-resolves using snapshots.
 func (es *EventStore) ReadStreamFrom(key string, fromVersion uint64) (*StreamData, error) {
+	es.requestMu.Lock()
+	defer es.requestMu.Unlock()
+
 	cmd := fmt.Sprintf("READ_STREAM topic=%s key=%s", es.topic, key)
 	if fromVersion > 0 {
 		cmd += fmt.Sprintf(" from_version=%d", fromVersion)
@@ -392,6 +400,9 @@ func parseStreamVersionResponse(respStr string) (uint64, error) {
 
 // Close closes the underlying connection.
 func (es *EventStore) Close() error {
+	es.requestMu.Lock()
+	defer es.requestMu.Unlock()
+
 	es.mu.Lock()
 	defer es.mu.Unlock()
 	if es.conn != nil {


### PR DESCRIPTION
Fixes

Summary:
- Keep multi-frame EventStore responses from interleaving across concurrent requests.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.