### PR TITLE
fix: manage metrics exporter lifecycle

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -1,12 +1,23 @@
 package metrics
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// MetricsServer owns the listener used by a Prometheus exporter. It keeps
+// each exporter isolated from http.DefaultServeMux.
+type MetricsServer struct {
+	server   *http.Server
+	listener net.Listener
+	done     chan struct{}
+}
 
 func init() {
 	prometheus.MustRegister(MessagesProcessed, MessagesPerSec, LatencyHist, QueueSize, CleanupCount, SeqNumGapTotal, SeqNumDuplicateTotal, ConsumerLag)
@@ -14,15 +25,61 @@ func init() {
 	prometheus.MustRegister(ReplicationLagBytes, ISRChangesTotal, LeaderElectionFailures, BrokerHealthStatus, QuorumOperations, PartitionReassignments)
 }
 
-func StartMetricsServer(port int) {
+// StartMetricsServer starts an exporter on port and returns an independently
+// owned server. Listener creation is synchronous so callers receive bind
+// errors instead of discovering them only in a background goroutine.
+func StartMetricsServer(port int) (*MetricsServer, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("listen for metrics exporter: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	server := &http.Server{Handler: mux}
+	metricsServer := &MetricsServer{
+		server:   server,
+		listener: listener,
+		done:     make(chan struct{}),
+	}
+
 	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		addr := fmt.Sprintf(":%d", port)
-		fmt.Println("[METRICS] Prometheus exporter listening on", addr)
-		if err := http.ListenAndServe(addr, nil); err != nil {
-			fmt.Printf("[METRICS] Failed to start metrics server: %v\n", err)
+		defer close(metricsServer.done)
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Printf("[METRICS] Metrics server stopped unexpectedly: %v\n", err)
 		}
 	}()
+
+	fmt.Println("[METRICS] Prometheus exporter listening on", listener.Addr())
+	return metricsServer, nil
+}
+
+// Addr returns the address selected for the exporter, including a dynamically
+// assigned port when StartMetricsServer receives port 0.
+func (s *MetricsServer) Addr() net.Addr {
+	return s.listener.Addr()
+}
+
+// Shutdown gracefully stops the exporter and waits for its serving goroutine
+// to exit. It is safe to call after Close.
+func (s *MetricsServer) Shutdown(ctx context.Context) error {
+	err := s.server.Shutdown(ctx)
+	<-s.done
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// Close immediately stops the exporter and waits for the listener to be
+// released.
+func (s *MetricsServer) Close() error {
+	err := s.server.Close()
+	<-s.done
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 // PushMetric updates Prometheus metrics for each processed message.

--- a/pkg/metrics/exporter_lifecycle_test.go
+++ b/pkg/metrics/exporter_lifecycle_test.go
@@ -1,0 +1,80 @@
+package metrics_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/metrics"
+)
+
+func TestStartMetricsServer_IndependentInstancesAndShutdown(t *testing.T) {
+	first, err := metrics.StartMetricsServer(0)
+	if err != nil {
+		t.Fatalf("start first exporter: %v", err)
+	}
+	second, err := metrics.StartMetricsServer(0)
+	if err != nil {
+		_ = first.Close()
+		t.Fatalf("start second exporter: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	assertMetricsEndpoint(t, first)
+	assertMetricsEndpoint(t, second)
+
+	addr := first.Addr().String()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := first.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown first exporter: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("exporter listener was not released: %v", err)
+	}
+	_ = listener.Close()
+}
+
+func TestStartMetricsServer_ReturnsListenError(t *testing.T) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("reserve exporter port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	server, err := metrics.StartMetricsServer(port)
+	if err == nil {
+		_ = server.Close()
+		t.Fatal("expected exporter listener error")
+	}
+}
+
+func assertMetricsEndpoint(t *testing.T, server *metrics.MetricsServer) {
+	t.Helper()
+	_, port, err := net.SplitHostPort(server.Addr().String())
+	if err != nil {
+		t.Fatalf("split exporter address: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%s/metrics", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		response, err := http.Get(url)
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("metrics endpoint status = %d, want %d", response.StatusCode, http.StatusOK)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("metrics endpoint never became reachable: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -40,7 +40,15 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 	defer cancel()
 
 	if cfg.EnableExporter {
-		metrics.StartMetricsServer(cfg.ExporterPort)
+		exporter, err := metrics.StartMetricsServer(cfg.ExporterPort)
+		if err != nil {
+			return fmt.Errorf("start metrics exporter: %w", err)
+		}
+		defer func() {
+			if err := exporter.Close(); err != nil {
+				util.Error("Failed to close metrics exporter: %v", err)
+			}
+		}()
 		util.Info("📈 Prometheus exporter started on port %d", cfg.ExporterPort)
 	} else {
 		util.Info("📉 Exporter disabled")

--- a/pkg/server/metrics_lifecycle_test.go
+++ b/pkg/server/metrics_lifecycle_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunServer_ClosesExporterWhenBrokerListenerFails(t *testing.T) {
+	brokerListener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer func() { _ = brokerListener.Close() }()
+
+	exporterReservation, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	exporterPort := exporterReservation.Addr().(*net.TCPAddr).Port
+	require.NoError(t, exporterReservation.Close())
+
+	cfg := config.DefaultConfig()
+	cfg.EnableExporter = true
+	cfg.ExporterPort = exporterPort
+	cfg.BrokerPort = brokerListener.Addr().(*net.TCPAddr).Port
+
+	err = RunServer(cfg, nil, nil, nil, nil)
+	require.Error(t, err)
+
+	exporterListener, err := net.Listen("tcp", fmt.Sprintf(":%d", exporterPort))
+	require.NoError(t, err, "RunServer should release its exporter on startup failure")
+	defer func() { _ = exporterListener.Close() }()
+}


### PR DESCRIPTION
Fixes

Summary:
- Give metrics exporters owned listeners and deterministic shutdown behavior.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.