### PR TITLE
fix: append stream index entries after reopen

### DIFF
--- a/pkg/eventsource/stream_index.go
+++ b/pkg/eventsource/stream_index.go
@@ -3,6 +3,7 @@ package eventsource
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -157,6 +158,17 @@ func (si *StreamIndex) loadFromDisk() error {
 			st.lastOffset = entry.Offset
 			st.entryCount++
 		}
+	}
+
+	// os.ReadFile above uses separate file descriptors, so neither open file's
+	// cursor advances while rebuilding the in-memory cache. Move both cursors
+	// to EOF before future Write calls; otherwise the first append after a
+	// restart overwrites the first persisted record.
+	if _, err := si.indexFile.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("seek index to end: %w", err)
+	}
+	if _, err := si.sidecarFile.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("seek sidecar to end: %w", err)
 	}
 
 	return nil

--- a/pkg/eventsource/stream_index_test.go
+++ b/pkg/eventsource/stream_index_test.go
@@ -60,6 +60,41 @@ func TestStreamIndex_LoadFromDisk(t *testing.T) {
 	assert.Equal(t, uint64(3), entries[2].AggregateVersion)
 }
 
+func TestStreamIndex_ReopenAppendPreservesExistingEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	idx, err := NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	require.NoError(t, idx.Append("a", 1, 10, 0))
+	require.NoError(t, idx.Close())
+
+	// Reopen before appending a new key. Both the index and sidecar must append
+	// at EOF rather than overwrite their first persisted records.
+	idx, err = NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	require.NoError(t, idx.Append("b", 1, 20, 1))
+	require.NoError(t, idx.Close())
+
+	idx, err = NewStreamIndex(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	for _, tc := range []struct {
+		key    string
+		offset uint64
+	}{
+		{key: "a", offset: 10},
+		{key: "b", offset: 20},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			assert.Equal(t, uint64(1), idx.GetVersion(tc.key))
+			entries, err := idx.Lookup(tc.key, 1)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			assert.Equal(t, tc.offset, entries[0].Offset)
+		})
+	}
+}
 func TestStreamIndex_MultipleKeys(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Fixes

Summary:
- Seek stream-index cursors to EOF after reload before appending entries.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.