### PR TITLE
fix: recover truncated snapshot payloads

### DIFF
--- a/pkg/eventsource/snapshot_store.go
+++ b/pkg/eventsource/snapshot_store.go
@@ -68,6 +68,15 @@ func (s *SnapshotStore) loadFromDisk() error {
 		return err
 	}
 
+	fileInfo, err := s.file.Stat()
+	if err != nil {
+		return err
+	}
+	if fileInfo.Size() < 0 {
+		return fmt.Errorf("negative snapshot file size: %d", fileInfo.Size())
+	}
+	fileSize := uint64(fileInfo.Size())
+
 	var offset uint64
 	var lastGoodOffset uint64
 	for {
@@ -123,12 +132,18 @@ func (s *SnapshotStore) loadFromDisk() error {
 		}
 		offset += 4
 
-		// Skip Payload bytes.
-		if _, err := s.file.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
+		// Check that the declared payload fits in the file before seeking. Seeking
+		// beyond EOF succeeds, so it cannot be used to detect a partial payload.
+		if offset > fileSize || uint64(payloadLen) > fileSize-offset {
 			if truncErr := s.file.Truncate(int64(lastGoodOffset)); truncErr != nil {
 				return fmt.Errorf("snapshot store: truncate after partial payload: %w", truncErr)
 			}
 			break
+		}
+
+		// Skip the validated payload bytes.
+		if _, err := s.file.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
+			return fmt.Errorf("snapshot store: seek payload: %w", err)
 		}
 		offset += uint64(payloadLen)
 

--- a/pkg/eventsource/snapshot_store_test.go
+++ b/pkg/eventsource/snapshot_store_test.go
@@ -265,3 +265,57 @@ func TestSnapshotStore_PartialWriteRecovery(t *testing.T) {
 	require.NotNil(t, snap)
 	assert.Equal(t, uint64(1), snap.Version)
 }
+
+func TestSnapshotStore_PartialPayloadRecovery(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := NewSnapshotStore(dir, 0)
+	require.NoError(t, err)
+	require.NoError(t, store.Save("good-key", 3, `{"ok":true}`))
+	require.NoError(t, store.Close())
+
+	path := filepath.Join(dir, fmt.Sprintf("partition_%d_snapshots.dat", 0))
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0644)
+	require.NoError(t, err)
+
+	key := []byte("partial-key")
+	require.NoError(t, binary.Write(f, binary.BigEndian, uint16(len(key))))
+	_, err = f.Write(key)
+	require.NoError(t, err)
+	require.NoError(t, binary.Write(f, binary.BigEndian, uint64(4)))
+	require.NoError(t, binary.Write(f, binary.BigEndian, uint32(100)))
+	_, err = f.Write([]byte("short"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Reopening must discard the incomplete record instead of indexing it or
+	// leaving a write offset past EOF.
+	store, err = NewSnapshotStore(dir, 0)
+	require.NoError(t, err)
+	snap, err := store.Read("good-key")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, `{"ok":true}`, snap.Payload)
+
+	snap, err = store.Read("partial-key")
+	require.NoError(t, err)
+	assert.Nil(t, snap)
+
+	require.NoError(t, store.Save("new-key", 1, `{"recovered":true}`))
+	require.NoError(t, store.Close())
+
+	store, err = NewSnapshotStore(dir, 0)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	snap, err = store.Read("good-key")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(3), snap.Version)
+
+	snap, err = store.Read("new-key")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+	assert.Equal(t, uint64(1), snap.Version)
+	assert.Equal(t, `{"recovered":true}`, snap.Payload)
+}


### PR DESCRIPTION
Fixes

Summary:
- Truncate incomplete snapshot payloads and allow subsequent saves after recovery.

Validation:
- Targeted package tests and `git diff --check` passed.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing). No issue number was provided.
- [x] Documentation has been updated as needed. No public documentation change is required for this internal fix.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully. Relevant package tests passed.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.