### PR TITLE
ci: auto-assign pull request authors

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -1,0 +1,50 @@
+name: auto-assign-pr-author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign pull request author
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { number, user } = context.payload.pull_request;
+            const { data: issue } = await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              assignees: [user.login],
+            });
+
+            const isAssigned = issue.assignees.some(
+              ({ login }) => login === user.login,
+            );
+
+            if (!isAssigned) {
+              const marker = "<!-- auto-assign-pr-author -->";
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  per_page: 100,
+                },
+              );
+
+              if (!comments.some(({ body }) => body?.includes(marker))) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body: `${marker}\n@${user.login} GitHub could not assign you because you do not have repository access.`,
+                });
+              }
+            }


### PR DESCRIPTION
Fixes N/A (repository automation enhancement)

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change; no issue-closing reference applies.
- [x] Documentation has been updated as needed (not needed for a repository-only workflow).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality (workflow-only change; YAML and embedded JavaScript syntax validated).
- [x] The build passes successfully (not applicable to this workflow-only change; static validation passed).
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

## Summary

- Automatically assign newly opened or reopened pull requests to their author.
- Leave one explanatory mention when GitHub cannot assign an external author.
- Pin the action to a full SHA, do not execute PR code, and use only `issues: write` permission.

## Validation

- `git diff --check`
- YAML parsing and embedded JavaScript syntax validation
