### PR TITLE
fix: grant PR assignment workflow pull request access

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -2,10 +2,10 @@ name: auto-assign-pr-author
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 permissions:
-  issues: write
+  pull-requests: write
 
 jobs:
   assign-author:
@@ -16,35 +16,9 @@ jobs:
         with:
           script: |
             const { number, user } = context.payload.pull_request;
-            const { data: issue } = await github.rest.issues.addAssignees({
+            await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: number,
               assignees: [user.login],
             });
-
-            const isAssigned = issue.assignees.some(
-              ({ login }) => login === user.login,
-            );
-
-            if (!isAssigned) {
-              const marker = "<!-- auto-assign-pr-author -->";
-              const comments = await github.paginate(
-                github.rest.issues.listComments,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: number,
-                  per_page: 100,
-                },
-              );
-
-              if (!comments.some(({ body }) => body?.includes(marker))) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: number,
-                  body: `${marker}\n@${user.login} GitHub could not assign you because you do not have repository access.`,
-                });
-              }
-            }


### PR DESCRIPTION
Fixes N/A (repository automation correction)

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change; no issue-closing reference applies.
- [x] Documentation has been updated as needed (not needed for a repository-only workflow).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality (workflow-only change; YAML validation covers the change).
- [x] The build passes successfully (not applicable to this workflow-only change; static validation passed).
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

## Summary

- Restore `pull-requests: write` required by the PR assignee API.
- Remove the external-author fallback comment and the unnecessary `issues: write` permission.
- Run the idempotent assignment when new commits are pushed to a PR.

## Validation

- `git diff --check`
- YAML parsing verifies `opened`, `reopened`, and `synchronize` triggers with only `pull-requests: write`.
