### PR TITLE
refactor: make cluster E2E readiness deterministic

### DIFF
--- a/test/e2e-cluster/actions.go
+++ b/test/e2e-cluster/actions.go
@@ -141,7 +141,6 @@ func (a *ClusterActions) SimulateFollowerFailure(nodeIndex int) *ClusterActions 
 	a.ctx.GetClient().Close()
 
 	a.ctx.GetT().Logf("Successfully stopped %s", containerName)
-	time.Sleep(2 * time.Second)
 	return a
 }
 

--- a/test/e2e-cluster/actions.go
+++ b/test/e2e-cluster/actions.go
@@ -308,25 +308,15 @@ func leaderAddressFromDescribe(resp string) (string, error) {
 }
 
 func (a *ClusterActions) waitForPartitionLeaderChange(topic, oldLeader string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	var lastErr error
-	for time.Now().Before(deadline) {
+	return eventually(a.ctx.GetT(), fmt.Sprintf("partition leader change for %s", topic), timeout, func() (bool, string, error) {
 		resp, err := a.actions.SendCommand(fmt.Sprintf("DESCRIBE topic=%s", topic))
-		if err == nil {
-			leader, parseErr := leaderAddressFromDescribe(resp)
-			switch {
-			case parseErr != nil:
-				lastErr = parseErr
-			case leader != oldLeader:
-				a.ctx.GetT().Logf("Partition leader changed from %s to %s", oldLeader, leader)
-				return nil
-			default:
-				lastErr = fmt.Errorf("partition leader is still %s", oldLeader)
-			}
-		} else {
-			lastErr = err
+		if err != nil {
+			return false, "DESCRIBE failed", err
 		}
-		time.Sleep(time.Second)
-	}
-	return fmt.Errorf("partition leader did not change from %s within %s: %w", oldLeader, timeout, lastErr)
+		leader, err := leaderAddressFromDescribe(resp)
+		if err != nil {
+			return false, resp, err
+		}
+		return leader != oldLeader, fmt.Sprintf("leader=%s", leader), nil
+	})
 }

--- a/test/e2e-cluster/actions.go
+++ b/test/e2e-cluster/actions.go
@@ -53,8 +53,12 @@ func (a *ClusterActions) StartCluster() *ClusterActions {
 
 // waitForNodeHealth checks if a node is healthy
 func (a *ClusterActions) waitForNodeHealth(nodeIndex int, healthURL string) error {
+	if err := validateNodeHealthURL(nodeIndex, healthURL); err != nil {
+		return err
+	}
 	a.ctx.GetT().Logf("Waiting for node %d health check", nodeIndex)
 	return eventually(a.ctx.GetT(), fmt.Sprintf("node %d health at %s", nodeIndex, healthURL), clusterReadyTimeout, func() (bool, string, error) {
+		// #nosec G107 -- validateNodeHealthURL restricts requests to the expected loopback test endpoint.
 		resp, err := http.Get(healthURL)
 		if err == nil && resp.StatusCode == http.StatusOK {
 			_ = resp.Body.Close()
@@ -65,6 +69,17 @@ func (a *ClusterActions) waitForNodeHealth(nodeIndex int, healthURL string) erro
 		}
 		return false, "health endpoint not ready", err
 	})
+}
+
+func validateNodeHealthURL(nodeIndex int, healthURL string) error {
+	if nodeIndex <= 0 {
+		return fmt.Errorf("invalid broker index %d", nodeIndex)
+	}
+	expected := fmt.Sprintf("http://localhost:%d/health", healthPort(nodeIndex))
+	if healthURL != expected {
+		return fmt.Errorf("refusing unexpected node health URL %q", healthURL)
+	}
+	return nil
 }
 
 // checkAllNodesHealth verifies all cluster nodes are healthy

--- a/test/e2e-cluster/actions.go
+++ b/test/e2e-cluster/actions.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 	"github.com/cursus-io/cursus/test/e2e"
-	"github.com/cursus-io/cursus/util"
 )
 
 // ClusterActions represents cluster-specific test actions
@@ -210,34 +209,28 @@ func (a *ClusterActions) DescribeTopic() *ClusterActions {
 
 func (a *ClusterActions) WaitForTopicMetadata() *ClusterActions {
 	topic := a.ctx.GetTopic()
-	a.ctx.GetT().Logf("Waiting for topic metadata to propagate: %s", topic)
-
 	addrs := a.ctx.GetBrokerAddrs()
-
-	for i := 0; i < 60; i++ {
+	if err := eventually(a.ctx.GetT(), fmt.Sprintf("topic metadata for %s", topic), clusterReadyTimeout, func() (bool, string, error) {
+		lastDetail := "no broker returned metadata"
 		for _, addr := range addrs {
 			tempClient := e2e.NewBrokerClient([]string{addr})
-			cmd := fmt.Sprintf("DESCRIBE topic=%s", topic)
-			resp, err := tempClient.SendCommand("", cmd, 2*time.Second)
+			resp, err := tempClient.SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", topic), 2*time.Second)
 			tempClient.Close()
-
-			if err == nil &&
-				!strings.Contains(resp, "not found") &&
-				!strings.Contains(resp, "ERROR:") &&
-				strings.Contains(resp, topic) &&
-				strings.Contains(resp, "{") {
-				a.ctx.GetT().Logf("Topic metadata for '%s' is now available on node %s", topic, addr)
-				return a
+			if err != nil {
+				lastDetail = fmt.Sprintf("%s: %v", addr, err)
+				continue
 			}
-			util.Debug("Still waiting for metadata on %s: resp=%s, err=%v", addr, resp, err)
+			if !strings.Contains(resp, "not found") && !strings.Contains(resp, "ERROR:") && strings.Contains(resp, topic) && strings.Contains(resp, "{") {
+				return true, fmt.Sprintf("available on %s", addr), nil
+			}
+			lastDetail = fmt.Sprintf("%s: %s", addr, resp)
 		}
-		time.Sleep(1 * time.Second)
+		return false, lastDetail, nil
+	}); err != nil {
+		a.ctx.GetT().Fatal(err)
 	}
-
-	a.ctx.GetT().Fatalf("Timed out waiting for topic metadata to propagate for topic %s", topic)
 	return a
 }
-
 func (a *ClusterActions) SimulateLeaderFailure() (int, *ClusterActions) {
 	topic := a.ctx.GetTopic()
 	a.ctx.GetT().Logf("Simulating leader failure for topic: %s", topic)

--- a/test/e2e-cluster/actions.go
+++ b/test/e2e-cluster/actions.go
@@ -29,32 +29,26 @@ func (c *ClusterTestContext) WhenCluster() *ClusterActions {
 
 func (a *ClusterActions) StartCluster() *ClusterActions {
 	a.ctx.GetT().Logf("Waiting for %d cluster nodes to register...", a.ctx.clusterSize)
-
-	maxRetries := 20
-	for i := 0; i < maxRetries; i++ {
+	if err := eventually(a.ctx.GetT(), "active cluster membership", clusterReadyTimeout, func() (bool, string, error) {
 		resp, err := a.actions.SendCommand("LIST_CLUSTER")
-		if err == nil {
-			a.ctx.GetT().Logf("DEBUG: LIST_CLUSTER raw response: %s", resp)
-			payload := strings.TrimPrefix(strings.TrimSpace(resp), "OK brokers=")
-			var brokers []fsm.BrokerInfo
-			if err := json.Unmarshal([]byte(payload), &brokers); err == nil {
-				activeCount := 0
-				for _, b := range brokers {
-					if b.Status == "active" {
-						activeCount++
-					}
-				}
-				a.ctx.GetT().Logf("LIST_CLUSTER (Attempt %d/%d): %d/%d active. Brokers: %+v", i+1, maxRetries, activeCount, a.ctx.clusterSize, brokers)
-				if activeCount >= a.ctx.clusterSize {
-					a.ctx.GetT().Logf("All %d cluster nodes registered and active", a.ctx.clusterSize)
-					return a
-				}
+		if err != nil {
+			return false, "LIST_CLUSTER failed", err
+		}
+		payload := strings.TrimPrefix(strings.TrimSpace(resp), "OK brokers=")
+		var brokers []fsm.BrokerInfo
+		if err := json.Unmarshal([]byte(payload), &brokers); err != nil {
+			return false, resp, err
+		}
+		activeCount := 0
+		for _, broker := range brokers {
+			if broker.Status == "active" {
+				activeCount++
 			}
 		}
-		time.Sleep(1 * time.Second)
+		return activeCount >= a.ctx.clusterSize, fmt.Sprintf("%d/%d active", activeCount, a.ctx.clusterSize), nil
+	}); err != nil {
+		a.ctx.GetT().Fatal(err)
 	}
-
-	a.ctx.GetT().Fatalf("cluster did not report %d active nodes after %d attempts", a.ctx.clusterSize, maxRetries)
 	return a
 }
 

--- a/test/e2e-cluster/actions.go
+++ b/test/e2e-cluster/actions.go
@@ -53,23 +53,19 @@ func (a *ClusterActions) StartCluster() *ClusterActions {
 }
 
 // waitForNodeHealth checks if a node is healthy
-func (a *ClusterActions) waitForNodeHealth(nodeIndex int, healthUrl string) error {
+func (a *ClusterActions) waitForNodeHealth(nodeIndex int, healthURL string) error {
 	a.ctx.GetT().Logf("Waiting for node %d health check", nodeIndex)
-
-	for retry := 0; retry < 30; retry++ {
-		resp, err := http.Get(healthUrl)
-		if err == nil && resp.StatusCode == 200 {
+	return eventually(a.ctx.GetT(), fmt.Sprintf("node %d health at %s", nodeIndex, healthURL), clusterReadyTimeout, func() (bool, string, error) {
+		resp, err := http.Get(healthURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
 			_ = resp.Body.Close()
-			a.ctx.GetT().Logf("Node %d is healthy", nodeIndex)
-			return nil
+			return true, "healthy", nil
 		}
 		if resp != nil {
 			_ = resp.Body.Close()
 		}
-		time.Sleep(2 * time.Second)
-	}
-
-	return fmt.Errorf("node %d failed to become healthy at %s after 30 retries", nodeIndex, healthUrl)
+		return false, "health endpoint not ready", err
+	})
 }
 
 // checkAllNodesHealth verifies all cluster nodes are healthy

--- a/test/e2e-cluster/actions_test.go
+++ b/test/e2e-cluster/actions_test.go
@@ -26,3 +26,18 @@ func TestLeaderNodeFromDescribeRejectsUnknownLeader(t *testing.T) {
 		t.Fatal("leaderNodeFromDescribe() error = nil, want out-of-range error")
 	}
 }
+
+func TestValidateNodeHealthURLRestrictsLoopbackEndpoint(t *testing.T) {
+	if err := validateNodeHealthURL(2, "http://localhost:9082/health"); err != nil {
+		t.Fatalf("expected cluster health URL to be accepted: %v", err)
+	}
+	for _, candidate := range []string{
+		"http://example.com:9082/health",
+		"http://localhost:9081/health",
+		"http://localhost:9082/other",
+	} {
+		if err := validateNodeHealthURL(2, candidate); err == nil {
+			t.Fatalf("validateNodeHealthURL(%q) error = nil, want rejection", candidate)
+		}
+	}
+}

--- a/test/e2e-cluster/chaos_test.go
+++ b/test/e2e-cluster/chaos_test.go
@@ -123,18 +123,20 @@ func TestChaosTransactionCoordinatorRestartPreservesAtomicVisibility(t *testing.
 	}
 	txnClient.Close()
 	actions.StopBroker(coordinatorNode)
-	time.Sleep(5 * time.Second)
 	actions.StartBroker(coordinatorNode)
-	time.Sleep(5 * time.Second)
 
 	recoveryClient := e2e.NewBrokerClient(ctx.GetBrokerAddrs())
 	defer recoveryClient.Close()
-	status, err := recoveryClient.GetTransactionStatus(txnID)
-	if err != nil {
-		t.Fatalf("transaction state was not recovered: %v", err)
-	}
-	if status.State != "open" || status.Messages != 2 || status.Offsets != 2 {
-		t.Fatalf("unexpected recovered transaction state: %+v", status)
+	var status e2e.TransactionStatus
+	if err := eventually(t, "transaction coordinator recovery", clusterReadyTimeout, func() (bool, string, error) {
+		current, statusErr := recoveryClient.GetTransactionStatus(txnID)
+		if statusErr != nil {
+			return false, "TXN_STATUS failed", statusErr
+		}
+		status = current
+		return status.State == "open" && status.Messages == 2 && status.Offsets == 2, fmt.Sprintf("state=%s messages=%d offsets=%d", status.State, status.Messages, status.Offsets), nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 	if err := recoveryClient.EndTransaction(txnID, producer, "commit"); err != nil {
 		t.Fatalf("commit recovered transaction: %v", err)

--- a/test/e2e-cluster/cluster_test.go
+++ b/test/e2e-cluster/cluster_test.go
@@ -67,8 +67,6 @@ func TestClusterDataConsistency(t *testing.T) {
 		RecoverFollower(3).
 		DescribeTopic()
 
-	time.Sleep(5 * time.Second)
-
 	ctx.Then().
 		Expect(ExpectDataConsistent())
 }
@@ -143,8 +141,6 @@ func TestClusterWideDeduplication(t *testing.T) {
 		CreateTopic().
 		PublishMessages()
 	ctx.WhenCluster().SimulateLeaderFailure()
-
-	time.Sleep(7 * time.Second)
 
 	ctx.WhenCluster().
 		RetryPublishMessages().

--- a/test/e2e-cluster/cluster_test.go
+++ b/test/e2e-cluster/cluster_test.go
@@ -2,7 +2,6 @@ package e2e_cluster
 
 import (
 	"testing"
-	"time"
 )
 
 // TestISRWithAllAcks tests ISR behavior with acks=all
@@ -84,14 +83,11 @@ func TestDistributedOffsetResilience(t *testing.T) {
 		StartCluster().
 		CreateTopic()
 
-	time.Sleep(5 * time.Second) // allow ISR to stabilize
-
+	ctx.WhenCluster().WaitForTopicMetadata()
 	ctx.WhenCluster().
 		JoinGroup().
 		CommitOffset(0, 50)
 	ctx.WhenCluster().SimulateLeaderFailure()
-
-	time.Sleep(10 * time.Second) // wait for Raft election and partition leader failover
 
 	ctx.Then().
 		Expect(ExpectOffsetMatched(0, 50))
@@ -116,7 +112,7 @@ func TestRollingRestartNoDowntime(t *testing.T) {
 		ctx.WhenCluster().
 			SimulateFollowerFailure(i).
 			RecoverFollower(i)
-		time.Sleep(5 * time.Second) // allow node to rejoin Raft
+		ctx.WhenCluster().WaitForTopicMetadata()
 	}
 
 	ctx.ResetPublishedCount().
@@ -161,14 +157,11 @@ func TestConsumerGroupRebalanceFailover(t *testing.T) {
 		StartCluster().
 		CreateTopic()
 
-	time.Sleep(5 * time.Second) // allow ISR to stabilize
-
+	ctx.WhenCluster().WaitForTopicMetadata()
 	ctx.WhenCluster().
 		JoinGroup().
 		SyncGroup()
 	ctx.WhenCluster().SimulateLeaderFailure()
-
-	time.Sleep(10 * time.Second) // wait for Raft election and partition leader failover
 
 	ctx.Then().
 		Expect(ISRMaintained())

--- a/test/e2e-cluster/expectations.go
+++ b/test/e2e-cluster/expectations.go
@@ -84,60 +84,37 @@ func ExpectOffsetMatched(partition int, expected uint64) e2e.Expectation {
 		topic := ctx.GetTopic()
 		group := ctx.GetConsumerGroup()
 		client := ctx.GetClient()
-
-		maxRetries := 15
-		var lastOffset uint64
-		var lastErr error
-
-		for i := 0; i < maxRetries; i++ {
-			lastOffset, lastErr = client.FetchCommittedOffset(topic, partition, group)
-			if lastErr == nil {
-				if lastOffset == expected {
-					ctx.GetT().Logf("Confirmed: Offset %d is correctly replicated and matched", lastOffset)
-					return nil
-				}
-				ctx.GetT().Logf("Offset mismatch (Attempt %d/%d): expected %d, got %d. Retrying...", i+1, maxRetries, expected, lastOffset)
-			} else {
-				// Retry on authorization errors as they usually indicate leader election is in progress
-				ctx.GetT().Logf("Fetch committed offset error (Attempt %d/%d): %v. Retrying...", i+1, maxRetries, lastErr)
+		return eventually(ctx.GetT(), fmt.Sprintf("committed offset %d for %s[%d]", expected, topic, partition), clusterReadyTimeout, func() (bool, string, error) {
+			offset, err := client.FetchCommittedOffset(topic, partition, group)
+			if err != nil {
+				return false, "fetch committed offset failed", err
 			}
-			time.Sleep(2 * time.Second)
-		}
-
-		if lastErr != nil {
-			return fmt.Errorf("failed to fetch offset after %d retries: %w", maxRetries, lastErr)
-		}
-		return fmt.Errorf("offset mismatch after %d retries: expected %d, got %d", maxRetries, expected, lastOffset)
+			return offset == expected, fmt.Sprintf("got %d, want %d", offset, expected), nil
+		})
 	}
 }
-
 func LeaderChanged(partitionID int, oldLeader string) e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
 		topic := ctx.GetTopic()
 		client := ctx.GetClient()
-
-		maxRetries := 20
-		for i := 0; i < maxRetries; i++ {
+		return eventually(ctx.GetT(), fmt.Sprintf("leader change for %s[%d]", topic, partitionID), clusterReadyTimeout, func() (bool, string, error) {
 			resp, err := client.SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", topic), 5*time.Second)
-			if err == nil {
-				var meta topicMetadata
-				if err := json.Unmarshal([]byte(resp), &meta); err == nil && len(meta.Partitions) > 0 {
-					for _, p := range meta.Partitions {
-						if p.ID == partitionID {
-							if p.Leader != "" && p.Leader != oldLeader {
-								ctx.GetT().Logf("Confirmed: Leader for %s:%d changed from %s to %s", topic, partitionID, oldLeader, p.Leader)
-								return nil
-							}
-						}
-					}
+			if err != nil {
+				return false, "DESCRIBE failed", err
+			}
+			var meta topicMetadata
+			if err := json.Unmarshal([]byte(resp), &meta); err != nil {
+				return false, resp, err
+			}
+			for _, partition := range meta.Partitions {
+				if partition.ID == partitionID {
+					return partition.Leader != "" && partition.Leader != oldLeader, fmt.Sprintf("leader=%s", partition.Leader), nil
 				}
 			}
-			time.Sleep(1 * time.Second)
-		}
-		return fmt.Errorf("leader for partition %d did not change from %s after %d retries", partitionID, oldLeader, maxRetries)
+			return false, "partition not found", nil
+		})
 	}
 }
-
 func ISRMaintained() e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
 		topic := ctx.GetTopic()

--- a/test/e2e-cluster/expectations.go
+++ b/test/e2e-cluster/expectations.go
@@ -44,31 +44,26 @@ func ExpectDataConsistent() e2e.Expectation {
 		})
 	}
 }
-func ExpectPartitionWatermarks(partition int, expectedLEO, expectedHWM uint64) e2e.Expectation {
+func ExpectPartitionWatermarks(partitionID int, expectedLEO, expectedHWM uint64) e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
-		resp, err := ctx.GetClient().SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", ctx.GetTopic()), 5*time.Second)
-		if err != nil {
-			return err
-		}
-
-		var meta topicMetadata
-		if err := json.Unmarshal([]byte(resp), &meta); err != nil {
-			return fmt.Errorf("failed to parse metadata: %w", err)
-		}
-		for _, p := range meta.Partitions {
-			if p.ID != partition {
-				continue
+		return eventually(ctx.GetT(), fmt.Sprintf("watermarks for %s[%d]", ctx.GetTopic(), partitionID), clusterReadyTimeout, func() (bool, string, error) {
+			resp, err := ctx.GetClient().SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", ctx.GetTopic()), 5*time.Second)
+			if err != nil {
+				return false, "DESCRIBE failed", err
 			}
-			if p.LEO != expectedLEO || p.HWM != expectedHWM {
-				return fmt.Errorf("partition %d watermark mismatch: expected leo=%d hwm=%d, got leo=%d hwm=%d",
-					partition, expectedLEO, expectedHWM, p.LEO, p.HWM)
+			var meta topicMetadata
+			if err := json.Unmarshal([]byte(resp), &meta); err != nil {
+				return false, resp, err
 			}
-			return nil
-		}
-		return fmt.Errorf("partition %d not found", partition)
+			for _, partition := range meta.Partitions {
+				if partition.ID == partitionID {
+					return partition.LEO == expectedLEO && partition.HWM == expectedHWM, fmt.Sprintf("leo=%d hwm=%d", partition.LEO, partition.HWM), nil
+				}
+			}
+			return false, "partition not found", nil
+		})
 	}
 }
-
 func ExpectOffsetMatched(partition int, expected uint64) e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
 		topic := ctx.GetTopic()
@@ -107,25 +102,22 @@ func LeaderChanged(partitionID int, oldLeader string) e2e.Expectation {
 }
 func ISRMaintained() e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
-		topic := ctx.GetTopic()
-		client := ctx.GetClient()
-
-		resp, err := client.SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", topic), 5*time.Second)
-		if err != nil {
-			return err
-		}
-
-		var meta topicMetadata
-		if err := json.Unmarshal([]byte(resp), &meta); err != nil {
-			return fmt.Errorf("failed to parse metadata: %w", err)
-		}
-
-		for _, p := range meta.Partitions {
-			if len(p.ISR) == 0 {
-				return fmt.Errorf("ISR is empty for partition %d", p.ID)
+		return eventually(ctx.GetT(), fmt.Sprintf("non-empty ISR for %s", ctx.GetTopic()), clusterReadyTimeout, func() (bool, string, error) {
+			resp, err := ctx.GetClient().SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", ctx.GetTopic()), 5*time.Second)
+			if err != nil {
+				return false, "DESCRIBE failed", err
 			}
-		}
-		return nil
+			var meta topicMetadata
+			if err := json.Unmarshal([]byte(resp), &meta); err != nil {
+				return false, resp, err
+			}
+			for _, partition := range meta.Partitions {
+				if len(partition.ISR) == 0 {
+					return false, fmt.Sprintf("partition %d ISR empty", partition.ID), nil
+				}
+			}
+			return len(meta.Partitions) > 0, "no partitions", nil
+		})
 	}
 }
 

--- a/test/e2e-cluster/expectations.go
+++ b/test/e2e-cluster/expectations.go
@@ -26,34 +26,24 @@ func ExpectDataConsistent() e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
 		topic := ctx.GetTopic()
 		client := ctx.GetClient()
-
-		ctx.GetT().Logf("Verifying data consistency across cluster...")
-
-		resp, err := client.SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", topic), 5*time.Second)
-		if err != nil {
-			return err
-		}
-
-		var meta topicMetadata
-		if err := json.Unmarshal([]byte(resp), &meta); err != nil {
-			return fmt.Errorf("failed to parse metadata: %w", err)
-		}
-
-		for _, p := range meta.Partitions {
-			if len(p.ISR) < 1 {
-				ctx.GetT().Logf("DEBUG: ISR empty for partition %d. Metadata: %+v", p.ID, p)
-				return fmt.Errorf("ISR is empty for partition %d", p.ID)
+		return eventually(ctx.GetT(), fmt.Sprintf("consistent metadata for %s", topic), clusterReadyTimeout, func() (bool, string, error) {
+			resp, err := client.SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", topic), 5*time.Second)
+			if err != nil {
+				return false, "DESCRIBE failed", err
 			}
-			if p.Leader == "" {
-				return fmt.Errorf("leader is empty for partition %d", p.ID)
+			var meta topicMetadata
+			if err := json.Unmarshal([]byte(resp), &meta); err != nil {
+				return false, resp, err
 			}
-		}
-
-		ctx.GetT().Logf("Data consistency metadata verified")
-		return nil
+			for _, partition := range meta.Partitions {
+				if partition.Leader == "" || len(partition.ISR) < 1 {
+					return false, fmt.Sprintf("partition %d leader=%q isr=%v", partition.ID, partition.Leader, partition.ISR), nil
+				}
+			}
+			return len(meta.Partitions) > 0, "no partitions", nil
+		})
 	}
 }
-
 func ExpectPartitionWatermarks(partition int, expectedLEO, expectedHWM uint64) e2e.Expectation {
 	return func(ctx *e2e.TestContext) error {
 		resp, err := ctx.GetClient().SendCommand("", fmt.Sprintf("DESCRIBE topic=%s", ctx.GetTopic()), 5*time.Second)

--- a/test/e2e-cluster/fixture.go
+++ b/test/e2e-cluster/fixture.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cursus-io/cursus/test/e2e"
 )
@@ -87,18 +86,14 @@ func GivenClusterRestart(t *testing.T) *ClusterTestContext {
 	}
 
 	t.Log("Waiting for Raft leader to be elected...")
-	leaderElected := false
-	for i := 0; i < 20; i++ {
+	if err := eventually(t, "Raft leader election", clusterReadyTimeout, func() (bool, string, error) {
 		resp, err := actions.actions.SendCommand("LIST")
-		if err == nil && !strings.Contains(resp, "ERROR:") && !strings.Contains(resp, "unknown") {
-			leaderElected = true
-			break
+		if err != nil {
+			return false, "LIST failed", err
 		}
-		time.Sleep(1 * time.Second)
-	}
-
-	if !leaderElected {
-		t.Fatal("Cluster started but no leader was elected within 20 seconds")
+		return !strings.Contains(resp, "ERROR:") && !strings.Contains(resp, "unknown"), resp, nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 	t.Log("Raft leader elected, cluster ready.")
 

--- a/test/e2e-cluster/wait.go
+++ b/test/e2e-cluster/wait.go
@@ -1,0 +1,41 @@
+package e2e_cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+const (
+	clusterPollInterval = 250 * time.Millisecond
+	clusterReadyTimeout = 30 * time.Second
+)
+
+// eventually waits for a cluster-visible condition rather than baking an
+// election or replication duration into a test. The condition detail is kept
+// in timeout errors for diagnosis.
+func eventually(t *testing.T, description string, timeout time.Duration, condition func() (bool, string, error)) error {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastDetail string
+	var lastErr error
+	for {
+		ok, detail, err := condition()
+		if ok {
+			return nil
+		}
+		if detail != "" {
+			lastDetail = detail
+		}
+		if err != nil {
+			lastErr = err
+		}
+		if time.Now().Add(clusterPollInterval).After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("timed out waiting for %s: %s: %w", description, lastDetail, lastErr)
+			}
+			return fmt.Errorf("timed out waiting for %s: %s", description, lastDetail)
+		}
+		time.Sleep(clusterPollInterval)
+	}
+}

--- a/test/e2e-cluster/wait_test.go
+++ b/test/e2e-cluster/wait_test.go
@@ -1,0 +1,31 @@
+package e2e_cluster
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEventuallyReturnsWhenConditionBecomesReady(t *testing.T) {
+	attempts := 0
+	err := eventually(t, "test condition", time.Second, func() (bool, string, error) {
+		attempts++
+		return attempts == 2, "not ready", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestEventuallyIncludesLastError(t *testing.T) {
+	err := eventually(t, "test condition", clusterPollInterval, func() (bool, string, error) {
+		return false, "broker-1 unavailable", errors.New("connection refused")
+	})
+	if err == nil || !strings.Contains(err.Error(), "broker-1 unavailable") || !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("unexpected timeout error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes N/A (cluster E2E reliability improvement)

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change; no issue-closing reference applies.
- [x] Documentation has been updated as needed (no public documentation change is required for this test-harness refactor).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

## Summary

- Add a reusable, bounded readiness polling helper with unit coverage.
- Replace fixed cluster sleeps with state-based waits for leader election, broker membership, node health, topic metadata, replication, failover, and transaction recovery.
- Centralize timeout diagnostics and remove redundant follower-stop and skipped-test delays.

## Why

The cluster E2E suite encoded readiness through fixed sleeps spread across fixtures, actions, and expectations. Those delays made tests slower on fast hosts and flaky on slower or contended hosts. Polling observable cluster state gives each failure a bounded timeout and behavior-specific diagnostic while preserving the scenarios under test.

## Validation

- `go test ./test/e2e-cluster` (passed in 273.157s)
- `go vet ./test/e2e-cluster`
- `git diff --check upstream/main...HEAD`
- Verified all 12 commits have valid GPG signatures and DCO sign-offs.