### PR TITLE
refactor: make worker cancellation lifecycle explicit

### DIFF
--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -38,7 +38,15 @@ const (
 
 // RunServer starts the broker with optional TLS and gzip
 func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager, cd *coordinator.Coordinator, sm *stream.StreamManager) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	return RunServerContext(context.Background(), cfg, tm, dm, cd, sm)
+}
+
+// RunServerContext starts the broker and shuts it down when ctx is canceled.
+func RunServerContext(ctx context.Context, cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager, cd *coordinator.Coordinator, sm *stream.StreamManager) error {
+	if ctx == nil {
+		return fmt.Errorf("server context must not be nil")
+	}
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	addr := fmt.Sprintf(":%d", cfg.BrokerPort)
@@ -58,6 +66,7 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 	}
 
 	defer func() { _ = ln.Close() }()
+	go closeListenerOnDone(ctx, ln)
 	util.Info("🧩 Broker listening on %s (TLS=%v, Compression=%v)", addr, cfg.UseTLS, cfg.CompressionType)
 
 	if cd != nil {
@@ -246,6 +255,11 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 		healthState.SetReady(true)
 		conn, err := ln.Accept()
 		if err != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			if errors.Is(err, net.ErrClosed) {
 				return fmt.Errorf("broker listener closed: %w", err)
 			}
@@ -263,8 +277,18 @@ func RunServer(cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager,
 			continue
 		}
 		temporaryDelay = 0
-		workerCh <- conn
+		select {
+		case workerCh <- conn:
+		case <-ctx.Done():
+			_ = conn.Close()
+			return ctx.Err()
+		}
 	}
+}
+
+func closeListenerOnDone(ctx context.Context, ln net.Listener) {
+	<-ctx.Done()
+	_ = ln.Close()
 }
 
 func startInternalBrokerListener(ctx context.Context, cfg *config.Config, cmdHandler *controller.CommandHandler) error {

--- a/pkg/server/main_context_test.go
+++ b/pkg/server/main_context_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/config"
+)
+
+func TestCloseListenerOnDone(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go closeListenerOnDone(ctx, ln)
+	cancel()
+
+	acceptDone := make(chan error, 1)
+	go func() {
+		_, acceptErr := ln.Accept()
+		acceptDone <- acceptErr
+	}()
+
+	select {
+	case acceptErr := <-acceptDone:
+		if !errors.Is(acceptErr, net.ErrClosed) {
+			t.Fatalf("expected closed listener error, got %v", acceptErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("listener remained blocked after cancellation")
+	}
+}
+
+func TestRunServerContextRejectsNilContext(t *testing.T) {
+	if err := RunServerContext(nil, nil, nil, nil, nil, nil); err == nil {
+		t.Fatal("expected nil context error")
+	}
+}
+
+func TestRunServerContextReturnsCancellation(t *testing.T) {
+	healthListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	healthPort := healthListener.Addr().(*net.TCPAddr).Port
+	if err := healthListener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.BrokerPort = 0
+	cfg.HealthCheckPort = healthPort
+	cfg.LogDir = t.TempDir()
+	cfg.EnableExporter = false
+	cfg.EnabledDistribution = false
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := RunServerContext(ctx, cfg, nil, nil, nil, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}

--- a/pkg/server/main_context_test.go
+++ b/pkg/server/main_context_test.go
@@ -38,7 +38,8 @@ func TestCloseListenerOnDone(t *testing.T) {
 }
 
 func TestRunServerContextRejectsNilContext(t *testing.T) {
-	if err := RunServerContext(nil, nil, nil, nil, nil, nil); err == nil {
+	var nilContext context.Context
+	if err := RunServerContext(nilContext, nil, nil, nil, nil, nil); err == nil {
 		t.Fatal("expected nil context error")
 	}
 }

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -43,6 +43,7 @@ type Consumer struct {
 
 	mainCtx    context.Context
 	mainCancel context.CancelFunc
+	rootCtx    context.Context
 
 	rebalancing  int32
 	rebalanceSig chan struct{}
@@ -63,6 +64,15 @@ type Consumer struct {
 }
 
 func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
+	return NewConsumerWithContext(context.Background(), cfg)
+}
+
+// NewConsumerWithContext creates a consumer whose worker lifecycle is bounded by ctx.
+// Rebalances derive replacement workers from the same root cancellation source.
+func NewConsumerWithContext(ctx context.Context, cfg *ConsumerConfig) (*Consumer, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("consumer context must not be nil")
+	}
 	if cfg.EnableMetrics {
 		initMetrics()
 	}
@@ -71,7 +81,7 @@ func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create consumer client: %w", err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	workerCtx, cancel := context.WithCancel(ctx)
 
 	c := &Consumer{
 		config:             cfg,
@@ -83,7 +93,8 @@ func NewConsumer(cfg *ConsumerConfig) (*Consumer, error) {
 		commitRetryMap:     make(map[int]uint64),
 		rebalanceSig:       make(chan struct{}, 1),
 		doneCh:             make(chan struct{}),
-		mainCtx:            ctx,
+		mainCtx:            workerCtx,
+		rootCtx:            ctx,
 		mainCancel:         cancel,
 	}
 

--- a/sdk/consumer.go
+++ b/sdk/consumer.go
@@ -48,9 +48,10 @@ type Consumer struct {
 	rebalancing  int32
 	rebalanceSig chan struct{}
 
-	offsets map[int]uint64
-	doneCh  chan struct{}
-	mu      sync.RWMutex
+	offsets   map[int]uint64
+	doneCh    chan struct{}
+	closeDone chan struct{}
+	mu        sync.RWMutex
 
 	partitionLeaders map[int]string
 	partitionMu      sync.RWMutex
@@ -93,6 +94,7 @@ func NewConsumerWithContext(ctx context.Context, cfg *ConsumerConfig) (*Consumer
 		commitRetryMap:     make(map[int]uint64),
 		rebalanceSig:       make(chan struct{}, 1),
 		doneCh:             make(chan struct{}),
+		closeDone:          make(chan struct{}),
 		mainCtx:            workerCtx,
 		rootCtx:            ctx,
 		mainCancel:         cancel,
@@ -817,8 +819,10 @@ func parseFetchOffsetResponse(respStr string) (uint64, error) {
 
 func (c *Consumer) Close() error {
 	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
-		return fmt.Errorf("%w", ErrConsumerClosed)
+		<-c.closeDone
+		return nil
 	}
+	defer close(c.closeDone)
 
 	close(c.doneCh)
 	// Cancel the active consume context and close live sockets so blocked I/O exits promptly.

--- a/sdk/consumer_context_test.go
+++ b/sdk/consumer_context_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestNewConsumerWithContextPropagatesCancellation(t *testing.T) {
@@ -38,5 +39,33 @@ func TestConsumerReplacementContextKeepsRootCancellation(t *testing.T) {
 	case <-consumer.mainCtx.Done():
 	default:
 		t.Fatal("replacement worker context detached from root cancellation")
+	}
+}
+
+func TestConsumerCloseIsIdempotentAndWaitsForShutdown(t *testing.T) {
+	consumer, err := NewConsumer(NewDefaultConsumerConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer.wg.Add(1)
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- consumer.Close() }()
+	<-consumer.Done()
+
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- consumer.Close() }()
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second Close returned before shutdown completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	consumer.wg.Done()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Close failed: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second Close failed: %v", err)
 	}
 }

--- a/sdk/consumer_context_test.go
+++ b/sdk/consumer_context_test.go
@@ -21,7 +21,8 @@ func TestNewConsumerWithContextPropagatesCancellation(t *testing.T) {
 }
 
 func TestNewConsumerWithContextRejectsNilContext(t *testing.T) {
-	if _, err := NewConsumerWithContext(nil, NewDefaultConsumerConfig()); err == nil {
+	var nilContext context.Context
+	if _, err := NewConsumerWithContext(nilContext, NewDefaultConsumerConfig()); err == nil {
 		t.Fatal("expected nil context error")
 	}
 }

--- a/sdk/consumer_context_test.go
+++ b/sdk/consumer_context_test.go
@@ -1,0 +1,42 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewConsumerWithContextPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer, err := NewConsumerWithContext(ctx, NewDefaultConsumerConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	select {
+	case <-consumer.mainCtx.Done():
+	default:
+		t.Fatal("consumer worker context was not canceled")
+	}
+}
+
+func TestNewConsumerWithContextRejectsNilContext(t *testing.T) {
+	if _, err := NewConsumerWithContext(nil, NewDefaultConsumerConfig()); err == nil {
+		t.Fatal("expected nil context error")
+	}
+}
+
+func TestConsumerReplacementContextKeepsRootCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer, err := NewConsumerWithContext(ctx, NewDefaultConsumerConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer.mainCancel()
+	consumer.mainCtx, consumer.mainCancel = context.WithCancel(consumer.rootCtx)
+	cancel()
+	select {
+	case <-consumer.mainCtx.Done():
+	default:
+		t.Fatal("replacement worker context detached from root cancellation")
+	}
+}

--- a/sdk/consumer_group.go
+++ b/sdk/consumer_group.go
@@ -292,7 +292,7 @@ drainDone:
 	c.offsets = make(map[int]uint64)
 	c.mu.Unlock()
 
-	c.mainCtx, c.mainCancel = context.WithCancel(context.Background())
+	c.mainCtx, c.mainCancel = context.WithCancel(c.rootCtx)
 
 	if coordAddr, err := c.findCoordinator(); err == nil {
 		c.mu.Lock()

--- a/sdk/partition_test.go
+++ b/sdk/partition_test.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"context"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -377,15 +376,9 @@ func TestConsumer_ProcessRetryQueue_DuringRebalance(t *testing.T) {
 
 func TestConsumer_Close_AlreadyClosed(t *testing.T) {
 	c := newTestConsumer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	c.mainCtx = ctx
-	c.mainCancel = cancel
 
-	atomic.StoreInt32(&c.closed, 1)
-
-	err := c.Close()
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrConsumerClosed)
+	assert.NoError(t, c.Close())
+	assert.NoError(t, c.Close())
 }
 
 func TestPartitionConsumer_CloseWithConn(t *testing.T) {

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -62,9 +63,11 @@ type Producer struct {
 	partitionLeaders map[int]string
 	partitionMu      sync.RWMutex
 
-	done    chan struct{}
-	closed  int32
-	closeMu sync.Mutex
+	done      chan struct{}
+	closed    int32
+	closeMu   sync.Mutex
+	closeDone chan struct{}
+	closeErr  error
 
 	bmMu         sync.Mutex
 	bmTotalTime  map[int]time.Duration
@@ -73,6 +76,13 @@ type Producer struct {
 }
 
 func NewProducer(cfg *PublisherConfig) (*Producer, error) {
+	return NewProducerWithContext(context.Background(), cfg)
+}
+
+func NewProducerWithContext(ctx context.Context, cfg *PublisherConfig) (*Producer, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("producer context must not be nil")
+	}
 	if cfg == nil {
 		return nil, fmt.Errorf("publisher config is required")
 	}
@@ -94,6 +104,7 @@ func NewProducer(cfg *PublisherConfig) (*Producer, error) {
 		partitions:       cfg.Partitions,
 		buffers:          make([]*partitionBuffer, cfg.Partitions),
 		done:             make(chan struct{}),
+		closeDone:        make(chan struct{}),
 		bmTotalTime:      make(map[int]time.Duration),
 		bmTotalCount:     make(map[int]int),
 		bmLatencies:      make([]time.Duration, 0),
@@ -137,7 +148,18 @@ func NewProducer(cfg *PublisherConfig) (*Producer, error) {
 	}
 
 	go p.batchStateGC()
+	p.closeOnContext(ctx)
 	return p, nil
+}
+
+func (p *Producer) closeOnContext(ctx context.Context) {
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = p.Close()
+		case <-p.done:
+		}
+	}()
 }
 
 func (p *Producer) fetchMetadata() {
@@ -728,15 +750,28 @@ func (p *Producer) batchStateGC() {
 	}
 }
 
-func (p *Producer) Close() error {
+func (p *Producer) Close() (result error) {
 	p.closeMu.Lock()
+	if p.closeDone == nil {
+		p.closeDone = make(chan struct{})
+	}
 	if atomic.LoadInt32(&p.closed) == 1 {
+		closeDone := p.closeDone
 		p.closeMu.Unlock()
-		return nil
+		<-closeDone
+		p.closeMu.Lock()
+		defer p.closeMu.Unlock()
+		return p.closeErr
 	}
 	atomic.StoreInt32(&p.closed, 1)
 	waiters := p.requestDrain(true)
 	p.closeMu.Unlock()
+	defer func() {
+		p.closeMu.Lock()
+		p.closeErr = result
+		close(p.closeDone)
+		p.closeMu.Unlock()
+	}()
 
 	timeout := p.flushTimeout()
 	drained := waitForDrain(waiters, timeout)

--- a/sdk/producer.go
+++ b/sdk/producer.go
@@ -144,6 +144,9 @@ func NewProducerWithContext(ctx context.Context, cfg *PublisherConfig) (*Produce
 		go p.partitionSender(i)
 	}
 	if connectedCount == 0 {
+		if closeErr := p.Close(); closeErr != nil {
+			LogWarn("failed to clean up producer after connection failure: %v", closeErr)
+		}
 		return nil, fmt.Errorf("failed to connect to any partition")
 	}
 

--- a/sdk/producer_context_test.go
+++ b/sdk/producer_context_test.go
@@ -21,7 +21,8 @@ func newProducerLifecycleTestHarness(t *testing.T) *Producer {
 }
 
 func TestNewProducerWithContextRejectsNilContext(t *testing.T) {
-	if _, err := NewProducerWithContext(nil, NewDefaultPublisherConfig()); err == nil {
+	var nilContext context.Context
+	if _, err := NewProducerWithContext(nilContext, NewDefaultPublisherConfig()); err == nil {
 		t.Fatal("expected nil context error")
 	}
 }

--- a/sdk/producer_context_test.go
+++ b/sdk/producer_context_test.go
@@ -1,7 +1,9 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -62,5 +64,31 @@ func TestProducerConcurrentCloseWaitsForShutdown(t *testing.T) {
 	}
 	if err := <-secondDone; err != nil {
 		t.Fatalf("second Close failed: %v", err)
+	}
+}
+
+func producerSenderGoroutines() int {
+	stack := make([]byte, 1<<20)
+	n := runtime.Stack(stack, true)
+	return bytes.Count(stack[:n], []byte("sdk.(*Producer).partitionSender"))
+}
+
+func TestNewProducerCleansUpWorkersWhenAllConnectionsFail(t *testing.T) {
+	before := producerSenderGoroutines()
+	cfg := NewDefaultPublisherConfig()
+	cfg.Topic = "producer-init-failure"
+	cfg.Partitions = 2
+	cfg.BrokerAddrs = []string{"127.0.0.1:0"}
+
+	if producer, err := NewProducer(cfg); err == nil || producer != nil {
+		t.Fatalf("expected connection failure, got producer=%v err=%v", producer, err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for producerSenderGoroutines() > before && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	if after := producerSenderGoroutines(); after > before {
+		t.Fatalf("producer initialization leaked %d sender goroutines", after-before)
 	}
 }

--- a/sdk/producer_context_test.go
+++ b/sdk/producer_context_test.go
@@ -1,0 +1,66 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func newProducerLifecycleTestHarness(t *testing.T) *Producer {
+	t.Helper()
+	cfg := NewDefaultPublisherConfig()
+	return &Producer{
+		config:    cfg,
+		client:    mustNewProducerClient(cfg),
+		gcTicker:  time.NewTicker(time.Hour),
+		done:      make(chan struct{}),
+		closeDone: make(chan struct{}),
+	}
+}
+
+func TestNewProducerWithContextRejectsNilContext(t *testing.T) {
+	if _, err := NewProducerWithContext(nil, NewDefaultPublisherConfig()); err == nil {
+		t.Fatal("expected nil context error")
+	}
+}
+
+func TestProducerContextCancellationClosesProducer(t *testing.T) {
+	producer := newProducerLifecycleTestHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	producer.closeOnContext(ctx)
+	cancel()
+
+	select {
+	case <-producer.done:
+	case <-time.After(time.Second):
+		t.Fatal("producer remained open after context cancellation")
+	}
+	if err := producer.Close(); err != nil {
+		t.Fatalf("repeated Close failed: %v", err)
+	}
+}
+
+func TestProducerConcurrentCloseWaitsForShutdown(t *testing.T) {
+	producer := newProducerLifecycleTestHarness(t)
+	producer.sendersWG.Add(1)
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- producer.Close() }()
+	<-producer.done
+
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- producer.Close() }()
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second Close returned before shutdown completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	producer.sendersWG.Done()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Close failed: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second Close failed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes N/A (worker lifecycle and cancellation improvement)

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change; no issue-closing reference applies.
- [x] Documentation has been updated as needed (no public documentation change is required for this internal lifecycle refactor).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

## Summary

- Bind consumer and producer background workers to caller-owned contexts.
- Propagate the server shutdown context through connection handling.
- Make consumer shutdown idempotent and ensure producer workers are cleaned up when initialization fails.
- Add cancellation, repeated-close, server-context, and producer lifecycle regression tests.

## Why

Consumers, producers, and server connections created background work through separate lifecycle paths, making cancellation ownership implicit and allowing partial initialization failures or repeated close calls to leave inconsistent state. Explicit context propagation and idempotent cleanup make shutdown predictable without changing public wire behavior.

## Validation

- `go test ./sdk ./pkg/server`
- `go vet ./sdk ./pkg/server`
- `git diff --check upstream/main...HEAD`
- `go test -race ./sdk ./pkg/server` was not available in the local Windows environment because Go requires CGO for the race detector; the ordinary test suite passed and CI will provide the supported environment.
- Verified all 5 commits have valid GPG signatures and DCO sign-offs.