### PR TITLE
fix: reconcile distributed topic materialization

### DIFF
--- a/pkg/cluster/controller/runtime.go
+++ b/pkg/cluster/controller/runtime.go
@@ -16,16 +16,25 @@ type PartitionRuntimeSnapshot struct {
 	InSync      int
 }
 
+// MaterializationAttemptsSnapshot counts local convergence attempts by result.
+type MaterializationAttemptsSnapshot struct {
+	Success uint64
+	Failure uint64
+}
+
 // RuntimeSnapshot is a point-in-time view of cluster control state.
 type RuntimeSnapshot struct {
-	Enabled          bool
-	BrokerID         string
-	BrokerCount      int
-	HasLeader        bool
-	IsLeader         bool
-	Offline          int
-	UnderReplicated  int
-	PartitionDetails []PartitionRuntimeSnapshot
+	Enabled                           bool
+	BrokerID                          string
+	BrokerCount                       int
+	HasLeader                         bool
+	IsLeader                          bool
+	Offline                           int
+	UnderReplicated                   int
+	TopicMaterializationsPending      map[string]int
+	TopicMaterializationAttempts      map[string]MaterializationAttemptsSnapshot
+	TopicMaterializationOldestPending float64
+	PartitionDetails                  []PartitionRuntimeSnapshot
 }
 
 // RuntimeSnapshot returns cluster metadata without exposing mutable FSM state.
@@ -46,6 +55,19 @@ func (cc *ClusterController) RuntimeSnapshot() RuntimeSnapshot {
 	}
 
 	snapshot.BrokerCount = len(fsmState.GetBrokers())
+	materialization := fsmState.TopicMaterializationRuntimeSnapshot()
+	snapshot.TopicMaterializationsPending = make(map[string]int, len(materialization.PendingByOperation))
+	for operation, count := range materialization.PendingByOperation {
+		snapshot.TopicMaterializationsPending[operation] = count
+	}
+	snapshot.TopicMaterializationAttempts = make(map[string]MaterializationAttemptsSnapshot, len(materialization.AttemptsByOperation))
+	for operation, attempts := range materialization.AttemptsByOperation {
+		snapshot.TopicMaterializationAttempts[operation] = MaterializationAttemptsSnapshot{
+			Success: attempts.Success,
+			Failure: attempts.Failure,
+		}
+	}
+	snapshot.TopicMaterializationOldestPending = materialization.OldestPending.Seconds()
 	keys := fsmState.GetAllPartitionKeys()
 	sort.Strings(keys)
 	for _, key := range keys {

--- a/pkg/cluster/controller/runtime_materialization_test.go
+++ b/pkg/cluster/controller/runtime_materialization_test.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+type runtimeFailingHandlerProvider struct{}
+
+func (runtimeFailingHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	return nil, errors.New("injected disk failure")
+}
+
+func TestRuntimeSnapshotIncludesTopicMaterializationState(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	topicManager := topic.NewTopicManager(cfg, runtimeFailingHandlerProvider{}, nil)
+	brokerFSM := fsm.NewBrokerFSM(topicManager, nil)
+	broker, err := json.Marshal(fsm.BrokerInfo{ID: "broker-1", Addr: "127.0.0.1:9000", Status: "active"})
+	require.NoError(t, err)
+	require.Nil(t, brokerFSM.Apply(&raft.Log{Data: []byte(fmt.Sprintf("REGISTER:%s", broker)), Index: 1}))
+	command, err := json.Marshal(fsm.TopicCommand{Name: "orders", Partitions: 1, ReplicationFactor: 1, Policy: topic.DefaultPolicy()})
+	require.NoError(t, err)
+	require.Error(t, brokerFSM.Apply(&raft.Log{Data: []byte("TOPIC:" + string(command)), Index: 2}).(error))
+
+	manager := &ComprehensiveMockRaftManager{isLeader: true, mockFSM: brokerFSM}
+	manager.On("GetLeaderAddress").Return("broker-1:9001").Once()
+	controller := &ClusterController{RaftManager: manager, brokerID: "broker-1"}
+
+	snapshot := controller.RuntimeSnapshot()
+	require.Equal(t, 1, snapshot.TopicMaterializationsPending[fsm.TopicMaterializationCreate])
+	require.Equal(t, uint64(1), snapshot.TopicMaterializationAttempts[fsm.TopicMaterializationCreate].Failure)
+	require.GreaterOrEqual(t, snapshot.TopicMaterializationOldestPending, float64(0))
+}

--- a/pkg/cluster/replication/fsm/fsm.go
+++ b/pkg/cluster/replication/fsm/fsm.go
@@ -67,8 +67,9 @@ type BrokerFSMState struct {
 }
 
 type BrokerFSM struct {
-	notifiers map[string]chan interface{}
-	mu        sync.RWMutex
+	notifiers         map[string]chan interface{}
+	mu                sync.RWMutex
+	materializationMu sync.Mutex
 
 	logs              map[uint64]*ReplicationEntry
 	brokers           map[string]*BrokerInfo
@@ -81,18 +82,22 @@ type BrokerFSM struct {
 	txn                      *transaction.Manager
 	restoredTransactionState map[string]*transaction.Snapshot
 	topicState               map[string]*topic.Definition
+	topicMaterialization     map[string]TopicMaterializationIssue
+	topicMaterializationRuns map[string]TopicMaterializationAttempts
 }
 
 func NewBrokerFSM(tm *topic.TopicManager, cd *coordinator.Coordinator) *BrokerFSM {
 	return &BrokerFSM{
-		notifiers:         make(map[string]chan interface{}),
-		logs:              make(map[uint64]*ReplicationEntry),
-		brokers:           make(map[string]*BrokerInfo),
-		partitionMetadata: make(map[string]*PartitionMetadata),
-		producerState:     make(map[string]map[int]map[string]ProducerSequence),
-		topicState:        make(map[string]*topic.Definition),
-		tm:                tm,
-		cd:                cd,
+		notifiers:                make(map[string]chan interface{}),
+		logs:                     make(map[uint64]*ReplicationEntry),
+		brokers:                  make(map[string]*BrokerInfo),
+		partitionMetadata:        make(map[string]*PartitionMetadata),
+		producerState:            make(map[string]map[int]map[string]ProducerSequence),
+		topicState:               make(map[string]*topic.Definition),
+		topicMaterialization:     make(map[string]TopicMaterializationIssue),
+		topicMaterializationRuns: make(map[string]TopicMaterializationAttempts),
+		tm:                       tm,
+		cd:                       cd,
 	}
 }
 
@@ -242,24 +247,63 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 		}
 		restoredTopicState = legacyTopicState(state.PartitionMetadata)
 	}
-	definitions, err := validateTopicState(restoredTopicState, state.PartitionMetadata)
+	_, err := validateTopicState(restoredTopicState, state.PartitionMetadata)
 	if err != nil {
 		return fmt.Errorf("restore topic definitions: %w", err)
 	}
+	f.materializationMu.Lock()
+	localDefinitions := []topic.Definition(nil)
+	persistedTopicStorage := []string(nil)
 	if f.tm != nil {
-		if err := f.tm.RestoreDefinitions(definitions); err != nil {
-			return fmt.Errorf("restore topic registry: %w", err)
+		localDefinitions = f.tm.ExportDefinitions()
+		persistedTopicStorage, err = f.tm.PersistedTopicStorageNames()
+		if err != nil {
+			f.materializationMu.Unlock()
+			return fmt.Errorf("inspect local topic storage before restore: %w", err)
 		}
 	}
 
 	f.mu.Lock()
+	previousMaterialization := f.topicMaterialization
 
 	f.logs = state.Logs
 	f.brokers = state.Brokers
 	f.partitionMetadata = state.PartitionMetadata
 	f.topicState = restoredTopicState
+	f.topicMaterialization = make(map[string]TopicMaterializationIssue, len(restoredTopicState))
+	now := time.Now()
+	for name := range restoredTopicState {
+		f.topicMaterialization[name] = TopicMaterializationIssue{
+			Topic: name, Operation: TopicMaterializationRestore, PendingSince: now,
+		}
+	}
+	for _, definition := range localDefinitions {
+		if restoredTopicState[definition.Name] == nil {
+			f.topicMaterialization[definition.Name] = TopicMaterializationIssue{
+				Topic: definition.Name, Operation: TopicMaterializationDelete, PendingSince: now,
+			}
+		}
+	}
+	for _, name := range persistedTopicStorage {
+		if restoredTopicState[name] == nil {
+			f.topicMaterialization[name] = TopicMaterializationIssue{
+				Topic: name, Operation: TopicMaterializationDelete, PendingSince: now,
+			}
+		}
+	}
+	for name, issue := range previousMaterialization {
+		if issue.Operation != TopicMaterializationDelete || restoredTopicState[name] != nil {
+			continue
+		}
+		if issue.PendingSince.IsZero() {
+			issue.PendingSince = now
+		}
+		f.topicMaterialization[name] = issue
+	}
+	if f.topicMaterializationRuns == nil {
+		f.topicMaterializationRuns = make(map[string]TopicMaterializationAttempts)
+	}
 	f.applied = state.Applied
-
 	f.producerState = state.ProducerState
 	if f.producerState == nil {
 		f.producerState = make(map[string]map[int]map[string]ProducerSequence)
@@ -293,6 +337,10 @@ func (f *BrokerFSM) Restore(rc io.ReadCloser) error {
 	}
 
 	f.mu.Unlock()
+	f.materializationMu.Unlock()
+	if err := f.ReconcileTopicMaterializations(); err != nil {
+		util.Warn("FSM Restore: Topic materialization pending: %v", err)
+	}
 	if state.Version >= 5 {
 		f.reconcileCommittedPartitions()
 	}

--- a/pkg/cluster/replication/fsm/fsm_command.go
+++ b/pkg/cluster/replication/fsm/fsm_command.go
@@ -57,136 +57,138 @@ func (f *BrokerFSM) applyTopicCommand(jsonData string) interface{} {
 	topicCmd.EventSourcing = definition.EventSourcing
 	topicCmd.Policy = definition.Policy
 
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	stageResult := func() interface{} {
+		f.mu.Lock()
+		defer f.mu.Unlock()
 
-	stagedTopics := copyTopicState(f.topicState)
-	stagedPartitions := copyPartitionMetadataState(f.partitionMetadata)
-	currentPartitions := 0
-	currentTopic := stagedTopics[topicCmd.Name]
-	if currentTopic == nil {
-		currentTopic = legacyTopicState(stagedPartitions)[topicCmd.Name]
-	}
-	if currentTopic != nil {
-		if topicCmd.Partitions < currentTopic.Partitions {
-			return fmt.Errorf("cannot decrease partition count for topic %q: %d -> %d", topicCmd.Name, currentTopic.Partitions, topicCmd.Partitions)
+		stagedTopics := copyTopicState(f.topicState)
+		stagedPartitions := copyPartitionMetadataState(f.partitionMetadata)
+		currentPartitions := 0
+		currentTopic := stagedTopics[topicCmd.Name]
+		if currentTopic == nil {
+			currentTopic = legacyTopicState(stagedPartitions)[topicCmd.Name]
 		}
-		currentPartitions = currentTopic.Partitions
-		topicCmd.Idempotent = currentTopic.Idempotent
-		topicCmd.EventSourcing = currentTopic.EventSourcing
-	}
-
-	var brokers []string
-	for id, info := range f.brokers {
-		if info.Status == "active" {
-			brokers = append(brokers, id)
+		if currentTopic != nil {
+			if topicCmd.Partitions < currentTopic.Partitions {
+				return fmt.Errorf("cannot decrease partition count for topic %q: %d -> %d", topicCmd.Name, currentTopic.Partitions, topicCmd.Partitions)
+			}
+			currentPartitions = currentTopic.Partitions
+			topicCmd.Idempotent = currentTopic.Idempotent
+			topicCmd.EventSourcing = currentTopic.EventSourcing
 		}
-	}
-	sort.Strings(brokers)
 
-	if len(brokers) == 0 {
-		util.Error("FSM: No active brokers available for topic creation")
-		return fmt.Errorf("no active brokers")
-	}
-
-	if topicCmd.Partitions <= 0 {
-		util.Error("FSM: Invalid partition count %d for topic %s", topicCmd.Partitions, topicCmd.Name)
-		return fmt.Errorf("invalid partition count: %d", topicCmd.Partitions)
-	}
-
-	if topicCmd.LeaderID != "" {
-		found := false
-		for _, b := range brokers {
-			if b == topicCmd.LeaderID {
-				found = true
-				break
+		var brokers []string
+		for id, info := range f.brokers {
+			if info.Status == "active" {
+				brokers = append(brokers, id)
 			}
 		}
-		if !found {
-			util.Error("FSM: Explicit leader %s not in active broker set %v", topicCmd.LeaderID, brokers)
-			return fmt.Errorf("leader %s not in active broker set", topicCmd.LeaderID)
+		sort.Strings(brokers)
+
+		if len(brokers) == 0 {
+			util.Error("FSM: No active brokers available for topic creation")
+			return fmt.Errorf("no active brokers")
 		}
-	}
 
-	replicationFactor := topicCmd.ReplicationFactor
-	if replicationFactor <= 0 {
-		replicationFactor = 3 // default small-cluster replication factor
-	}
-	if replicationFactor > len(brokers) {
-		util.Warn("FSM: Requested RF %d exceeds active brokers %d. Capping to %d", replicationFactor, len(brokers), len(brokers))
-		replicationFactor = len(brokers)
-	}
-	topicCmd.ReplicationFactor = replicationFactor
-
-	ring := util.NewConsistentHashRing(150, nil)
-	ring.Add(brokers...)
-
-	for i := 0; i < currentPartitions; i++ {
-		key := topicCmd.Name + "-" + strconv.Itoa(i)
-		if stagedPartitions[key] == nil {
-			return fmt.Errorf("topic %q is missing partition metadata %d", topicCmd.Name, i)
+		if topicCmd.Partitions <= 0 {
+			util.Error("FSM: Invalid partition count %d for topic %s", topicCmd.Partitions, topicCmd.Name)
+			return fmt.Errorf("invalid partition count: %d", topicCmd.Partitions)
 		}
-	}
-	for i := 0; i < currentPartitions; i++ {
-		key := topicCmd.Name + "-" + strconv.Itoa(i)
-		stagedPartitions[key].PartitionCount = topicCmd.Partitions
-	}
 
-	for i := currentPartitions; i < topicCmd.Partitions; i++ {
-		key := topicCmd.Name + "-" + strconv.Itoa(i)
-
-		assignedLeader := topicCmd.LeaderID
-		var replicas []string
-		if assignedLeader == "" {
-			replicas = ring.GetN(key, replicationFactor)
-			if len(replicas) == 0 {
-				return fmt.Errorf("no replicas assigned for partition %s", key)
-			}
-			assignedLeader = replicas[0]
-		} else {
-			// Explicit leader: build replica set starting from leader
-			replicas = ring.GetN(key, replicationFactor)
-			// Ensure the explicit leader is in the replica set
-			leaderFound := false
-			for _, r := range replicas {
-				if r == assignedLeader {
-					leaderFound = true
+		if topicCmd.LeaderID != "" {
+			found := false
+			for _, b := range brokers {
+				if b == topicCmd.LeaderID {
+					found = true
 					break
 				}
 			}
-			if !leaderFound {
-				replicas[len(replicas)-1] = assignedLeader
+			if !found {
+				util.Error("FSM: Explicit leader %s not in active broker set %v", topicCmd.LeaderID, brokers)
+				return fmt.Errorf("leader %s not in active broker set", topicCmd.LeaderID)
 			}
 		}
 
-		isrCopy := append([]string(nil), replicas...)
-
-		stagedPartitions[key] = &PartitionMetadata{
-			PartitionCount: topicCmd.Partitions,
-			Leader:         assignedLeader,
-			LeaderEpoch:    1,
-			Idempotent:     topicCmd.Idempotent,
-			Replicas:       replicas,
-			ISR:            isrCopy,
+		replicationFactor := topicCmd.ReplicationFactor
+		if replicationFactor <= 0 {
+			replicationFactor = 3 // default small-cluster replication factor
 		}
-		util.Info("FSM: Assigned leader %s to partition %s (replicas=%v)", assignedLeader, key, replicas)
+		if replicationFactor > len(brokers) {
+			util.Warn("FSM: Requested RF %d exceeds active brokers %d. Capping to %d", replicationFactor, len(brokers), len(brokers))
+			replicationFactor = len(brokers)
+		}
+		topicCmd.ReplicationFactor = replicationFactor
+
+		ring := util.NewConsistentHashRing(150, nil)
+		ring.Add(brokers...)
+
+		for i := 0; i < currentPartitions; i++ {
+			key := topicCmd.Name + "-" + strconv.Itoa(i)
+			if stagedPartitions[key] == nil {
+				return fmt.Errorf("topic %q is missing partition metadata %d", topicCmd.Name, i)
+			}
+		}
+		for i := 0; i < currentPartitions; i++ {
+			key := topicCmd.Name + "-" + strconv.Itoa(i)
+			stagedPartitions[key].PartitionCount = topicCmd.Partitions
+		}
+
+		for i := currentPartitions; i < topicCmd.Partitions; i++ {
+			key := topicCmd.Name + "-" + strconv.Itoa(i)
+
+			assignedLeader := topicCmd.LeaderID
+			var replicas []string
+			if assignedLeader == "" {
+				replicas = ring.GetN(key, replicationFactor)
+				if len(replicas) == 0 {
+					return fmt.Errorf("no replicas assigned for partition %s", key)
+				}
+				assignedLeader = replicas[0]
+			} else {
+				// Explicit leader: build replica set starting from leader
+				replicas = ring.GetN(key, replicationFactor)
+				// Ensure the explicit leader is in the replica set
+				leaderFound := false
+				for _, r := range replicas {
+					if r == assignedLeader {
+						leaderFound = true
+						break
+					}
+				}
+				if !leaderFound {
+					replicas[len(replicas)-1] = assignedLeader
+				}
+			}
+
+			isrCopy := append([]string(nil), replicas...)
+
+			stagedPartitions[key] = &PartitionMetadata{
+				PartitionCount: topicCmd.Partitions,
+				Leader:         assignedLeader,
+				LeaderEpoch:    1,
+				Idempotent:     topicCmd.Idempotent,
+				Replicas:       replicas,
+				ISR:            isrCopy,
+			}
+			util.Info("FSM: Assigned leader %s to partition %s (replicas=%v)", assignedLeader, key, replicas)
+		}
+
+		definition.Idempotent = topicCmd.Idempotent
+		definition.EventSourcing = topicCmd.EventSourcing
+		stagedTopics[topicCmd.Name] = copyTopicDefinition(&definition)
+		f.partitionMetadata = stagedPartitions
+		f.topicState = stagedTopics
+		return nil
+	}()
+	if stageResult != nil {
+		return stageResult
 	}
 
-	definition.Idempotent = topicCmd.Idempotent
-	definition.EventSourcing = topicCmd.EventSourcing
-	stagedTopics[topicCmd.Name] = copyTopicDefinition(&definition)
-	tm := f.tm
-
-	if tm != nil {
-		if err := tm.CreateTopicWithPolicy(topicCmd.Name, topicCmd.Partitions, topicCmd.Idempotent, topicCmd.EventSourcing, topicCmd.Policy); err != nil {
-			util.Error("FSM: Failed to create topic '%s' in local manager: %v", topicCmd.Name, err)
-			return err
-		}
+	if err := f.materializeTopicCreate(&definition); err != nil {
+		util.Error("FSM: Failed to create topic '%s' in local manager: %v", topicCmd.Name, err)
+		return err
 	}
-	f.partitionMetadata = stagedPartitions
-	f.topicState = stagedTopics
 	util.Info("FSM: Created topic '%s' with %d partitions", topicCmd.Name, topicCmd.Partitions)
-
 	return nil
 }
 
@@ -202,40 +204,36 @@ func (f *BrokerFSM) applyTopicDeleteCommand(jsonData string) interface{} {
 		return fmt.Errorf("invalid topic name: %w", err)
 	}
 
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	stageResult := func() interface{} {
+		f.mu.Lock()
+		defer f.mu.Unlock()
 
-	found := f.topicState[payload.Topic] != nil
-	for key := range f.partitionMetadata {
-		if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
-			found = true
+		found := f.topicState[payload.Topic] != nil
+		for key := range f.partitionMetadata {
+			if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
+				found = true
+			}
 		}
-	}
-	if !found {
-		return fmt.Errorf("%w: %s", topic.ErrTopicNotFound, payload.Topic)
-	}
-
-	tm := f.tm
-	if tm != nil {
-		deleted, err := tm.DeleteTopicDurable(payload.Topic)
-		if err != nil {
-			return fmt.Errorf("delete local topic %q: %w", payload.Topic, err)
-		}
-		if !deleted {
+		if !found {
 			return fmt.Errorf("%w: %s", topic.ErrTopicNotFound, payload.Topic)
 		}
-	} else if !found {
-		return fmt.Errorf("%w: %s", topic.ErrTopicNotFound, payload.Topic)
-	}
 
-	for key := range f.partitionMetadata {
-		if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
-			delete(f.partitionMetadata, key)
+		for key := range f.partitionMetadata {
+			if idx := strings.LastIndex(key, "-"); idx != -1 && key[:idx] == payload.Topic {
+				delete(f.partitionMetadata, key)
+			}
 		}
+		delete(f.topicState, payload.Topic)
+		return nil
+	}()
+	if stageResult != nil {
+		return stageResult
 	}
-	delete(f.topicState, payload.Topic)
-	util.Info("FSM: Deleted topic '%s'", payload.Topic)
 
+	if err := f.materializeTopicDelete(payload.Topic); err != nil {
+		return err
+	}
+	util.Info("FSM: Deleted topic '%s'", payload.Topic)
 	return nil
 }
 

--- a/pkg/cluster/replication/fsm/fsm_topic_integrity_test.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_integrity_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cursus-io/cursus/pkg/config"
@@ -17,14 +18,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type failingTopicHandlerProvider struct{}
-
-func (failingTopicHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
-	return nil, errors.New("open partition failed")
+type recoverableTopicHandlerProvider struct {
+	fail atomic.Bool
 }
 
-func TestBrokerFSMTopicCreateFailureLeavesMetadataUnchanged(t *testing.T) {
-	manager := topic.NewTopicManager(config.DefaultConfig(), failingTopicHandlerProvider{}, nil)
+func (p *recoverableTopicHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	if p.fail.Load() {
+		return nil, errors.New("open partition failed")
+	}
+	return &MockStorageHandler{}, nil
+}
+
+func TestBrokerFSMTopicCreateFailureCommitsDesiredStateAndReconciles(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	provider := &recoverableTopicHandlerProvider{}
+	provider.fail.Store(true)
+	manager := topic.NewTopicManager(cfg, provider, nil)
 	f := NewBrokerFSM(manager, nil)
 	registerActiveBroker(t, f, "broker-1")
 
@@ -40,12 +50,21 @@ func TestBrokerFSMTopicCreateFailureLeavesMetadataUnchanged(t *testing.T) {
 	applyErr, ok := result.(error)
 	require.True(t, ok)
 	require.ErrorContains(t, applyErr, "open partition failed")
-	require.Nil(t, f.GetPartitionMetadata("orders-0"))
-	require.Nil(t, f.topicState["orders"])
+	require.NotNil(t, f.GetPartitionMetadata("orders-0"))
+	require.NotNil(t, f.topicState["orders"])
 	require.Nil(t, manager.GetTopic("orders"))
+	require.Error(t, f.TopicMaterializationReadinessError())
+	require.Len(t, f.TopicMaterializationIssues(), 1)
+	require.Equal(t, TopicMaterializationCreate, f.TopicMaterializationIssues()[0].Operation)
+
+	provider.fail.Store(false)
+	require.NoError(t, f.ReconcileTopicMaterializations())
+	require.NotNil(t, manager.GetTopic("orders"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
+	require.Empty(t, f.TopicMaterializationIssues())
 }
 
-func TestBrokerFSMDeleteFailurePreservesMetadataAndRegistry(t *testing.T) {
+func TestBrokerFSMDeleteFailureCommitsDesiredStateAndReconciles(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.LogDir = t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(cfg.LogDir, topic.TopicMetadataFileName), 0o750))
@@ -73,9 +92,15 @@ func TestBrokerFSMDeleteFailurePreservesMetadataAndRegistry(t *testing.T) {
 	applyErr, ok := result.(error)
 	require.True(t, ok)
 	require.ErrorContains(t, applyErr, "delete local topic")
-	require.NotNil(t, f.GetPartitionMetadata("orders-0"))
-	require.NotNil(t, f.topicState["orders"])
+	require.Nil(t, f.GetPartitionMetadata("orders-0"))
+	require.Nil(t, f.topicState["orders"])
 	require.NotNil(t, manager.GetTopic("orders"))
+	require.Error(t, f.TopicMaterializationReadinessError())
+
+	require.NoError(t, os.RemoveAll(filepath.Join(cfg.LogDir, topic.TopicMetadataFileName)))
+	require.NoError(t, f.ReconcileTopicMaterializations())
+	require.Nil(t, manager.GetTopic("orders"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
 }
 
 func TestBrokerFSMDeleteMissingTopicReturnsNotFound(t *testing.T) {
@@ -139,4 +164,57 @@ func TestBrokerFSMRestoreRejectsTopicMetadataConflicts(t *testing.T) {
 			require.ErrorContains(t, err, tt.want)
 		})
 	}
+}
+
+func TestBrokerFSMRestoreDefersLocalTopicMaterializationFailure(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	provider := &recoverableTopicHandlerProvider{}
+	provider.fail.Store(true)
+	manager := topic.NewTopicManager(cfg, provider, nil)
+	f := NewBrokerFSM(manager, nil)
+	state := BrokerFSMState{
+		Version: 6,
+		TopicState: map[string]*topic.Definition{
+			"orders": {Name: "orders", Partitions: 1, Policy: topic.DefaultPolicy()},
+		},
+		PartitionMetadata: map[string]*PartitionMetadata{
+			"orders-0": {PartitionCount: 1},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	require.NoError(t, f.Restore(io.NopCloser(bytes.NewReader(data))))
+	require.NotNil(t, f.GetPartitionMetadata("orders-0"))
+	require.Nil(t, manager.GetTopic("orders"))
+	require.Error(t, f.TopicMaterializationReadinessError())
+
+	provider.fail.Store(false)
+	require.NoError(t, f.ReconcileTopicMaterializations())
+	require.NotNil(t, manager.GetTopic("orders"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
+}
+
+func TestBrokerFSMDeleteSupersedesPendingCreateWithoutLocalTopic(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	provider := &recoverableTopicHandlerProvider{}
+	provider.fail.Store(true)
+	manager := topic.NewTopicManager(cfg, provider, nil)
+	f := NewBrokerFSM(manager, nil)
+	registerActiveBroker(t, f, "broker-1")
+
+	command, err := json.Marshal(TopicCommand{
+		Name: "orders", Partitions: 1, ReplicationFactor: 1, Policy: topic.DefaultPolicy(),
+	})
+	require.NoError(t, err)
+	require.Error(t, f.Apply(&raft.Log{Data: []byte("TOPIC:" + string(command)), Index: 2}).(error))
+	require.Error(t, f.TopicMaterializationReadinessError())
+
+	result := f.Apply(&raft.Log{Data: []byte(`TOPIC_DELETE:{"topic":"orders"}`), Index: 3})
+	require.Nil(t, result)
+	require.Nil(t, f.GetPartitionMetadata("orders-0"))
+	require.Nil(t, manager.GetTopic("orders"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
 }

--- a/pkg/cluster/replication/fsm/fsm_topic_materialization.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_materialization.go
@@ -1,0 +1,250 @@
+package fsm
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+const (
+	TopicMaterializationCreate  = "create"
+	TopicMaterializationRestore = "restore"
+	TopicMaterializationDelete  = "delete"
+)
+
+// TopicMaterializationIssue describes node-local work that has not converged
+// with the authoritative topic state committed by Raft.
+type TopicMaterializationIssue struct {
+	Topic        string    `json:"topic"`
+	Operation    string    `json:"operation"`
+	Error        string    `json:"error"`
+	PendingSince time.Time `json:"pending_since"`
+}
+
+// TopicMaterializationAttempts counts completed node-local attempts by result.
+type TopicMaterializationAttempts struct {
+	Success uint64
+	Failure uint64
+}
+
+// TopicMaterializationRuntimeSnapshot is a detached operational view of local
+// topic convergence.
+type TopicMaterializationRuntimeSnapshot struct {
+	PendingByOperation  map[string]int
+	AttemptsByOperation map[string]TopicMaterializationAttempts
+	OldestPending       time.Duration
+}
+
+func (f *BrokerFSM) TopicMaterializationIssues() []TopicMaterializationIssue {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	issues := make([]TopicMaterializationIssue, 0, len(f.topicMaterialization))
+	for _, issue := range f.topicMaterialization {
+		issues = append(issues, issue)
+	}
+	sort.Slice(issues, func(i, j int) bool { return issues[i].Topic < issues[j].Topic })
+	return issues
+}
+
+// TopicMaterializationRuntimeSnapshot returns aggregate metrics without
+// exposing mutable FSM maps.
+func (f *BrokerFSM) TopicMaterializationRuntimeSnapshot() TopicMaterializationRuntimeSnapshot {
+	snapshot := TopicMaterializationRuntimeSnapshot{
+		PendingByOperation:  make(map[string]int),
+		AttemptsByOperation: make(map[string]TopicMaterializationAttempts),
+	}
+	if f == nil {
+		return snapshot
+	}
+
+	now := time.Now()
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, issue := range f.topicMaterialization {
+		snapshot.PendingByOperation[issue.Operation]++
+		if issue.PendingSince.IsZero() {
+			continue
+		}
+		age := now.Sub(issue.PendingSince)
+		if age < 0 {
+			age = 0
+		}
+		if age > snapshot.OldestPending {
+			snapshot.OldestPending = age
+		}
+	}
+	for operation, attempts := range f.topicMaterializationRuns {
+		snapshot.AttemptsByOperation[operation] = attempts
+	}
+	return snapshot
+}
+
+func (f *BrokerFSM) TopicMaterializationReadinessError() error {
+	issues := f.TopicMaterializationIssues()
+	if len(issues) == 0 {
+		return nil
+	}
+	first := issues[0]
+	if first.Error == "" {
+		return fmt.Errorf("%d topic materialization operation(s) pending: %s %s", len(issues), first.Operation, first.Topic)
+	}
+	return fmt.Errorf("%d topic materialization operation(s) pending: %s %s: %s", len(issues), first.Operation, first.Topic, first.Error)
+}
+
+// ReconcileTopicMaterializations retries node-local operations against the
+// authoritative desired state. Calls are serialized with Apply side effects.
+func (f *BrokerFSM) ReconcileTopicMaterializations() error {
+	f.mu.RLock()
+	desired := make(map[string]*topic.Definition)
+	deletes := make([]string, 0)
+	for name, issue := range f.topicMaterialization {
+		switch issue.Operation {
+		case TopicMaterializationCreate, TopicMaterializationRestore:
+			desired[name] = copyTopicDefinition(f.topicState[name])
+		case TopicMaterializationDelete:
+			deletes = append(deletes, name)
+		}
+	}
+	f.mu.RUnlock()
+
+	names := make([]string, 0, len(desired))
+	for name := range desired {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	sort.Strings(deletes)
+
+	var reconcileErr error
+	for _, name := range names {
+		f.mu.RLock()
+		operation := f.topicMaterialization[name].Operation
+		f.mu.RUnlock()
+		var err error
+		if operation == TopicMaterializationRestore {
+			err = f.materializeTopicRestore(desired[name])
+		} else {
+			err = f.materializeTopicCreate(desired[name])
+		}
+		if err != nil {
+			reconcileErr = errors.Join(reconcileErr, err)
+		}
+	}
+	for _, name := range deletes {
+		if err := f.materializeTopicDelete(name); err != nil {
+			reconcileErr = errors.Join(reconcileErr, err)
+		}
+	}
+	return reconcileErr
+}
+
+func (f *BrokerFSM) materializeTopicCreate(definition *topic.Definition) error {
+	if definition == nil || f.tm == nil {
+		return nil
+	}
+
+	f.materializationMu.Lock()
+	defer f.materializationMu.Unlock()
+
+	f.mu.RLock()
+	current := copyTopicDefinition(f.topicState[definition.Name])
+	f.mu.RUnlock()
+	if !reflect.DeepEqual(current, definition) {
+		return nil
+	}
+
+	err := f.tm.CreateTopicWithPolicy(definition.Name, definition.Partitions, definition.Idempotent, definition.EventSourcing, definition.Policy)
+	f.recordTopicMaterialization(definition.Name, TopicMaterializationCreate, err)
+	if err != nil {
+		return fmt.Errorf("materialize topic %q: %w", definition.Name, err)
+	}
+	return nil
+}
+
+func (f *BrokerFSM) materializeTopicRestore(definition *topic.Definition) error {
+	if definition == nil {
+		return nil
+	}
+	if f.tm == nil {
+		f.recordTopicMaterialization(definition.Name, TopicMaterializationRestore, nil)
+		return nil
+	}
+
+	f.materializationMu.Lock()
+	defer f.materializationMu.Unlock()
+
+	f.mu.RLock()
+	current := copyTopicDefinition(f.topicState[definition.Name])
+	f.mu.RUnlock()
+	if !reflect.DeepEqual(current, definition) {
+		return nil
+	}
+
+	err := f.tm.RestoreDefinitions([]topic.Definition{*definition})
+	f.recordTopicMaterialization(definition.Name, TopicMaterializationRestore, err)
+	if err != nil {
+		return fmt.Errorf("restore local topic %q: %w", definition.Name, err)
+	}
+	return nil
+}
+
+func (f *BrokerFSM) materializeTopicDelete(name string) error {
+	if f.tm == nil {
+		f.recordTopicMaterialization(name, TopicMaterializationDelete, nil)
+		return nil
+	}
+
+	f.materializationMu.Lock()
+	defer f.materializationMu.Unlock()
+
+	f.mu.RLock()
+	desired := f.topicState[name]
+	f.mu.RUnlock()
+	if desired != nil {
+		return nil
+	}
+
+	deleted, err := f.tm.DeleteTopicDurable(name)
+	if err == nil && !deleted {
+		err = f.tm.CleanupTopicStorage(name)
+	}
+	f.recordTopicMaterialization(name, TopicMaterializationDelete, err)
+	if err != nil {
+		return fmt.Errorf("delete local topic %q: %w", name, err)
+	}
+	return nil
+}
+
+func (f *BrokerFSM) recordTopicMaterialization(name, operation string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.topicMaterialization == nil {
+		f.topicMaterialization = make(map[string]TopicMaterializationIssue)
+	}
+	if f.topicMaterializationRuns == nil {
+		f.topicMaterializationRuns = make(map[string]TopicMaterializationAttempts)
+	}
+	attempts := f.topicMaterializationRuns[operation]
+	if err == nil {
+		attempts.Success++
+		f.topicMaterializationRuns[operation] = attempts
+		delete(f.topicMaterialization, name)
+		return
+	}
+	attempts.Failure++
+	f.topicMaterializationRuns[operation] = attempts
+	pendingSince := time.Now()
+	if existing, ok := f.topicMaterialization[name]; ok && !existing.PendingSince.IsZero() {
+		pendingSince = existing.PendingSince
+	}
+	f.topicMaterialization[name] = TopicMaterializationIssue{
+		Topic:        name,
+		Operation:    operation,
+		Error:        err.Error(),
+		PendingSince: pendingSince,
+	}
+}

--- a/pkg/cluster/replication/fsm/fsm_topic_materialization_ext_test.go
+++ b/pkg/cluster/replication/fsm/fsm_topic_materialization_ext_test.go
@@ -1,0 +1,199 @@
+package fsm
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingTopicHandlerProvider struct {
+	started sync.Once
+	ready   chan struct{}
+	release chan struct{}
+}
+
+func (p *blockingTopicHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	p.started.Do(func() { close(p.ready) })
+	<-p.release
+	return &MockStorageHandler{}, nil
+}
+
+type recoverableCleanupHandlerProvider struct {
+	fail atomic.Bool
+}
+
+func (p *recoverableCleanupHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	return &MockStorageHandler{}, nil
+}
+
+func (p *recoverableCleanupHandlerProvider) RemoveTopicStorage(path string) error {
+	if p.fail.Load() {
+		return errors.New("injected physical cleanup failure")
+	}
+	return os.RemoveAll(path)
+}
+
+func emptyTopicSnapshot(t *testing.T) io.ReadCloser {
+	t.Helper()
+	data, err := json.Marshal(BrokerFSMState{
+		Version:           6,
+		TopicState:        map[string]*topic.Definition{},
+		PartitionMetadata: map[string]*PartitionMetadata{},
+	})
+	require.NoError(t, err)
+	return io.NopCloser(bytes.NewReader(data))
+}
+
+func TestBrokerFSMRestoreRemovesLocalTopicMissingFromSnapshot(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnabledDistribution = true
+	cfg.LogDir = t.TempDir()
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := topic.NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("stale", 1, false, false))
+	f := NewBrokerFSM(manager, nil)
+
+	require.NoError(t, f.Restore(emptyTopicSnapshot(t)))
+	require.Nil(t, manager.GetTopic("stale"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
+}
+
+func TestBrokerFSMRestorePreservesPendingDeleteUntilRetrySucceeds(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := topic.NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("stale", 1, false, false))
+
+	manifestPath := filepath.Join(cfg.LogDir, topic.TopicMetadataFileName)
+	require.NoError(t, os.Remove(manifestPath))
+	require.NoError(t, os.Mkdir(manifestPath, 0o750))
+
+	f := NewBrokerFSM(manager, nil)
+	f.topicMaterialization["stale"] = TopicMaterializationIssue{
+		Topic: "stale", Operation: TopicMaterializationDelete, Error: "previous failure", PendingSince: time.Now().Add(-time.Minute),
+	}
+
+	require.NoError(t, f.Restore(emptyTopicSnapshot(t)))
+	require.Error(t, f.TopicMaterializationReadinessError())
+	require.Equal(t, TopicMaterializationDelete, f.TopicMaterializationIssues()[0].Operation)
+
+	require.NoError(t, os.RemoveAll(manifestPath))
+	require.NoError(t, f.ReconcileTopicMaterializations())
+	require.Nil(t, manager.GetTopic("stale"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
+}
+
+func TestBrokerFSMRestoreSerializesWithReconcileAndCleansStaleResult(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnabledDistribution = true
+	cfg.LogDir = t.TempDir()
+	provider := &blockingTopicHandlerProvider{ready: make(chan struct{}), release: make(chan struct{})}
+	manager := topic.NewTopicManager(cfg, provider, nil)
+	f := NewBrokerFSM(manager, nil)
+	definition := &topic.Definition{Name: "stale", Partitions: 1, Policy: topic.DefaultPolicy()}
+	f.topicState[definition.Name] = definition
+	f.topicMaterialization[definition.Name] = TopicMaterializationIssue{
+		Topic: definition.Name, Operation: TopicMaterializationCreate, Error: "pending", PendingSince: time.Now(),
+	}
+
+	reconcileDone := make(chan error, 1)
+	go func() { reconcileDone <- f.ReconcileTopicMaterializations() }()
+	<-provider.ready
+
+	restoreInput := emptyTopicSnapshot(t)
+	restoreDone := make(chan error, 1)
+	go func() { restoreDone <- f.Restore(restoreInput) }()
+	select {
+	case err := <-restoreDone:
+		t.Fatalf("restore bypassed materialization barrier: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(provider.release)
+	require.NoError(t, <-reconcileDone)
+	require.NoError(t, <-restoreDone)
+	require.Nil(t, manager.GetTopic("stale"))
+	require.NoError(t, f.TopicMaterializationReadinessError())
+}
+
+func TestTopicMaterializationRuntimeSnapshotCountsResultsAndAge(t *testing.T) {
+	f := NewBrokerFSM(nil, nil)
+	f.topicMaterialization["orders"] = TopicMaterializationIssue{
+		Topic: "orders", Operation: TopicMaterializationCreate, Error: errors.New("disk").Error(), PendingSince: time.Now().Add(-time.Second),
+	}
+	f.topicMaterializationRuns[TopicMaterializationCreate] = TopicMaterializationAttempts{Success: 2, Failure: 3}
+
+	snapshot := f.TopicMaterializationRuntimeSnapshot()
+	require.Equal(t, 1, snapshot.PendingByOperation[TopicMaterializationCreate])
+	require.Equal(t, uint64(2), snapshot.AttemptsByOperation[TopicMaterializationCreate].Success)
+	require.Equal(t, uint64(3), snapshot.AttemptsByOperation[TopicMaterializationCreate].Failure)
+	require.GreaterOrEqual(t, snapshot.OldestPending, time.Second)
+}
+
+func TestBrokerFSMPhysicalCleanupFailureRemainsPendingUntilRetry(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnabledDistribution = true
+	cfg.LogDir = t.TempDir()
+	provider := &recoverableCleanupHandlerProvider{}
+	provider.fail.Store(true)
+	manager := topic.NewTopicManager(cfg, provider, nil)
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+	f := NewBrokerFSM(manager, nil)
+	definition := topic.Definition{Name: "orders", Partitions: 1, Policy: topic.DefaultPolicy()}
+	f.topicState["orders"] = copyTopicDefinition(&definition)
+	f.partitionMetadata["orders-0"] = &PartitionMetadata{PartitionCount: 1}
+
+	result := f.Apply(&raft.Log{Data: []byte(`TOPIC_DELETE:{"topic":"orders"}`), Index: 1})
+	applyErr, ok := result.(error)
+	require.True(t, ok)
+	require.ErrorContains(t, applyErr, "injected physical cleanup failure")
+	require.Nil(t, f.topicState["orders"])
+	require.Nil(t, manager.GetTopic("orders"))
+	require.Error(t, f.TopicMaterializationReadinessError())
+	require.Equal(t, TopicMaterializationDelete, f.TopicMaterializationIssues()[0].Operation)
+
+	provider.fail.Store(false)
+	require.NoError(t, f.ReconcileTopicMaterializations())
+	require.NoError(t, f.TopicMaterializationReadinessError())
+	require.NoDirExists(t, filepath.Join(cfg.LogDir, "orders"))
+}
+
+func TestBrokerFSMRestoreCleansPersistedTopicMissingFromRegistryAndSnapshot(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnabledDistribution = true
+	cfg.LogDir = t.TempDir()
+	staleDir := filepath.Join(cfg.LogDir, "stale")
+	require.NoError(t, os.MkdirAll(staleDir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(staleDir, "partition_0_segment_00000000000000000000.log"),
+		nil,
+		0o600,
+	))
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := topic.NewTopicManager(cfg, dm, nil)
+	require.Empty(t, manager.ExportDefinitions())
+	f := NewBrokerFSM(manager, nil)
+
+	require.NoError(t, f.Restore(emptyTopicSnapshot(t)))
+	require.NoDirExists(t, staleDir)
+	require.NoError(t, f.TopicMaterializationReadinessError())
+}

--- a/pkg/cluster/replication/manager.go
+++ b/pkg/cluster/replication/manager.go
@@ -185,10 +185,25 @@ func NewRaftReplicationManager(ctx context.Context, cfg *config.Config, brokerID
 	go rm.isrManager.Start()
 
 	go rm.observeLeadership(notifyCh)
+	go rm.reconcileTopicMaterializations(ctx, 5*time.Second)
 
 	return rm, nil
 }
 
+func (rm *RaftReplicationManager) reconcileTopicMaterializations(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := rm.fsm.ReconcileTopicMaterializations(); err != nil {
+				util.Warn("Topic materialization reconcile pending on broker %s: %v", rm.brokerID, err)
+			}
+		}
+	}
+}
 func (rm *RaftReplicationManager) observeLeadership(notifyCh <-chan bool) {
 	for isLeader := range notifyCh {
 		rm.isLeader.Store(isLeader)

--- a/pkg/cluster/replication/materialization_reconcile_test.go
+++ b/pkg/cluster/replication/materialization_reconcile_test.go
@@ -1,0 +1,66 @@
+package replication
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/topic"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+type loopRecoverableHandlerProvider struct{ fail atomic.Bool }
+
+func (p *loopRecoverableHandlerProvider) GetHandler(string, int) (types.StorageHandler, error) {
+	if p.fail.Load() {
+		return nil, errors.New("injected disk failure")
+	}
+	return &MockStorageHandler{}, nil
+}
+
+func TestReconcileTopicMaterializationsLoopRetriesAndStops(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	provider := &loopRecoverableHandlerProvider{}
+	provider.fail.Store(true)
+	manager := topic.NewTopicManager(cfg, provider, nil)
+	brokerFSM := fsm.NewBrokerFSM(manager, nil)
+
+	broker, err := json.Marshal(fsm.BrokerInfo{ID: "broker-1", Addr: "127.0.0.1:9000", Status: "active"})
+	require.NoError(t, err)
+	require.Nil(t, brokerFSM.Apply(&raft.Log{Data: []byte(fmt.Sprintf("REGISTER:%s", broker)), Index: 1}))
+	command, err := json.Marshal(fsm.TopicCommand{Name: "orders", Partitions: 1, ReplicationFactor: 1, Policy: topic.DefaultPolicy()})
+	require.NoError(t, err)
+	require.Error(t, brokerFSM.Apply(&raft.Log{Data: []byte("TOPIC:" + string(command)), Index: 2}).(error))
+
+	rm := &RaftReplicationManager{fsm: brokerFSM, brokerID: "broker-1"}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		rm.reconcileTopicMaterializations(ctx, 5*time.Millisecond)
+		close(done)
+	}()
+
+	provider.fail.Store(false)
+	require.Eventually(t, func() bool {
+		return brokerFSM.TopicMaterializationReadinessError() == nil && manager.GetTopic("orders") != nil
+	}, time.Second, 10*time.Millisecond)
+	snapshot := brokerFSM.TopicMaterializationRuntimeSnapshot()
+	require.GreaterOrEqual(t, snapshot.AttemptsByOperation[fsm.TopicMaterializationCreate].Failure, uint64(1))
+	require.GreaterOrEqual(t, snapshot.AttemptsByOperation[fsm.TopicMaterializationCreate].Success, uint64(1))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reconcile loop did not stop after context cancellation")
+	}
+}

--- a/pkg/observability/collector.go
+++ b/pkg/observability/collector.go
@@ -48,77 +48,83 @@ type Collector struct {
 	readiness   ReadinessSource
 	descriptors []*prometheus.Desc
 
-	ready                  *prometheus.Desc
-	topicCount             *prometheus.Desc
-	partitionCount         *prometheus.Desc
-	logStart               *prometheus.Desc
-	logEnd                 *prometheus.Desc
-	highWatermark          *prometheus.Desc
-	groupMembers           *prometheus.Desc
-	groupGeneration        *prometheus.Desc
-	groupAssignments       *prometheus.Desc
-	groupCommittedOffset   *prometheus.Desc
-	groupLag               *prometheus.Desc
-	legacyGroupLag         *prometheus.Desc
-	groupOffsetOutOfRange  *prometheus.Desc
-	activeStreams          *prometheus.Desc
-	storageHandlers        *prometheus.Desc
-	storageSegments        *prometheus.Desc
-	storageBytes           *prometheus.Desc
-	storagePendingWrites   *prometheus.Desc
-	storageActiveReaders   *prometheus.Desc
-	storageStatFailures    *prometheus.Desc
-	distributionEnabled    *prometheus.Desc
-	clusterBrokers         *prometheus.Desc
-	clusterHasLeader       *prometheus.Desc
-	clusterIsLeader        *prometheus.Desc
-	clusterOffline         *prometheus.Desc
-	clusterUnderReplicated *prometheus.Desc
-	partitionReplicas      *prometheus.Desc
-	partitionInSync        *prometheus.Desc
-	partitionLeaderEpoch   *prometheus.Desc
-	partitionLeader        *prometheus.Desc
+	ready                        *prometheus.Desc
+	topicCount                   *prometheus.Desc
+	partitionCount               *prometheus.Desc
+	logStart                     *prometheus.Desc
+	logEnd                       *prometheus.Desc
+	highWatermark                *prometheus.Desc
+	groupMembers                 *prometheus.Desc
+	groupGeneration              *prometheus.Desc
+	groupAssignments             *prometheus.Desc
+	groupCommittedOffset         *prometheus.Desc
+	groupLag                     *prometheus.Desc
+	legacyGroupLag               *prometheus.Desc
+	groupOffsetOutOfRange        *prometheus.Desc
+	activeStreams                *prometheus.Desc
+	storageHandlers              *prometheus.Desc
+	storageSegments              *prometheus.Desc
+	storageBytes                 *prometheus.Desc
+	storagePendingWrites         *prometheus.Desc
+	storageActiveReaders         *prometheus.Desc
+	storageStatFailures          *prometheus.Desc
+	distributionEnabled          *prometheus.Desc
+	clusterBrokers               *prometheus.Desc
+	clusterHasLeader             *prometheus.Desc
+	clusterIsLeader              *prometheus.Desc
+	clusterOffline               *prometheus.Desc
+	clusterUnderReplicated       *prometheus.Desc
+	topicMaterializationPending  *prometheus.Desc
+	topicMaterializationAttempts *prometheus.Desc
+	topicMaterializationOldest   *prometheus.Desc
+	partitionReplicas            *prometheus.Desc
+	partitionInSync              *prometheus.Desc
+	partitionLeaderEpoch         *prometheus.Desc
+	partitionLeader              *prometheus.Desc
 }
 
 // NewCollector creates a broker runtime collector. Nil sources are supported.
 func NewCollector(topics topicSource, groups groupSource, diskState diskSource, streams streamSource, cluster clusterSource, readiness ReadinessSource) *Collector {
 	c := &Collector{
-		topics:                 topics,
-		groups:                 groups,
-		disk:                   diskState,
-		streams:                streams,
-		cluster:                cluster,
-		readiness:              readiness,
-		ready:                  prometheus.NewDesc("cursus_broker_ready", "Whether the broker is ready to accept client work.", nil, nil),
-		topicCount:             prometheus.NewDesc("cursus_broker_topics", "Number of topics loaded by this broker.", nil, nil),
-		partitionCount:         prometheus.NewDesc("cursus_broker_partitions", "Number of topic partitions loaded by this broker.", nil, nil),
-		logStart:               prometheus.NewDesc("cursus_partition_log_start_offset", "Earliest retained offset for a partition.", []string{"topic", "partition"}, nil),
-		logEnd:                 prometheus.NewDesc("cursus_partition_log_end_offset", "Next offset allocated in a partition.", []string{"topic", "partition"}, nil),
-		highWatermark:          prometheus.NewDesc("cursus_partition_high_watermark", "Next offset visible to committed readers.", []string{"topic", "partition"}, nil),
-		groupMembers:           prometheus.NewDesc("cursus_consumer_group_members", "Active members in a consumer group.", []string{"group", "topic"}, nil),
-		groupGeneration:        prometheus.NewDesc("cursus_consumer_group_generation", "Current consumer group generation.", []string{"group", "topic"}, nil),
-		groupAssignments:       prometheus.NewDesc("cursus_consumer_group_assigned_partitions", "Partitions assigned to active group members.", []string{"group", "topic"}, nil),
-		groupCommittedOffset:   prometheus.NewDesc("cursus_consumer_group_committed_offset", "Committed next offset for a consumer group partition.", []string{"group", "topic", "partition"}, nil),
-		groupLag:               prometheus.NewDesc("cursus_consumer_group_lag", "Committed-reader lag, max(high watermark - committed next offset, 0).", []string{"group", "topic", "partition"}, nil),
-		legacyGroupLag:         prometheus.NewDesc("broker_consumer_lag", "Deprecated alias of cursus_consumer_group_lag.", []string{"topic", "partition", "group"}, nil),
-		groupOffsetOutOfRange:  prometheus.NewDesc("cursus_consumer_group_offset_out_of_range", "Whether a committed offset is outside the retained committed-readable range.", []string{"group", "topic", "partition"}, nil),
-		activeStreams:          prometheus.NewDesc("cursus_streams_active", "Currently registered streaming consumers.", nil, nil),
-		storageHandlers:        prometheus.NewDesc("cursus_storage_handlers", "Open partition storage handlers.", nil, nil),
-		storageSegments:        prometheus.NewDesc("cursus_storage_segments", "Open storage segments including active segments.", nil, nil),
-		storageBytes:           prometheus.NewDesc("cursus_storage_bytes", "Bytes used by segment and offset index files for open handlers.", nil, nil),
-		storagePendingWrites:   prometheus.NewDesc("cursus_storage_pending_writes", "Messages waiting in storage write queues.", nil, nil),
-		storageActiveReaders:   prometheus.NewDesc("cursus_storage_active_readers", "Readers currently accessing storage segments.", nil, nil),
-		storageStatFailures:    prometheus.NewDesc("cursus_storage_stat_failures", "Storage files that could not be inspected during this scrape.", nil, nil),
-		distributionEnabled:    prometheus.NewDesc("cursus_distribution_enabled", "Whether distributed cluster mode is enabled.", nil, nil),
-		clusterBrokers:         prometheus.NewDesc("cursus_cluster_brokers", "Brokers present in replicated cluster metadata.", nil, nil),
-		clusterHasLeader:       prometheus.NewDesc("cursus_cluster_has_leader", "Whether this broker can resolve the cluster leader.", nil, nil),
-		clusterIsLeader:        prometheus.NewDesc("cursus_cluster_is_leader", "Whether this broker is the current cluster leader.", nil, nil),
-		clusterOffline:         prometheus.NewDesc("cursus_cluster_offline_partitions", "Partitions without an assigned leader.", nil, nil),
-		clusterUnderReplicated: prometheus.NewDesc("cursus_cluster_under_replicated_partitions", "Partitions whose in-sync replica count is below their replica count.", nil, nil),
-		partitionReplicas:      prometheus.NewDesc("cursus_cluster_partition_replicas", "Configured replica count for a partition.", []string{"topic", "partition"}, nil),
-		partitionInSync:        prometheus.NewDesc("cursus_cluster_partition_in_sync_replicas", "In-sync replica count for a partition.", []string{"topic", "partition"}, nil),
-		partitionLeaderEpoch:   prometheus.NewDesc("cursus_cluster_partition_leader_epoch", "Current partition leader epoch.", []string{"topic", "partition"}, nil),
-		partitionLeader:        prometheus.NewDesc("cursus_cluster_partition_leader", "Current partition leader identity.", []string{"topic", "partition", "broker_id"}, nil),
+		topics:                       topics,
+		groups:                       groups,
+		disk:                         diskState,
+		streams:                      streams,
+		cluster:                      cluster,
+		readiness:                    readiness,
+		ready:                        prometheus.NewDesc("cursus_broker_ready", "Whether the broker is ready to accept client work.", nil, nil),
+		topicCount:                   prometheus.NewDesc("cursus_broker_topics", "Number of topics loaded by this broker.", nil, nil),
+		partitionCount:               prometheus.NewDesc("cursus_broker_partitions", "Number of topic partitions loaded by this broker.", nil, nil),
+		logStart:                     prometheus.NewDesc("cursus_partition_log_start_offset", "Earliest retained offset for a partition.", []string{"topic", "partition"}, nil),
+		logEnd:                       prometheus.NewDesc("cursus_partition_log_end_offset", "Next offset allocated in a partition.", []string{"topic", "partition"}, nil),
+		highWatermark:                prometheus.NewDesc("cursus_partition_high_watermark", "Next offset visible to committed readers.", []string{"topic", "partition"}, nil),
+		groupMembers:                 prometheus.NewDesc("cursus_consumer_group_members", "Active members in a consumer group.", []string{"group", "topic"}, nil),
+		groupGeneration:              prometheus.NewDesc("cursus_consumer_group_generation", "Current consumer group generation.", []string{"group", "topic"}, nil),
+		groupAssignments:             prometheus.NewDesc("cursus_consumer_group_assigned_partitions", "Partitions assigned to active group members.", []string{"group", "topic"}, nil),
+		groupCommittedOffset:         prometheus.NewDesc("cursus_consumer_group_committed_offset", "Committed next offset for a consumer group partition.", []string{"group", "topic", "partition"}, nil),
+		groupLag:                     prometheus.NewDesc("cursus_consumer_group_lag", "Committed-reader lag, max(high watermark - committed next offset, 0).", []string{"group", "topic", "partition"}, nil),
+		legacyGroupLag:               prometheus.NewDesc("broker_consumer_lag", "Deprecated alias of cursus_consumer_group_lag.", []string{"topic", "partition", "group"}, nil),
+		groupOffsetOutOfRange:        prometheus.NewDesc("cursus_consumer_group_offset_out_of_range", "Whether a committed offset is outside the retained committed-readable range.", []string{"group", "topic", "partition"}, nil),
+		activeStreams:                prometheus.NewDesc("cursus_streams_active", "Currently registered streaming consumers.", nil, nil),
+		storageHandlers:              prometheus.NewDesc("cursus_storage_handlers", "Open partition storage handlers.", nil, nil),
+		storageSegments:              prometheus.NewDesc("cursus_storage_segments", "Open storage segments including active segments.", nil, nil),
+		storageBytes:                 prometheus.NewDesc("cursus_storage_bytes", "Bytes used by segment and offset index files for open handlers.", nil, nil),
+		storagePendingWrites:         prometheus.NewDesc("cursus_storage_pending_writes", "Messages waiting in storage write queues.", nil, nil),
+		storageActiveReaders:         prometheus.NewDesc("cursus_storage_active_readers", "Readers currently accessing storage segments.", nil, nil),
+		storageStatFailures:          prometheus.NewDesc("cursus_storage_stat_failures", "Storage files that could not be inspected during this scrape.", nil, nil),
+		distributionEnabled:          prometheus.NewDesc("cursus_distribution_enabled", "Whether distributed cluster mode is enabled.", nil, nil),
+		clusterBrokers:               prometheus.NewDesc("cursus_cluster_brokers", "Brokers present in replicated cluster metadata.", nil, nil),
+		clusterHasLeader:             prometheus.NewDesc("cursus_cluster_has_leader", "Whether this broker can resolve the cluster leader.", nil, nil),
+		clusterIsLeader:              prometheus.NewDesc("cursus_cluster_is_leader", "Whether this broker is the current cluster leader.", nil, nil),
+		clusterOffline:               prometheus.NewDesc("cursus_cluster_offline_partitions", "Partitions without an assigned leader.", nil, nil),
+		clusterUnderReplicated:       prometheus.NewDesc("cursus_cluster_under_replicated_partitions", "Partitions whose in-sync replica count is below their replica count.", nil, nil),
+		topicMaterializationPending:  prometheus.NewDesc("cursus_cluster_topic_materializations_pending", "Node-local topic materialization operations waiting to converge.", []string{"operation"}, nil),
+		topicMaterializationAttempts: prometheus.NewDesc("cursus_cluster_topic_materialization_attempts_total", "Node-local topic materialization attempts by operation and result.", []string{"operation", "result"}, nil),
+		topicMaterializationOldest:   prometheus.NewDesc("cursus_cluster_topic_materialization_oldest_pending_seconds", "Age of the oldest pending node-local topic materialization.", nil, nil),
+		partitionReplicas:            prometheus.NewDesc("cursus_cluster_partition_replicas", "Configured replica count for a partition.", []string{"topic", "partition"}, nil),
+		partitionInSync:              prometheus.NewDesc("cursus_cluster_partition_in_sync_replicas", "In-sync replica count for a partition.", []string{"topic", "partition"}, nil),
+		partitionLeaderEpoch:         prometheus.NewDesc("cursus_cluster_partition_leader_epoch", "Current partition leader epoch.", []string{"topic", "partition"}, nil),
+		partitionLeader:              prometheus.NewDesc("cursus_cluster_partition_leader", "Current partition leader identity.", []string{"topic", "partition", "broker_id"}, nil),
 	}
 	c.descriptors = []*prometheus.Desc{
 		c.ready, c.topicCount, c.partitionCount, c.logStart, c.logEnd, c.highWatermark,
@@ -126,7 +132,8 @@ func NewCollector(topics topicSource, groups groupSource, diskState diskSource, 
 		c.groupLag, c.legacyGroupLag, c.groupOffsetOutOfRange, c.activeStreams, c.storageHandlers,
 		c.storageSegments, c.storageBytes, c.storagePendingWrites, c.storageActiveReaders,
 		c.storageStatFailures, c.distributionEnabled, c.clusterBrokers, c.clusterHasLeader,
-		c.clusterIsLeader, c.clusterOffline, c.clusterUnderReplicated, c.partitionReplicas,
+		c.clusterIsLeader, c.clusterOffline, c.clusterUnderReplicated, c.topicMaterializationPending,
+		c.topicMaterializationAttempts, c.topicMaterializationOldest, c.partitionReplicas,
 		c.partitionInSync, c.partitionLeaderEpoch, c.partitionLeader,
 	}
 	return c
@@ -258,6 +265,13 @@ func (c *Collector) collectCluster(ch chan<- prometheus.Metric) {
 	ch <- gauge(c.clusterIsLeader, boolValue(state.IsLeader))
 	ch <- gauge(c.clusterOffline, float64(state.Offline))
 	ch <- gauge(c.clusterUnderReplicated, float64(state.UnderReplicated))
+	for _, operation := range []string{"create", "restore", "delete"} {
+		ch <- gauge(c.topicMaterializationPending, float64(state.TopicMaterializationsPending[operation]), operation)
+		attempts := state.TopicMaterializationAttempts[operation]
+		ch <- counter(c.topicMaterializationAttempts, float64(attempts.Success), operation, "success")
+		ch <- counter(c.topicMaterializationAttempts, float64(attempts.Failure), operation, "failure")
+	}
+	ch <- gauge(c.topicMaterializationOldest, state.TopicMaterializationOldestPending)
 	for _, partition := range state.PartitionDetails {
 		partitionLabel := strconv.Itoa(partition.Partition)
 		ch <- gauge(c.partitionReplicas, float64(partition.Replicas), partition.Topic, partitionLabel)
@@ -280,6 +294,9 @@ func boolValue(value bool) float64 {
 	return 0
 }
 
+func counter(desc *prometheus.Desc, value float64, labels ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(desc, prometheus.CounterValue, value, labels...)
+}
 func gauge(desc *prometheus.Desc, value float64, labels ...string) prometheus.Metric {
 	return prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, value, labels...)
 }

--- a/pkg/observability/collector_test.go
+++ b/pkg/observability/collector_test.go
@@ -67,6 +67,11 @@ func TestCollectorExportsScrapeTimeBrokerState(t *testing.T) {
 		fixedStreams(2),
 		fixedCluster{snapshot: clustercontroller.RuntimeSnapshot{
 			Enabled: true, BrokerCount: 3, HasLeader: true, IsLeader: true, UnderReplicated: 1,
+			TopicMaterializationsPending: map[string]int{"create": 2},
+			TopicMaterializationAttempts: map[string]clustercontroller.MaterializationAttemptsSnapshot{
+				"create": {Success: 4, Failure: 3},
+			},
+			TopicMaterializationOldestPending: 12.5,
 			PartitionDetails: []clustercontroller.PartitionRuntimeSnapshot{{
 				Topic: "orders", Partition: 0, Leader: "broker-1", LeaderEpoch: 4, Replicas: 3, InSync: 2,
 			}},
@@ -90,9 +95,30 @@ func TestCollectorExportsScrapeTimeBrokerState(t *testing.T) {
 	assertGauge(t, families, "cursus_storage_bytes", nil, 4096)
 	assertGauge(t, families, "cursus_streams_active", nil, 2)
 	assertGauge(t, families, "cursus_cluster_under_replicated_partitions", nil, 1)
+	assertGauge(t, families, "cursus_cluster_topic_materializations_pending", map[string]string{"operation": "create"}, 2)
+	assertCounter(t, families, "cursus_cluster_topic_materialization_attempts_total", map[string]string{"operation": "create", "result": "success"}, 4)
+	assertCounter(t, families, "cursus_cluster_topic_materialization_attempts_total", map[string]string{"operation": "create", "result": "failure"}, 3)
+	assertGauge(t, families, "cursus_cluster_topic_materialization_oldest_pending_seconds", nil, 12.5)
 	assertGauge(t, families, "cursus_cluster_partition_leader", map[string]string{"topic": "orders", "partition": "0", "broker_id": "broker-1"}, 1)
 }
 
+func assertCounter(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string, want float64) {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if labelsMatch(metric.Label, labels) {
+				if got := metric.GetCounter().GetValue(); got != want {
+					t.Fatalf("%s%v = %v, want %v", name, labels, got, want)
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("metric %s%v not found", name, labels)
+}
 func assertGauge(t *testing.T, families []*dto.MetricFamily, name string, labels map[string]string, want float64) {
 	t.Helper()
 	for _, family := range families {

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -205,6 +205,12 @@ func RunServerContext(ctx context.Context, cfg *config.Config, tm *topic.TopicMa
 			_, leaderErr := cc.GetClusterLeader()
 			return leaderErr
 		})
+		healthState.AddCheck("topic_materialization", func(context.Context) error {
+			if cc == nil || cc.RaftManager == nil || cc.RaftManager.GetFSM() == nil {
+				return fmt.Errorf("topic materialization state unavailable")
+			}
+			return cc.RaftManager.GetFSM().TopicMaterializationReadinessError()
+		})
 	}
 
 	runtimeCollector := observability.NewCollector(tm, cd, dm, sm, cc, healthState)

--- a/pkg/topic/cleanup_retry_test.go
+++ b/pkg/topic/cleanup_retry_test.go
@@ -1,0 +1,49 @@
+package topic
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicStorageCleanupFailureCanBeRetriedAfterLogicalDelete(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnabledDistribution = true
+	cfg.LogDir = t.TempDir()
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+
+	originalRemove := removeTopicStorageFn
+	fail := true
+	removeTopicStorageFn = func(path string) error {
+		if fail {
+			return errors.New("injected cleanup failure")
+		}
+		return os.RemoveAll(path)
+	}
+	t.Cleanup(func() { removeTopicStorageFn = originalRemove })
+
+	deleted, err := manager.DeleteTopicDurable("orders")
+	require.True(t, deleted)
+	require.ErrorContains(t, err, "injected cleanup failure")
+	require.Nil(t, manager.GetTopic("orders"))
+	require.DirExists(t, filepath.Join(cfg.LogDir, "orders"))
+
+	fail = false
+	require.NoError(t, manager.CleanupTopicStorage("orders"))
+	require.NoDirExists(t, filepath.Join(cfg.LogDir, "orders"))
+	require.NoError(t, manager.CleanupTopicStorage("orders"))
+
+	require.NoError(t, manager.CreateTopic("payments", 1, false, false))
+	fail = true
+	require.True(t, manager.DeleteTopic("payments"), "logical deletion must remain visible when only cleanup fails")
+	fail = false
+	require.NoError(t, manager.CleanupTopicStorage("payments"))
+}

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -19,6 +19,8 @@ import (
 
 var ErrTopicNotFound = errors.New("topic not found")
 
+var removeTopicStorageFn = os.RemoveAll
+
 type StreamManager interface {
 	AddStream(key string, streamConn *stream.StreamConnection, readFn func(offset uint64, max int) ([]types.Message, error), legacyCommitInterval time.Duration) error
 	RemoveStream(key string)
@@ -49,6 +51,10 @@ type existingPartitionProvider interface {
 
 type topicHandlerCloser interface {
 	CloseTopicHandlers(topic string)
+}
+
+type topicStorageRemover interface {
+	RemoveTopicStorage(path string) error
 }
 
 func (tm *TopicManager) SetCoordinator(cd *coordinator.Coordinator) {
@@ -405,7 +411,7 @@ func (tm *TopicManager) DeleteTopic(name string) bool {
 	deleted, err := tm.DeleteTopicDurable(name)
 	if err != nil {
 		util.Warn("Failed to durably delete topic %s: %v", name, err)
-		return false
+		return deleted
 	}
 	return deleted
 }
@@ -441,12 +447,33 @@ func (tm *TopicManager) DeleteTopicDurable(name string) (bool, error) {
 		}
 	}
 	if err := tm.deleteTopicLogDirLocked(name); err != nil {
-		// The durable definition removal is already committed. Keep the command
-		// result aligned with the logical state and leave physical cleanup for an
-		// operator or a later retry instead of reporting a false rollback.
-		util.Warn("Failed to clean log directory for deleted topic %s: %v", name, err)
+		return true, fmt.Errorf("clean topic storage %q: %w", name, err)
 	}
 	return true, nil
+}
+
+// CleanupTopicStorage retries the idempotent physical cleanup that follows a
+// logically committed topic deletion. It is safe to call after the topic has
+// already disappeared from the in-memory registry.
+func (tm *TopicManager) CleanupTopicStorage(name string) error {
+	if err := ValidateName(name); err != nil {
+		return fmt.Errorf("invalid topic name: %w", err)
+	}
+	if tm == nil {
+		return nil
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if tm.topics[name] != nil {
+		return fmt.Errorf("topic %q still has an active definition", name)
+	}
+	if closer, ok := tm.hp.(topicHandlerCloser); ok {
+		closer.CloseTopicHandlers(name)
+	}
+	if err := tm.deleteTopicLogDirLocked(name); err != nil {
+		return fmt.Errorf("clean topic storage %q: %w", name, err)
+	}
+	return nil
 }
 func (tm *TopicManager) deleteTopicLogDirLocked(name string) error {
 	if tm.cfg == nil || strings.TrimSpace(tm.cfg.LogDir) == "" {
@@ -468,7 +495,10 @@ func (tm *TopicManager) deleteTopicLogDirLocked(name string) error {
 	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
 		return fmt.Errorf("refusing to delete topic path outside log root: %s", target)
 	}
-	return os.RemoveAll(target)
+	if remover, ok := tm.hp.(topicStorageRemover); ok {
+		return remover.RemoveTopicStorage(target)
+	}
+	return removeTopicStorageFn(target)
 }
 
 func (tm *TopicManager) ListTopics() []string {

--- a/pkg/topic/metadata_consistency.go
+++ b/pkg/topic/metadata_consistency.go
@@ -62,6 +62,16 @@ func (s *topicMetadataStore) orphanedTopicDirectories(manifestTopics map[string]
 	return orphaned, nil
 }
 
+// PersistedTopicStorageNames returns topic directories that contain partition
+// logs without opening handlers. Distributed snapshot restore uses this to
+// resume cleanup work even after an in-memory delete issue was lost on restart.
+func (tm *TopicManager) PersistedTopicStorageNames() ([]string, error) {
+	if tm == nil || tm.cfg == nil || strings.TrimSpace(tm.cfg.LogDir) == "" {
+		return nil, nil
+	}
+	store := &topicMetadataStore{path: filepath.Join(tm.cfg.LogDir, TopicMetadataFileName)}
+	return store.orphanedTopicDirectories(nil)
+}
 func hasPersistedPartitionLog(path string) (bool, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {


### PR DESCRIPTION
Fixes N/A

Reconciles node-local topic storage with Raft-authoritative metadata after create, delete, retry, and snapshot restore operations. Local materialization failures now remain pending, make the node not ready, retry periodically, and expose bounded operational metrics without rolling back committed cluster metadata.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (no issue number is available).
- [x] Documentation has been updated as needed (no documentation change is required for this internal consistency fix).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.