### PR TITLE
feat: add pre-manifest storage migration CLI

### DIFF
--- a/cmd/storage/help_test.go
+++ b/cmd/storage/help_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunHelpReturnsSuccess(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	require.Equal(t, 0, run([]string{"--help"}, &stdout, &stderr))
+	require.Contains(t, stdout.String(), "manifest create")
+	require.Empty(t, stderr.String())
+
+	stdout.Reset()
+	require.Equal(t, 0, run([]string{"manifest", "create", "--help"}, &stdout, &stderr))
+	require.Contains(t, stderr.String(), "-definitions")
+}

--- a/cmd/storage/main.go
+++ b/cmd/storage/main.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		printUsage(stdout)
+		return 0
+	}
+	if len(args) < 2 {
+		printUsage(stderr)
+		return 2
+	}
+	switch args[0] + " " + args[1] {
+	case "manifest inspect":
+		flags := flag.NewFlagSet("manifest inspect", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		logDir := flags.String("log-dir", "", "broker log directory")
+		if code := parseCommandFlags(flags, args[2:]); code >= 0 {
+			return code
+		}
+		if *logDir == "" || flags.NArg() != 0 {
+			return usageError(stderr, "--log-dir is required and positional arguments are not accepted")
+		}
+		inventory, err := topic.InspectStandaloneStorage(*logDir)
+		if err != nil {
+			return operationError(stderr, err)
+		}
+		return writeJSON(stdout, stderr, inventory)
+
+	case "manifest create":
+		flags := flag.NewFlagSet("manifest create", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		logDir := flags.String("log-dir", "", "broker log directory")
+		definitionsPath := flags.String("definitions", "", "strict manifest-shaped topic definitions JSON")
+		dryRun := flags.Bool("dry-run", false, "validate without writing")
+		if code := parseCommandFlags(flags, args[2:]); code >= 0 {
+			return code
+		}
+		if *logDir == "" || *definitionsPath == "" || flags.NArg() != 0 {
+			return usageError(stderr, "--log-dir and --definitions are required; positional arguments are not accepted")
+		}
+		definitions, err := topic.ReadTopicDefinitionsFile(*definitionsPath)
+		if err != nil {
+			return operationError(stderr, err)
+		}
+		result, err := topic.CreateStandaloneManifest(*logDir, definitions, *dryRun)
+		if writeErr := writeJSONValue(stdout, result); writeErr != nil {
+			return operationError(stderr, writeErr)
+		}
+		if err != nil {
+			return operationError(stderr, err)
+		}
+		return 0
+
+	case "orphan inspect":
+		flags := flag.NewFlagSet("orphan inspect", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		logDir := flags.String("log-dir", "", "broker log directory")
+		if code := parseCommandFlags(flags, args[2:]); code >= 0 {
+			return code
+		}
+		if *logDir == "" || flags.NArg() != 0 {
+			return usageError(stderr, "--log-dir is required and positional arguments are not accepted")
+		}
+		inventory, err := topic.InspectStandaloneStorage(*logDir)
+		if err != nil {
+			return operationError(stderr, err)
+		}
+		if !inventory.ManifestPresent {
+			return operationError(stderr, errors.New("cannot inspect orphans: no topic metadata manifest is present"))
+		}
+		declared := make(map[string]struct{}, len(inventory.ManifestTopics))
+		for _, name := range inventory.ManifestTopics {
+			declared[name] = struct{}{}
+		}
+		orphans := make([]topic.PersistedTopic, 0)
+		for _, persisted := range inventory.Topics {
+			if _, ok := declared[persisted.Name]; !ok {
+				orphans = append(orphans, persisted)
+			}
+		}
+		return writeJSON(stdout, stderr, struct {
+			Topics   []topic.PersistedTopic `json:"topics"`
+			Problems []topic.StorageProblem `json:"problems,omitempty"`
+		}{Topics: orphans, Problems: inventory.Problems})
+
+	case "orphan archive":
+		flags := flag.NewFlagSet("orphan archive", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		logDir := flags.String("log-dir", "", "broker log directory")
+		archiveDir := flags.String("archive-dir", "", "archive directory outside the broker log directory")
+		topicName := flags.String("topic", "", "single orphan topic to archive")
+		dryRun := flags.Bool("dry-run", false, "validate without moving")
+		if code := parseCommandFlags(flags, args[2:]); code >= 0 {
+			return code
+		}
+		if *logDir == "" || *archiveDir == "" || *topicName == "" || flags.NArg() != 0 {
+			return usageError(stderr, "--log-dir, --archive-dir, and --topic are required; positional arguments are not accepted")
+		}
+		result, err := topic.ArchiveOrphanTopic(*logDir, *archiveDir, *topicName, *dryRun)
+		if writeErr := writeJSONValue(stdout, result); writeErr != nil {
+			return operationError(stderr, writeErr)
+		}
+		if err != nil {
+			return operationError(stderr, err)
+		}
+		return 0
+	default:
+		printUsage(stderr)
+		return 2
+	}
+}
+
+func writeJSON(stdout, stderr io.Writer, value any) int {
+	if err := writeJSONValue(stdout, value); err != nil {
+		return operationError(stderr, err)
+	}
+	return 0
+}
+
+func writeJSONValue(writer io.Writer, value any) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func operationError(stderr io.Writer, err error) int {
+	fmt.Fprintln(stderr, "error:", err)
+	return 1
+}
+
+func parseCommandFlags(flags *flag.FlagSet, args []string) int {
+	err := flags.Parse(args)
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+	if err != nil {
+		return 2
+	}
+	return -1
+}
+
+func usageError(stderr io.Writer, message string) int {
+	fmt.Fprintln(stderr, "error:", message)
+	return 2
+}
+
+func printUsage(writer io.Writer) {
+	fmt.Fprintln(writer, "usage:")
+	fmt.Fprintln(writer, "  cursus-storage manifest inspect --log-dir DIR")
+	fmt.Fprintln(writer, "  cursus-storage manifest create --log-dir DIR --definitions FILE [--dry-run]")
+	fmt.Fprintln(writer, "  cursus-storage orphan inspect --log-dir DIR")
+	fmt.Fprintln(writer, "  cursus-storage orphan archive --log-dir DIR --archive-dir DIR --topic NAME [--dry-run]")
+}

--- a/cmd/storage/main_test.go
+++ b/cmd/storage/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRejectsIncompleteCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	require.Equal(t, 2, run([]string{"manifest"}, &stdout, &stderr))
+	require.Contains(t, stderr.String(), "usage:")
+}
+
+func TestRunManifestInspectWritesJSON(t *testing.T) {
+	root := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	require.Equal(t, 0, run([]string{"manifest", "inspect", "--log-dir", root}, &stdout, &stderr))
+	require.JSONEq(t, `{"manifest_present":false,"topics":[]}`, stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+func TestRunManifestCreateRejectsInvalidDefinitions(t *testing.T) {
+	root := t.TempDir()
+	definitions := filepath.Join(t.TempDir(), "definitions.json")
+	require.NoError(t, os.WriteFile(definitions, []byte(`{"version":1,"topics":[],"unknown":true}`), 0o600))
+	var stdout, stderr bytes.Buffer
+	require.Equal(t, 1, run([]string{"manifest", "create", "--log-dir", root, "--definitions", definitions}, &stdout, &stderr))
+	require.Contains(t, stderr.String(), "unknown field")
+}
+
+func TestRunOrphanInspectRequiresManifest(t *testing.T) {
+	root := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	require.Equal(t, 1, run([]string{"orphan", "inspect", "--log-dir", root}, &stdout, &stderr))
+	require.Empty(t, stdout.String())
+	require.Contains(t, stderr.String(), "no topic metadata manifest is present")
+}

--- a/pkg/topic/storage_archive_linux.go
+++ b/pkg/topic/storage_archive_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package topic
+
+import "golang.org/x/sys/unix"
+
+func archiveTopicDirectoryExclusive(source, destination string) error {
+	return unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, destination, unix.RENAME_NOREPLACE)
+}

--- a/pkg/topic/storage_archive_other.go
+++ b/pkg/topic/storage_archive_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !windows
+
+package topic
+
+import "fmt"
+
+func archiveTopicDirectoryExclusive(_, _ string) error {
+	return fmt.Errorf("exclusive orphan archive is unsupported on this platform")
+}

--- a/pkg/topic/storage_archive_physical_path_test.go
+++ b/pkg/topic/storage_archive_physical_path_test.go
@@ -1,0 +1,26 @@
+package topic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveOrphanTopicRejectsSymlinkedParentIntoLogRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "logs")
+	require.NoError(t, os.Mkdir(root, 0o750))
+	writeMigrationSegment(t, root, "orphan", 0, 0, nil)
+	inside := filepath.Join(root, "inside")
+	require.NoError(t, os.Mkdir(inside, 0o750))
+	alias := filepath.Join(parent, "alias")
+	if err := os.Symlink(inside, alias); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	_, err := ArchiveOrphanTopic(root, filepath.Join(alias, "archive"), "orphan", false)
+	require.ErrorContains(t, err, "resolves inside the log directory")
+	require.DirExists(t, filepath.Join(root, "orphan"))
+}

--- a/pkg/topic/storage_archive_safety.go
+++ b/pkg/topic/storage_archive_safety.go
@@ -1,0 +1,61 @@
+package topic
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func validateArchiveRoot(path string, allowMissing bool) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) && allowMissing {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect archive directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("archive directory must be a real directory")
+	}
+	return nil
+}
+
+func archiveRootWithinLogRoot(logRoot, archiveRoot string) (bool, error) {
+	resolvedLogRoot, err := resolvePhysicalPath(logRoot)
+	if err != nil {
+		return false, fmt.Errorf("resolve physical log directory: %w", err)
+	}
+	resolvedArchiveRoot, err := resolvePhysicalPath(archiveRoot)
+	if err != nil {
+		return false, fmt.Errorf("resolve physical archive directory: %w", err)
+	}
+	return pathWithin(resolvedLogRoot, resolvedArchiveRoot), nil
+}
+func resolvePhysicalPath(path string) (string, error) {
+	probe := path
+	missing := make([]string, 0)
+	for {
+		_, err := os.Lstat(probe)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return "", err
+		}
+		missing = append(missing, filepath.Base(probe))
+		probe = parent
+	}
+	resolved, err := filepath.EvalSymlinks(probe)
+	if err != nil {
+		return "", err
+	}
+	for index := len(missing) - 1; index >= 0; index-- {
+		resolved = filepath.Join(resolved, missing[index])
+	}
+	return resolved, nil
+}

--- a/pkg/topic/storage_archive_windows.go
+++ b/pkg/topic/storage_archive_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package topic
+
+import "golang.org/x/sys/windows"
+
+func archiveTopicDirectoryExclusive(source, destination string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/pkg/topic/storage_definitions.go
+++ b/pkg/topic/storage_definitions.go
@@ -1,0 +1,12 @@
+package topic
+
+import "fmt"
+
+// ReadTopicDefinitionsFile reads a strict manifest-shaped operator definition file.
+func ReadTopicDefinitionsFile(path string) ([]Definition, error) {
+	definitions, err := readStandaloneManifest(path)
+	if err != nil {
+		return nil, fmt.Errorf("read explicit topic definitions: %w", err)
+	}
+	return definitions, nil
+}

--- a/pkg/topic/storage_install_unix.go
+++ b/pkg/topic/storage_install_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package topic
+
+import "os"
+
+func installCheckpointFileExclusive(tmp, path string) error {
+	return os.Link(tmp, path)
+}

--- a/pkg/topic/storage_install_windows.go
+++ b/pkg/topic/storage_install_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package topic
+
+import "golang.org/x/sys/windows"
+
+func installCheckpointFileExclusive(tmp, path string) error {
+	from, err := windows.UTF16PtrFromString(tmp)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/pkg/topic/storage_manifest_read.go
+++ b/pkg/topic/storage_manifest_read.go
@@ -1,0 +1,63 @@
+package topic
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
+
+func readStandaloneManifestIfPresent(path string) ([]Definition, error) {
+	definitions, err := readStandaloneManifest(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return definitions, err
+}
+
+func readStandaloneManifest(path string) ([]Definition, error) {
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !pathInfo.Mode().IsRegular() || pathInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("topic metadata manifest must be a regular file")
+	}
+	file, err := os.Open(path) // #nosec G304 -- caller supplies the broker-owned manifest path.
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat topic metadata: %w", err)
+	}
+	if info.Size() > maxTopicMetadataBytes {
+		return nil, fmt.Errorf("topic metadata size %d exceeds limit %d", info.Size(), maxTopicMetadataBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxTopicMetadataBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read topic metadata: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest topicMetadataManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode topic metadata: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("decode topic metadata trailing content")
+	}
+	if manifest.Version != topicMetadataFormatVersion {
+		return nil, fmt.Errorf("unsupported topic metadata version %d", manifest.Version)
+	}
+	definitions, _, err := normalizeAndMarshalManifest(manifest.Topics)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(definitions, func(i, j int) bool { return definitions[i].Name < definitions[j].Name })
+	return definitions, nil
+}

--- a/pkg/topic/storage_migration.go
+++ b/pkg/topic/storage_migration.go
@@ -1,0 +1,582 @@
+package topic
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cursus-io/cursus/util"
+)
+
+const (
+	maxPersistedRecordBytes          = 16 << 20
+	persistedCompactionMarkerVersion = "cursus-compaction-v1\n"
+)
+
+var persistedSegmentName = regexp.MustCompile(`^partition_(0|[1-9][0-9]*)_segment_([0-9]{20})\.log$`)
+
+// StorageProblem describes persisted storage that cannot safely be adopted.
+type StorageProblem struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+// PersistedSegment is a read-only description of one log segment.
+type PersistedSegment struct {
+	BaseOffset       uint64 `json:"base_offset"`
+	Path             string `json:"path"`
+	Size             int64  `json:"size"`
+	ModifiedUnixNano int64  `json:"modified_unix_nano"`
+}
+
+// PersistedPartition is a read-only description of one topic partition.
+type PersistedPartition struct {
+	ID       int                `json:"id"`
+	Segments []PersistedSegment `json:"segments"`
+}
+
+// PersistedTopic is a read-only description of one topic directory.
+type PersistedTopic struct {
+	Name       string               `json:"name"`
+	Partitions []PersistedPartition `json:"partitions"`
+}
+
+// StorageInventory reports standalone topic storage without opening handlers.
+type StorageInventory struct {
+	ManifestPresent bool             `json:"manifest_present"`
+	ManifestTopics  []string         `json:"manifest_topics,omitempty"`
+	Topics          []PersistedTopic `json:"topics"`
+	Problems        []StorageProblem `json:"problems,omitempty"`
+}
+
+// ManifestMigrationResult reports whether a manifest was published.
+type ManifestMigrationResult struct {
+	Changed   bool             `json:"changed"`
+	Committed bool             `json:"committed"`
+	Inventory StorageInventory `json:"inventory"`
+}
+
+// ArchiveResult reports one atomic orphan-directory move.
+type ArchiveResult struct {
+	Changed     bool             `json:"changed"`
+	Committed   bool             `json:"committed"`
+	Source      string           `json:"source"`
+	Destination string           `json:"destination"`
+	Problems    []StorageProblem `json:"problems,omitempty"`
+}
+
+// InspectStandaloneStorage inventories persisted topic logs without opening a DiskHandler.
+func InspectStandaloneStorage(logDir string) (StorageInventory, error) {
+	root, err := safeStorageRoot(logDir)
+	if err != nil {
+		return StorageInventory{}, err
+	}
+
+	inventory := StorageInventory{Topics: make([]PersistedTopic, 0)}
+	manifestPath := filepath.Join(root, TopicMetadataFileName)
+	definitions, err := readStandaloneManifestIfPresent(manifestPath)
+	if err != nil {
+		return StorageInventory{}, err
+	}
+	if definitions != nil {
+		inventory.ManifestPresent = true
+		for _, definition := range definitions {
+			inventory.ManifestTopics = append(inventory.ManifestTopics, definition.Name)
+		}
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return StorageInventory{}, fmt.Errorf("read log directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == "raft" {
+			continue
+		}
+		name := entry.Name()
+		if ValidateName(name) != nil {
+			continue
+		}
+		topicPath := filepath.Join(root, name)
+		if entry.Type()&os.ModeSymlink != 0 {
+			inventory.Problems = append(inventory.Problems, storageProblem(root, topicPath, "topic storage entry is a symbolic link"))
+			continue
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		info, statErr := os.Lstat(topicPath)
+		if statErr != nil {
+			return StorageInventory{}, fmt.Errorf("inspect topic directory %q: %w", name, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			inventory.Problems = append(inventory.Problems, storageProblem(root, topicPath, "topic directory is a symbolic link"))
+			continue
+		}
+
+		topicInventory, candidate, problems, inspectErr := inspectPersistedTopic(root, name, topicPath)
+		if inspectErr != nil {
+			return StorageInventory{}, inspectErr
+		}
+		inventory.Problems = append(inventory.Problems, problems...)
+		if candidate {
+			inventory.Topics = append(inventory.Topics, topicInventory)
+		}
+	}
+	sort.Slice(inventory.Topics, func(i, j int) bool { return inventory.Topics[i].Name < inventory.Topics[j].Name })
+	sort.Slice(inventory.Problems, func(i, j int) bool {
+		if inventory.Problems[i].Path == inventory.Problems[j].Path {
+			return inventory.Problems[i].Message < inventory.Problems[j].Message
+		}
+		return inventory.Problems[i].Path < inventory.Problems[j].Path
+	})
+	return inventory, nil
+}
+
+func inspectPersistedTopic(root, name, topicPath string) (PersistedTopic, bool, []StorageProblem, error) {
+	entries, err := os.ReadDir(topicPath)
+	if err != nil {
+		return PersistedTopic{}, false, nil, fmt.Errorf("read topic directory %q: %w", name, err)
+	}
+	segments := make(map[int][]PersistedSegment)
+	problems := make([]StorageProblem, 0)
+	candidate := false
+	for _, entry := range entries {
+		fileName := entry.Name()
+		matches := persistedSegmentName.FindStringSubmatch(fileName)
+		if matches == nil {
+			if strings.HasPrefix(fileName, "partition_") && strings.HasSuffix(fileName, ".log") {
+				candidate = true
+				problems = append(problems, storageProblem(root, filepath.Join(topicPath, fileName), "non-canonical partition log name"))
+			}
+			continue
+		}
+		candidate = true
+		path := filepath.Join(topicPath, fileName)
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return PersistedTopic{}, false, nil, fmt.Errorf("stat persisted segment %q: %w", path, statErr)
+		}
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			problems = append(problems, storageProblem(root, path, "partition log is not a regular file"))
+			continue
+		}
+		partition64, partitionErr := strconv.ParseInt(matches[1], 10, 32)
+		baseOffset, baseErr := strconv.ParseUint(matches[2], 10, 64)
+		if partitionErr != nil || baseErr != nil {
+			problems = append(problems, storageProblem(root, path, "partition or segment offset is out of range"))
+			continue
+		}
+		partition := int(partition64)
+		segments[partition] = append(segments[partition], PersistedSegment{BaseOffset: baseOffset, Path: relativeStoragePath(root, path), Size: info.Size(), ModifiedUnixNano: info.ModTime().UnixNano()})
+	}
+	if !candidate {
+		return PersistedTopic{}, false, problems, nil
+	}
+
+	topic := PersistedTopic{Name: name}
+	partitionIDs := make([]int, 0, len(segments))
+	for id := range segments {
+		partitionIDs = append(partitionIDs, id)
+	}
+	sort.Ints(partitionIDs)
+	for _, id := range partitionIDs {
+		partitionSegments := segments[id]
+		sort.Slice(partitionSegments, func(i, j int) bool { return partitionSegments[i].BaseOffset < partitionSegments[j].BaseOffset })
+		var previousLast uint64
+		previousAllowsGaps := false
+		havePrevious := false
+		for segmentIndex, segment := range partitionSegments {
+			active := segmentIndex == len(partitionSegments)-1
+			first, last, count, allowsGaps, scanProblems, scanErr := scanPersistedSegment(root, name, id, segment, active)
+			if scanErr != nil {
+				return PersistedTopic{}, false, nil, scanErr
+			}
+			problems = append(problems, scanProblems...)
+			if count > 0 && havePrevious {
+				if first <= previousLast {
+					problems = append(problems, StorageProblem{Path: segment.Path, Message: "segment offsets overlap or regress"})
+				} else if first != previousLast+1 && !previousAllowsGaps && !allowsGaps {
+					problems = append(problems, StorageProblem{Path: segment.Path, Message: "segment offsets are not contiguous"})
+				}
+			}
+			if count > 0 {
+				previousLast = last
+				previousAllowsGaps = allowsGaps
+				havePrevious = true
+			} else if havePrevious && allowsGaps {
+				previousAllowsGaps = true
+			}
+		}
+		topic.Partitions = append(topic.Partitions, PersistedPartition{ID: id, Segments: partitionSegments})
+	}
+	return topic, true, problems, nil
+}
+
+func scanPersistedSegment(root, topicName string, partition int, segment PersistedSegment, active bool) (uint64, uint64, int, bool, []StorageProblem, error) {
+	path := filepath.Join(root, filepath.FromSlash(segment.Path))
+	file, err := os.Open(path) // #nosec G304 -- path came from a contained, validated directory entry.
+	if err != nil {
+		return 0, 0, 0, false, nil, fmt.Errorf("open persisted segment %q: %w", segment.Path, err)
+	}
+	defer file.Close()
+	reader := bufio.NewReader(file)
+	markerAllowsGaps, markerProblem := compactionMarkerStatus(path, segment.Size)
+	allowGaps := markerAllowsGaps && !active
+	var first, previous uint64
+	count := 0
+	problems := make([]StorageProblem, 0)
+	if markerProblem != "" {
+		problems = append(problems, StorageProblem{Path: segment.Path, Message: markerProblem})
+	}
+	for {
+		var lengthBytes [4]byte
+		_, readErr := io.ReadFull(reader, lengthBytes[:])
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			problems = append(problems, StorageProblem{Path: segment.Path, Message: "truncated record length"})
+			break
+		}
+		length := binary.BigEndian.Uint32(lengthBytes[:])
+		if length == 0 || length > maxPersistedRecordBytes {
+			problems = append(problems, StorageProblem{Path: segment.Path, Message: fmt.Sprintf("invalid record length %d", length)})
+			break
+		}
+		payload := make([]byte, int(length))
+		if _, readErr = io.ReadFull(reader, payload); readErr != nil {
+			problems = append(problems, StorageProblem{Path: segment.Path, Message: "truncated record payload"})
+			break
+		}
+		message, decodeErr := util.DeserializeDiskMessage(payload)
+		if decodeErr != nil {
+			problems = append(problems, StorageProblem{Path: segment.Path, Message: "invalid record: " + decodeErr.Error()})
+			break
+		}
+		if message.Topic != topicName || int(message.Partition) != partition {
+			problems = append(problems, StorageProblem{Path: segment.Path, Message: "record topic or partition does not match its path"})
+		}
+		if count == 0 {
+			first = message.Offset
+			if !allowGaps && first != segment.BaseOffset {
+				problems = append(problems, StorageProblem{Path: segment.Path, Message: fmt.Sprintf("first offset %d does not match segment base %d", first, segment.BaseOffset)})
+			}
+		} else if message.Offset <= previous || (!allowGaps && message.Offset != previous+1) {
+			problems = append(problems, StorageProblem{Path: segment.Path, Message: "record offsets are not strictly contiguous"})
+		}
+		previous = message.Offset
+		count++
+	}
+	return first, previous, count, allowGaps, problems, nil
+}
+
+func compactionMarkerStatus(logPath string, size int64) (bool, string) {
+	markers, _ := filepath.Glob(logPath + ".compacted-*")
+	for _, marker := range markers {
+		suffix := strings.TrimPrefix(marker, logPath+".compacted-")
+		expected, err := strconv.ParseInt(suffix, 10, 64)
+		if err != nil || expected != size {
+			continue
+		}
+		info, err := os.Lstat(marker)
+		if err != nil {
+			return false, "inspect current compaction marker: " + err.Error()
+		}
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return false, "current compaction marker is not a regular file"
+		}
+		if info.Size() != int64(len(persistedCompactionMarkerVersion)) {
+			return false, "current compaction marker has invalid content"
+		}
+		data, err := os.ReadFile(marker) // #nosec G304 -- marker is adjacent to a contained validated log.
+		if err != nil {
+			return false, "read current compaction marker: " + err.Error()
+		}
+		if string(data) != persistedCompactionMarkerVersion {
+			return false, "current compaction marker has invalid content"
+		}
+		return true, ""
+	}
+	return false, ""
+}
+
+// CreateStandaloneManifest publishes explicit definitions without replacing an existing manifest.
+func CreateStandaloneManifest(logDir string, definitions []Definition, dryRun bool) (ManifestMigrationResult, error) {
+	inventory, err := InspectStandaloneStorage(logDir)
+	if err != nil {
+		return ManifestMigrationResult{}, err
+	}
+	result := ManifestMigrationResult{Inventory: inventory}
+	normalized, data, err := normalizeAndMarshalManifest(definitions)
+	if err != nil {
+		return result, err
+	}
+	root, err := safeStorageRoot(logDir)
+	if err != nil {
+		return result, err
+	}
+	manifestPath := filepath.Join(root, TopicMetadataFileName)
+	if inventory.ManifestPresent {
+		existing, readErr := readStandaloneManifest(manifestPath)
+		if readErr != nil {
+			return result, readErr
+		}
+		if reflect.DeepEqual(existing, normalized) {
+			if len(inventory.Problems) > 0 {
+				return result, fmt.Errorf("persisted topic storage has %d validation problem(s)", len(inventory.Problems))
+			}
+			if err := definitionsMatchInventory(existing, inventory.Topics); err != nil {
+				return result, fmt.Errorf("existing topic metadata is not aligned with storage: %w", err)
+			}
+			return result, nil
+		}
+		return result, fmt.Errorf("topic metadata manifest already exists with different definitions")
+	}
+	if len(inventory.Problems) > 0 {
+		return result, fmt.Errorf("persisted topic storage has %d validation problem(s)", len(inventory.Problems))
+	}
+	if err := definitionsMatchInventory(normalized, inventory.Topics); err != nil {
+		return result, err
+	}
+	if dryRun {
+		return result, nil
+	}
+
+	second, err := InspectStandaloneStorage(root)
+	if err != nil {
+		return result, err
+	}
+	if !reflect.DeepEqual(inventory, second) {
+		return result, fmt.Errorf("persisted topic storage changed during validation")
+	}
+	committed, err := installManifestExclusive(root, manifestPath, data)
+	result.Committed = committed
+	result.Changed = committed
+	return result, err
+}
+
+func definitionsMatchInventory(definitions []Definition, topics []PersistedTopic) error {
+	if len(definitions) != len(topics) {
+		return fmt.Errorf("explicit definitions cover %d topics but storage contains %d", len(definitions), len(topics))
+	}
+	byName := make(map[string]PersistedTopic, len(topics))
+	for _, topic := range topics {
+		byName[topic.Name] = topic
+	}
+	for _, definition := range definitions {
+		persisted, ok := byName[definition.Name]
+		if !ok {
+			return fmt.Errorf("definition %q has no persisted topic storage", definition.Name)
+		}
+		if len(persisted.Partitions) != definition.Partitions {
+			return fmt.Errorf("topic %q definition has %d partitions but storage has %d", definition.Name, definition.Partitions, len(persisted.Partitions))
+		}
+		for expected, partition := range persisted.Partitions {
+			if partition.ID != expected {
+				return fmt.Errorf("topic %q persisted partition IDs are not contiguous from zero", definition.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeAndMarshalManifest(definitions []Definition) ([]Definition, []byte, error) {
+	normalized := make([]Definition, 0, len(definitions))
+	seen := make(map[string]struct{}, len(definitions))
+	for _, raw := range definitions {
+		definition, err := raw.Normalize()
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid topic metadata for %q: %w", raw.Name, err)
+		}
+		if _, exists := seen[definition.Name]; exists {
+			return nil, nil, fmt.Errorf("duplicate topic metadata for %q", definition.Name)
+		}
+		seen[definition.Name] = struct{}{}
+		if err := validateCleanupPolicyForTopic(definition.Policy, nil, definition.EventSourcing); err != nil {
+			return nil, nil, fmt.Errorf("invalid topic metadata for %q: %w", definition.Name, err)
+		}
+		normalized = append(normalized, definition)
+	}
+	sort.Slice(normalized, func(i, j int) bool { return normalized[i].Name < normalized[j].Name })
+	data, err := json.MarshalIndent(topicMetadataManifest{Version: topicMetadataFormatVersion, Topics: normalized}, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal topic metadata: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxTopicMetadataBytes {
+		return nil, nil, fmt.Errorf("topic metadata size %d exceeds limit %d", len(data), maxTopicMetadataBytes)
+	}
+	return normalized, data, nil
+}
+
+func installManifestExclusive(root, path string, data []byte) (committed bool, err error) {
+	tmp, err := os.CreateTemp(root, ".topic-metadata-migration-*")
+	if err != nil {
+		return false, fmt.Errorf("create topic metadata temporary file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return false, fmt.Errorf("secure topic metadata temporary file: %w", err)
+	}
+	if err := writeMetadataFile(tmp, data); err != nil {
+		return false, err
+	}
+	if err := tmp.Close(); err != nil {
+		return false, fmt.Errorf("close topic metadata temporary file: %w", err)
+	}
+	if err := installCheckpointFileExclusive(tmpPath, path); err != nil {
+		return false, fmt.Errorf("publish topic metadata without overwrite: %w", err)
+	}
+	committed = true
+	if err := syncTopicMetadataDirectoryFn(root); err != nil {
+		return true, fmt.Errorf("sync topic metadata directory: %w", err)
+	}
+	return true, nil
+}
+
+// ArchiveOrphanTopic atomically moves one manifest-omitted topic directory.
+func ArchiveOrphanTopic(logDir, archiveDir, topicName string, dryRun bool) (ArchiveResult, error) {
+	if err := ValidateName(topicName); err != nil {
+		return ArchiveResult{}, err
+	}
+	if strings.TrimSpace(archiveDir) == "" {
+		return ArchiveResult{}, fmt.Errorf("archive directory is empty")
+	}
+	inventory, err := InspectStandaloneStorage(logDir)
+	if err != nil {
+		return ArchiveResult{}, err
+	}
+	for _, declared := range inventory.ManifestTopics {
+		if declared == topicName {
+			return ArchiveResult{}, fmt.Errorf("topic %q is declared in the manifest", topicName)
+		}
+	}
+	var persisted *PersistedTopic
+	for i := range inventory.Topics {
+		if inventory.Topics[i].Name == topicName {
+			persisted = &inventory.Topics[i]
+			break
+		}
+	}
+	if persisted == nil {
+		return ArchiveResult{}, fmt.Errorf("topic %q is not a persisted orphan candidate", topicName)
+	}
+	root, err := safeStorageRoot(logDir)
+	if err != nil {
+		return ArchiveResult{}, err
+	}
+	archiveRoot, err := filepath.Abs(filepath.Clean(archiveDir))
+	if err != nil {
+		return ArchiveResult{}, fmt.Errorf("resolve archive directory: %w", err)
+	}
+	if err := validateArchiveRoot(archiveRoot, true); err != nil {
+		return ArchiveResult{}, err
+	}
+	if pathWithin(root, archiveRoot) {
+		return ArchiveResult{}, fmt.Errorf("archive directory must be outside the log directory")
+	}
+	insideLogRoot, err := archiveRootWithinLogRoot(root, archiveRoot)
+	if err != nil {
+		return ArchiveResult{}, err
+	}
+	if insideLogRoot {
+		return ArchiveResult{}, fmt.Errorf("archive directory resolves inside the log directory")
+	}
+	source := filepath.Join(root, topicName)
+	destination := filepath.Join(archiveRoot, topicName)
+	result := ArchiveResult{Source: source, Destination: destination}
+	for _, problem := range inventory.Problems {
+		if problem.Path == topicName || strings.HasPrefix(problem.Path, topicName+"/") {
+			result.Problems = append(result.Problems, problem)
+		}
+	}
+	if _, err := os.Lstat(destination); err == nil {
+		return result, fmt.Errorf("archive destination already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return result, fmt.Errorf("inspect archive destination: %w", err)
+	}
+	if dryRun {
+		return result, nil
+	}
+	if err := os.MkdirAll(archiveRoot, 0o700); err != nil {
+		return result, fmt.Errorf("create archive directory: %w", err)
+	}
+	if err := validateArchiveRoot(archiveRoot, false); err != nil {
+		return result, err
+	}
+	insideLogRoot, err = archiveRootWithinLogRoot(root, archiveRoot)
+	if err != nil {
+		return result, err
+	}
+	if insideLogRoot {
+		return result, fmt.Errorf("archive directory resolves inside the log directory")
+	}
+	second, err := InspectStandaloneStorage(root)
+	if err != nil {
+		return result, err
+	}
+	if !reflect.DeepEqual(inventory, second) {
+		return result, fmt.Errorf("persisted topic storage changed during validation")
+	}
+	if err := archiveTopicDirectoryExclusive(source, destination); err != nil {
+		return result, fmt.Errorf("atomically archive orphan topic: %w", err)
+	}
+	result.Changed = true
+	result.Committed = true
+	sourceSyncErr := syncTopicMetadataDirectoryFn(root)
+	archiveSyncErr := syncTopicMetadataDirectoryFn(archiveRoot)
+	if err := errors.Join(sourceSyncErr, archiveSyncErr); err != nil {
+		return result, fmt.Errorf("sync archive directory move: %w", err)
+	}
+	return result, nil
+}
+
+func safeStorageRoot(logDir string) (string, error) {
+	if strings.TrimSpace(logDir) == "" {
+		return "", fmt.Errorf("log directory is empty")
+	}
+	root, err := filepath.Abs(filepath.Clean(logDir))
+	if err != nil {
+		return "", fmt.Errorf("resolve log directory: %w", err)
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return "", fmt.Errorf("inspect log directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("log directory must be a real directory")
+	}
+	return root, nil
+}
+
+func pathWithin(root, candidate string) bool {
+	relative, err := filepath.Rel(root, candidate)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(os.PathSeparator))
+}
+
+func relativeStoragePath(root, path string) string {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return filepath.ToSlash(relative)
+}
+
+func storageProblem(root, path, message string) StorageProblem {
+	return StorageProblem{Path: relativeStoragePath(root, path), Message: message}
+}

--- a/pkg/topic/storage_migration_active_segment_test.go
+++ b/pkg/topic/storage_migration_active_segment_test.go
@@ -1,0 +1,26 @@
+package topic
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectStandaloneStorageDoesNotAllowGapsInActiveSegment(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 1}})
+	logPath := filepath.Join(root, "orders", "partition_0_segment_00000000000000000000.log")
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	marker := fmt.Sprintf("%s.compacted-%d", logPath, info.Size())
+	require.NoError(t, os.WriteFile(marker, []byte(persistedCompactionMarkerVersion), 0o600))
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.NotEmpty(t, inventory.Problems)
+	require.Contains(t, inventory.Problems[0].Message, "does not match segment base")
+}

--- a/pkg/topic/storage_migration_final_audit_test.go
+++ b/pkg/topic/storage_migration_final_audit_test.go
@@ -1,0 +1,65 @@
+package topic
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateStandaloneManifestEquivalentExistingRejectsOrphanedStorage(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "declared", 0, 0, nil)
+	writeMigrationSegment(t, root, "orphan", 0, 0, nil)
+	definition := Definition{Name: "declared", Partitions: 1, Policy: DefaultPolicy()}
+	_, manifest, err := normalizeAndMarshalManifest([]Definition{definition})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(root, TopicMetadataFileName), manifest, 0o600))
+
+	result, err := CreateStandaloneManifest(root, []Definition{definition}, false)
+	require.ErrorContains(t, err, "not aligned with storage")
+	require.False(t, result.Changed)
+}
+
+func TestInspectStandaloneStorageReportsInvalidCurrentSizeCompactionMarker(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 0}})
+	logPath := filepath.Join(root, "orders", "partition_0_segment_00000000000000000000.log")
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	marker := fmt.Sprintf("%s.compacted-%d", logPath, info.Size())
+	require.NoError(t, os.WriteFile(marker, []byte("invalid"), 0o600))
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.Len(t, inventory.Problems, 1)
+	require.Contains(t, inventory.Problems[0].Message, "invalid content")
+}
+
+func TestInspectStandaloneStorageAllowsGapAcrossEmptyCompactedSegment(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 0}})
+	writeMigrationSegment(t, root, "orders", 0, 1, nil)
+	writeMigrationSegment(t, root, "orders", 0, 2, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 2}})
+	emptyLog := filepath.Join(root, "orders", "partition_0_segment_00000000000000000001.log")
+	require.NoError(t, os.WriteFile(emptyLog+".compacted-0", []byte(persistedCompactionMarkerVersion), 0o600))
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.Empty(t, inventory.Problems)
+}
+
+func TestArchiveTopicDirectoryExclusiveDoesNotReplaceDestination(t *testing.T) {
+	parent := t.TempDir()
+	source := filepath.Join(parent, "source")
+	destination := filepath.Join(parent, "destination")
+	require.NoError(t, os.Mkdir(source, 0o750))
+	require.NoError(t, os.Mkdir(destination, 0o750))
+
+	require.Error(t, archiveTopicDirectoryExclusive(source, destination))
+	require.DirExists(t, source)
+	require.DirExists(t, destination)
+}

--- a/pkg/topic/storage_migration_safety_test.go
+++ b/pkg/topic/storage_migration_safety_test.go
@@ -1,0 +1,53 @@
+package topic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateStandaloneManifestRejectsUnsafeEventSourcingPolicy(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "events", 0, 0, nil)
+	policy := DefaultPolicy()
+	policy.CleanupPolicy = config.CleanupPolicyCompact
+
+	_, err := CreateStandaloneManifest(root, []Definition{{
+		Name:          "events",
+		Partitions:    1,
+		EventSourcing: true,
+		Policy:        policy,
+	}}, false)
+	require.ErrorContains(t, err, "not supported for event-sourcing topics")
+	require.NoFileExists(t, filepath.Join(root, TopicMetadataFileName))
+}
+
+func TestCreateStandaloneManifestNeverReplacesCorruptManifest(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, nil)
+	manifestPath := filepath.Join(root, TopicMetadataFileName)
+	original := []byte(`{"version":1,"topics":[],"unknown":true}`)
+	require.NoError(t, os.WriteFile(manifestPath, original, 0o600))
+
+	_, err := CreateStandaloneManifest(root, []Definition{{Name: "orders", Partitions: 1, Policy: DefaultPolicy()}}, false)
+	require.ErrorContains(t, err, "unknown field")
+	after, readErr := os.ReadFile(manifestPath)
+	require.NoError(t, readErr)
+	require.Equal(t, original, after)
+}
+
+func TestArchiveOrphanTopicRefusesDestinationCollision(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "logs")
+	archive := filepath.Join(parent, "archive")
+	require.NoError(t, os.Mkdir(root, 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(archive, "orphan"), 0o750))
+	writeMigrationSegment(t, root, "orphan", 0, 0, nil)
+
+	_, err := ArchiveOrphanTopic(root, archive, "orphan", false)
+	require.ErrorContains(t, err, "destination already exists")
+	require.DirExists(t, filepath.Join(root, "orphan"))
+}

--- a/pkg/topic/storage_migration_symlink_test.go
+++ b/pkg/topic/storage_migration_symlink_test.go
@@ -1,0 +1,23 @@
+package topic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectStandaloneStorageReportsTopicSymlink(t *testing.T) {
+	root := t.TempDir()
+	target := t.TempDir()
+	if err := os.Symlink(target, filepath.Join(root, "linked-topic")); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.Empty(t, inventory.Topics)
+	require.Len(t, inventory.Problems, 1)
+	require.Contains(t, inventory.Problems[0].Message, "symbolic link")
+}

--- a/pkg/topic/storage_migration_test.go
+++ b/pkg/topic/storage_migration_test.go
@@ -1,0 +1,166 @@
+package topic
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/cursus-io/cursus/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectStandaloneStorageReadsLogsWithoutOpeningHandlers(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, []types.DiskMessage{
+		{Topic: "orders", Partition: 0, Offset: 0, Payload: "first"},
+		{Topic: "orders", Partition: 0, Offset: 1, Payload: "second"},
+	})
+	require.NoError(t, os.Mkdir(filepath.Join(root, "raft"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "__transaction_state.journal"), []byte("state"), 0o600))
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.False(t, inventory.ManifestPresent)
+	require.Len(t, inventory.Topics, 1)
+	require.Equal(t, "orders", inventory.Topics[0].Name)
+	require.Equal(t, 0, inventory.Topics[0].Partitions[0].ID)
+	require.Empty(t, inventory.Problems)
+
+	// Inventory must not create runtime index or checkpoint files.
+	require.NoFileExists(t, filepath.Join(root, "orders", "partition_0_segment_00000000000000000000.index"))
+	require.NoFileExists(t, filepath.Join(root, "orders", "partition_0.hwm"))
+}
+
+func TestInspectStandaloneStorageReportsCorruptAndMismatchedLogs(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, []types.DiskMessage{
+		{Topic: "wrong", Partition: 0, Offset: 0, Payload: "bad"},
+	})
+	malformed := filepath.Join(root, "orders", "partition_01_segment_0.log")
+	require.NoError(t, os.WriteFile(malformed, []byte{0, 0}, 0o600))
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.Len(t, inventory.Topics, 1)
+	require.Len(t, inventory.Problems, 2)
+	require.Contains(t, inventory.Problems[0].Message+inventory.Problems[1].Message, "non-canonical")
+	require.Contains(t, inventory.Problems[0].Message+inventory.Problems[1].Message, "does not match")
+}
+
+func TestCreateStandaloneManifestIsExplicitExclusiveAndIdempotent(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, nil)
+	definition := Definition{Name: "orders", Partitions: 1, Policy: DefaultPolicy()}
+
+	result, err := CreateStandaloneManifest(root, []Definition{definition}, false)
+	require.NoError(t, err)
+	require.True(t, result.Changed)
+	require.True(t, result.Committed)
+	manifestPath := filepath.Join(root, TopicMetadataFileName)
+	before, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	result, err = CreateStandaloneManifest(root, []Definition{definition}, false)
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+
+	conflicting := definition
+	conflicting.Idempotent = true
+	_, err = CreateStandaloneManifest(root, []Definition{conflicting}, false)
+	require.ErrorContains(t, err, "already exists with different definitions")
+	after, readErr := os.ReadFile(manifestPath)
+	require.NoError(t, readErr)
+	require.Equal(t, before, after)
+
+	cfg := config.DefaultConfig()
+	cfg.LogDir = root
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.NoError(t, manager.RestoreTopics())
+	require.NotNil(t, manager.GetTopic("orders"))
+}
+
+func TestCreateStandaloneManifestRejectsIncompleteDefinitionsAndDryRunDoesNotWrite(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 0, 0, nil)
+
+	result, err := CreateStandaloneManifest(root, []Definition{{Name: "orders", Partitions: 2, Policy: DefaultPolicy()}}, true)
+	require.ErrorContains(t, err, "storage has 1")
+	require.False(t, result.Changed)
+	require.NoFileExists(t, filepath.Join(root, TopicMetadataFileName))
+
+	result, err = CreateStandaloneManifest(root, []Definition{{Name: "orders", Partitions: 1, Policy: DefaultPolicy()}}, true)
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+	require.NoFileExists(t, filepath.Join(root, TopicMetadataFileName))
+}
+
+func TestArchiveOrphanTopicMovesExactlyOneDirectory(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "logs")
+	require.NoError(t, os.Mkdir(root, 0o750))
+	writeMigrationSegment(t, root, "declared", 0, 0, nil)
+	writeMigrationSegment(t, root, "orphan", 0, 0, []types.DiskMessage{{Topic: "orphan", Partition: 0, Offset: 0, Payload: "keep"}})
+	_, err := CreateStandaloneManifest(root, []Definition{
+		{Name: "declared", Partitions: 1, Policy: DefaultPolicy()},
+		{Name: "orphan", Partitions: 1, Policy: DefaultPolicy()},
+	}, false)
+	require.NoError(t, err)
+
+	// Simulate a valid manifest that omits the orphan without using the migration overwrite path.
+	_, data, err := normalizeAndMarshalManifest([]Definition{{Name: "declared", Partitions: 1, Policy: DefaultPolicy()}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(root, TopicMetadataFileName), data, 0o600))
+
+	archive := filepath.Join(parent, "archive")
+	dryRun, err := ArchiveOrphanTopic(root, archive, "orphan", true)
+	require.NoError(t, err)
+	require.False(t, dryRun.Changed)
+	require.DirExists(t, filepath.Join(root, "orphan"))
+	require.NoDirExists(t, archive)
+
+	result, err := ArchiveOrphanTopic(root, archive, "orphan", false)
+	require.NoError(t, err)
+	require.True(t, result.Committed)
+	require.NoDirExists(t, filepath.Join(root, "orphan"))
+	require.FileExists(t, filepath.Join(archive, "orphan", "partition_0_segment_00000000000000000000.log"))
+	require.DirExists(t, filepath.Join(root, "declared"))
+
+	_, err = ArchiveOrphanTopic(root, archive, "declared", false)
+	require.ErrorContains(t, err, "declared in the manifest")
+}
+
+func TestArchiveOrphanTopicRejectsArchiveInsideLogRoot(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orphan", 0, 0, nil)
+	_, err := ArchiveOrphanTopic(root, filepath.Join(root, "archive"), "orphan", false)
+	require.ErrorContains(t, err, "outside the log directory")
+	require.DirExists(t, filepath.Join(root, "orphan"))
+}
+
+func writeMigrationSegment(t *testing.T, root, topicName string, partition int, base uint64, messages []types.DiskMessage) {
+	t.Helper()
+	directory := filepath.Join(root, topicName)
+	require.NoError(t, os.MkdirAll(directory, 0o750))
+	path := filepath.Join(directory, "partition_"+strconv.Itoa(partition)+"_segment_"+fmt.Sprintf("%020d", base)+".log")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	require.NoError(t, err)
+	for _, message := range messages {
+		payload, serializeErr := util.SerializeDiskMessage(message)
+		require.NoError(t, serializeErr)
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(payload)))
+		_, err = file.Write(length[:])
+		require.NoError(t, err)
+		_, err = file.Write(payload)
+		require.NoError(t, err)
+	}
+	require.NoError(t, file.Close())
+}

--- a/pkg/topic/storage_migration_validation_test.go
+++ b/pkg/topic/storage_migration_validation_test.go
@@ -1,0 +1,73 @@
+package topic
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectStandaloneStorageRequiresValidCompactionMarkerForSegmentGaps(t *testing.T) {
+	tests := []struct {
+		name          string
+		markerContent string
+		wantProblem   bool
+		wantMessage   string
+	}{
+		{name: "missing marker", wantProblem: true, wantMessage: "not contiguous"},
+		{name: "invalid marker", markerContent: "not-a-cursus-marker\n", wantProblem: true, wantMessage: "invalid content"},
+		{name: "valid marker", markerContent: persistedCompactionMarkerVersion, wantProblem: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeMigrationSegment(t, root, "orders", 0, 0, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 0}})
+			writeMigrationSegment(t, root, "orders", 0, 2, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 2}})
+			writeMigrationSegment(t, root, "orders", 0, 3, []types.DiskMessage{{Topic: "orders", Partition: 0, Offset: 3}})
+			if test.markerContent != "" {
+				logPath := filepath.Join(root, "orders", "partition_0_segment_00000000000000000002.log")
+				info, err := os.Stat(logPath)
+				require.NoError(t, err)
+				marker := fmt.Sprintf("%s.compacted-%d", logPath, info.Size())
+				require.NoError(t, os.WriteFile(marker, []byte(test.markerContent), 0o600))
+			}
+
+			inventory, err := InspectStandaloneStorage(root)
+			require.NoError(t, err)
+			if test.wantProblem {
+				require.NotEmpty(t, inventory.Problems)
+				require.Contains(t, inventory.Problems[0].Message, test.wantMessage)
+			} else {
+				require.Empty(t, inventory.Problems)
+			}
+		})
+	}
+}
+
+func TestInspectStandaloneStorageReportsTruncatedRecord(t *testing.T) {
+	root := t.TempDir()
+	directory := filepath.Join(root, "orders")
+	require.NoError(t, os.MkdirAll(directory, 0o750))
+	path := filepath.Join(directory, "partition_0_segment_00000000000000000000.log")
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], 8)
+	require.NoError(t, os.WriteFile(path, append(length[:], 1, 2), 0o600))
+
+	inventory, err := InspectStandaloneStorage(root)
+	require.NoError(t, err)
+	require.Len(t, inventory.Problems, 1)
+	require.Contains(t, inventory.Problems[0].Message, "truncated record payload")
+}
+
+func TestCreateStandaloneManifestRejectsPartitionIDsThatDoNotStartAtZero(t *testing.T) {
+	root := t.TempDir()
+	writeMigrationSegment(t, root, "orders", 1, 0, nil)
+
+	_, err := CreateStandaloneManifest(root, []Definition{{Name: "orders", Partitions: 1, Policy: DefaultPolicy()}}, false)
+	require.ErrorContains(t, err, "not contiguous from zero")
+	require.NoFileExists(t, filepath.Join(root, TopicMetadataFileName))
+}


### PR DESCRIPTION
Fixes N/A

Adds an offline, fail-closed storage migration CLI for brokers created before topic manifests existed. Operators can inspect persisted logs, validate explicit topic definitions before exclusively publishing a manifest, inspect manifest-omitted orphan topics, and atomically archive one orphan without overwriting an existing destination.

The broker must be stopped while a create or archive operation runs; the runtime does not currently honor a migration lock.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (no issue number is available).
- [x] Documentation has been updated as needed (documentation is intentionally excluded from this change).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.