### PR TITLE
feat: expose topic metadata diagnostics

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/signal"
 	"syscall"
@@ -15,6 +16,9 @@ import (
 	"github.com/cursus-io/cursus/pkg/topic"
 	"github.com/cursus-io/cursus/util"
 )
+
+var runServerContext = server.RunServerContext
+var runTopicMetadataDiagnostics = server.RunTopicMetadataDiagnostics
 
 func main() {
 	// Configuration
@@ -42,38 +46,41 @@ func main() {
 	util.Info("🚀 Starting broker on port %d\n", cfg.BrokerPort)
 	util.Info("📊 Exporter: %v\n", cfg.EnableExporter)
 
-	// Initialization
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if err := runBroker(ctx, cfg); err != nil && !errors.Is(err, context.Canceled) {
+		util.Fatal("❌ Broker failed: %v", err)
+	}
+}
+
+func runBroker(ctx context.Context, cfg *config.Config) error {
 	dm := disk.NewDiskManager(cfg)
 	sm := stream.NewStreamManager(cfg.MaxStreamConnections, cfg.StreamTimeout, cfg.StreamHeartbeatInterval)
 	smAdapter, err := topic.NewStreamManagerAdapter(sm)
 	if err != nil {
-		util.Fatal("❌ Failed to create stream manager adapter: %v", err)
+		return fmt.Errorf("create stream manager adapter: %w", err)
 	}
 
 	tm := topic.NewTopicManager(cfg, dm, smAdapter)
 	if err := tm.RestoreTopics(); err != nil {
-		util.Fatal("❌ Failed to restore durable topic metadata: %v", err)
+		util.Error("Failed to restore durable topic metadata; serving diagnostics only: %v", err)
+		return runTopicMetadataDiagnostics(ctx, cfg, tm, dm)
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+
 	cd := coordinator.NewCoordinator(ctx, cfg, tm)
 	tm.SetCoordinator(cd)
-
-	// Static consumer groups
 	for _, gcfg := range cfg.StaticConsumerGroups {
 		for _, topicName := range gcfg.Topics {
-			t := tm.GetTopic(topicName)
-			if t == nil {
+			current := tm.GetTopic(topicName)
+			if current == nil {
 				util.Error("⚠️ Topic %q does not exist; skipping static consumer group registration", topicName)
-			} else {
-				if _, err := tm.RegisterConsumerGroup(topicName, gcfg.Name, gcfg.ConsumerCount); err != nil {
-					util.Error("⚠️ Failed to register static consumer group %q on topic %q: %v", gcfg.Name, topicName, err)
-				}
+				continue
+			}
+			if _, err := tm.RegisterConsumerGroup(topicName, gcfg.Name, gcfg.ConsumerCount); err != nil {
+				util.Error("⚠️ Failed to register static consumer group %q on topic %q: %v", gcfg.Name, topicName, err)
 			}
 		}
 	}
 
-	if err := server.RunServer(cfg, tm, dm, cd, sm); err != nil {
-		util.Fatal("❌ Broker failed: %v", err)
-	}
+	return runServerContext(ctx, cfg, tm, dm, cd, sm)
 }

--- a/cmd/broker/main_test.go
+++ b/cmd/broker/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/coordinator"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/stream"
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+func TestRunBrokerUsesDiagnosticsWhenTopicManifestRestoreFails(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.EnabledDistribution = false
+	if err := os.WriteFile(filepath.Join(cfg.LogDir, topic.TopicMetadataFileName), []byte(`{"version":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalDiagnostics := runTopicMetadataDiagnostics
+	originalServer := runServerContext
+	t.Cleanup(func() {
+		runTopicMetadataDiagnostics = originalDiagnostics
+		runServerContext = originalServer
+	})
+	diagnosticsCalled := false
+	serverCalled := false
+	runTopicMetadataDiagnostics = func(_ context.Context, _ *config.Config, tm *topic.TopicManager, _ *disk.DiskManager) error {
+		diagnosticsCalled = true
+		if err := tm.MetadataReadinessError(); err == nil {
+			t.Error("diagnostics received topic manager without readiness error")
+		}
+		return nil
+	}
+	runServerContext = func(context.Context, *config.Config, *topic.TopicManager, *disk.DiskManager, *coordinator.Coordinator, *stream.StreamManager) error {
+		serverCalled = true
+		return nil
+	}
+
+	if err := runBroker(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !diagnosticsCalled || serverCalled {
+		t.Fatalf("diagnosticsCalled=%t serverCalled=%t", diagnosticsCalled, serverCalled)
+	}
+}
+
+func TestRunBrokerStartsMainServerAfterSuccessfulTopicRestore(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.EnabledDistribution = false
+
+	originalDiagnostics := runTopicMetadataDiagnostics
+	originalServer := runServerContext
+	t.Cleanup(func() {
+		runTopicMetadataDiagnostics = originalDiagnostics
+		runServerContext = originalServer
+	})
+	diagnosticsCalled := false
+	serverCalled := false
+	runTopicMetadataDiagnostics = func(context.Context, *config.Config, *topic.TopicManager, *disk.DiskManager) error {
+		diagnosticsCalled = true
+		return nil
+	}
+	runServerContext = func(_ context.Context, _ *config.Config, _ *topic.TopicManager, dm *disk.DiskManager, _ *coordinator.Coordinator, _ *stream.StreamManager) error {
+		serverCalled = true
+		dm.CloseAllHandlers()
+		return nil
+	}
+
+	if err := runBroker(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if diagnosticsCalled || !serverCalled {
+		t.Fatalf("diagnosticsCalled=%t serverCalled=%t", diagnosticsCalled, serverCalled)
+	}
+}

--- a/pkg/observability/collector.go
+++ b/pkg/observability/collector.go
@@ -48,80 +48,90 @@ type Collector struct {
 	readiness   ReadinessSource
 	descriptors []*prometheus.Desc
 
-	ready                  *prometheus.Desc
-	topicCount             *prometheus.Desc
-	partitionCount         *prometheus.Desc
-	logStart               *prometheus.Desc
-	logEnd                 *prometheus.Desc
-	highWatermark          *prometheus.Desc
-	groupMembers           *prometheus.Desc
-	groupGeneration        *prometheus.Desc
-	groupAssignments       *prometheus.Desc
-	groupCommittedOffset   *prometheus.Desc
-	groupLag               *prometheus.Desc
-	legacyGroupLag         *prometheus.Desc
-	groupOffsetOutOfRange  *prometheus.Desc
-	activeStreams          *prometheus.Desc
-	storageHandlers        *prometheus.Desc
-	storageSegments        *prometheus.Desc
-	storageBytes           *prometheus.Desc
-	storagePendingWrites   *prometheus.Desc
-	storageActiveReaders   *prometheus.Desc
-	storageStatFailures    *prometheus.Desc
-	distributionEnabled    *prometheus.Desc
-	clusterBrokers         *prometheus.Desc
-	clusterHasLeader       *prometheus.Desc
-	clusterIsLeader        *prometheus.Desc
-	clusterOffline         *prometheus.Desc
-	clusterUnderReplicated *prometheus.Desc
-	partitionReplicas      *prometheus.Desc
-	partitionInSync        *prometheus.Desc
-	partitionLeaderEpoch   *prometheus.Desc
-	partitionLeader        *prometheus.Desc
+	ready                           *prometheus.Desc
+	topicCount                      *prometheus.Desc
+	metadataLoadFailure             *prometheus.Desc
+	metadataOrphanTopics            *prometheus.Desc
+	metadataDurabilityWarning       *prometheus.Desc
+	metadataDurabilityWarningsTotal *prometheus.Desc
+	partitionCount                  *prometheus.Desc
+	logStart                        *prometheus.Desc
+	logEnd                          *prometheus.Desc
+	highWatermark                   *prometheus.Desc
+	groupMembers                    *prometheus.Desc
+	groupGeneration                 *prometheus.Desc
+	groupAssignments                *prometheus.Desc
+	groupCommittedOffset            *prometheus.Desc
+	groupLag                        *prometheus.Desc
+	legacyGroupLag                  *prometheus.Desc
+	groupOffsetOutOfRange           *prometheus.Desc
+	activeStreams                   *prometheus.Desc
+	storageHandlers                 *prometheus.Desc
+	storageSegments                 *prometheus.Desc
+	storageBytes                    *prometheus.Desc
+	storagePendingWrites            *prometheus.Desc
+	storageActiveReaders            *prometheus.Desc
+	storageStatFailures             *prometheus.Desc
+	distributionEnabled             *prometheus.Desc
+	clusterBrokers                  *prometheus.Desc
+	clusterHasLeader                *prometheus.Desc
+	clusterIsLeader                 *prometheus.Desc
+	clusterOffline                  *prometheus.Desc
+	clusterUnderReplicated          *prometheus.Desc
+	partitionReplicas               *prometheus.Desc
+	partitionInSync                 *prometheus.Desc
+	partitionLeaderEpoch            *prometheus.Desc
+	partitionLeader                 *prometheus.Desc
 }
 
 // NewCollector creates a broker runtime collector. Nil sources are supported.
 func NewCollector(topics topicSource, groups groupSource, diskState diskSource, streams streamSource, cluster clusterSource, readiness ReadinessSource) *Collector {
 	c := &Collector{
-		topics:                 topics,
-		groups:                 groups,
-		disk:                   diskState,
-		streams:                streams,
-		cluster:                cluster,
-		readiness:              readiness,
-		ready:                  prometheus.NewDesc("cursus_broker_ready", "Whether the broker is ready to accept client work.", nil, nil),
-		topicCount:             prometheus.NewDesc("cursus_broker_topics", "Number of topics loaded by this broker.", nil, nil),
-		partitionCount:         prometheus.NewDesc("cursus_broker_partitions", "Number of topic partitions loaded by this broker.", nil, nil),
-		logStart:               prometheus.NewDesc("cursus_partition_log_start_offset", "Earliest retained offset for a partition.", []string{"topic", "partition"}, nil),
-		logEnd:                 prometheus.NewDesc("cursus_partition_log_end_offset", "Next offset allocated in a partition.", []string{"topic", "partition"}, nil),
-		highWatermark:          prometheus.NewDesc("cursus_partition_high_watermark", "Next offset visible to committed readers.", []string{"topic", "partition"}, nil),
-		groupMembers:           prometheus.NewDesc("cursus_consumer_group_members", "Active members in a consumer group.", []string{"group", "topic"}, nil),
-		groupGeneration:        prometheus.NewDesc("cursus_consumer_group_generation", "Current consumer group generation.", []string{"group", "topic"}, nil),
-		groupAssignments:       prometheus.NewDesc("cursus_consumer_group_assigned_partitions", "Partitions assigned to active group members.", []string{"group", "topic"}, nil),
-		groupCommittedOffset:   prometheus.NewDesc("cursus_consumer_group_committed_offset", "Committed next offset for a consumer group partition.", []string{"group", "topic", "partition"}, nil),
-		groupLag:               prometheus.NewDesc("cursus_consumer_group_lag", "Committed-reader lag, max(high watermark - committed next offset, 0).", []string{"group", "topic", "partition"}, nil),
-		legacyGroupLag:         prometheus.NewDesc("broker_consumer_lag", "Deprecated alias of cursus_consumer_group_lag.", []string{"topic", "partition", "group"}, nil),
-		groupOffsetOutOfRange:  prometheus.NewDesc("cursus_consumer_group_offset_out_of_range", "Whether a committed offset is outside the retained committed-readable range.", []string{"group", "topic", "partition"}, nil),
-		activeStreams:          prometheus.NewDesc("cursus_streams_active", "Currently registered streaming consumers.", nil, nil),
-		storageHandlers:        prometheus.NewDesc("cursus_storage_handlers", "Open partition storage handlers.", nil, nil),
-		storageSegments:        prometheus.NewDesc("cursus_storage_segments", "Open storage segments including active segments.", nil, nil),
-		storageBytes:           prometheus.NewDesc("cursus_storage_bytes", "Bytes used by segment and offset index files for open handlers.", nil, nil),
-		storagePendingWrites:   prometheus.NewDesc("cursus_storage_pending_writes", "Messages waiting in storage write queues.", nil, nil),
-		storageActiveReaders:   prometheus.NewDesc("cursus_storage_active_readers", "Readers currently accessing storage segments.", nil, nil),
-		storageStatFailures:    prometheus.NewDesc("cursus_storage_stat_failures", "Storage files that could not be inspected during this scrape.", nil, nil),
-		distributionEnabled:    prometheus.NewDesc("cursus_distribution_enabled", "Whether distributed cluster mode is enabled.", nil, nil),
-		clusterBrokers:         prometheus.NewDesc("cursus_cluster_brokers", "Brokers present in replicated cluster metadata.", nil, nil),
-		clusterHasLeader:       prometheus.NewDesc("cursus_cluster_has_leader", "Whether this broker can resolve the cluster leader.", nil, nil),
-		clusterIsLeader:        prometheus.NewDesc("cursus_cluster_is_leader", "Whether this broker is the current cluster leader.", nil, nil),
-		clusterOffline:         prometheus.NewDesc("cursus_cluster_offline_partitions", "Partitions without an assigned leader.", nil, nil),
-		clusterUnderReplicated: prometheus.NewDesc("cursus_cluster_under_replicated_partitions", "Partitions whose in-sync replica count is below their replica count.", nil, nil),
-		partitionReplicas:      prometheus.NewDesc("cursus_cluster_partition_replicas", "Configured replica count for a partition.", []string{"topic", "partition"}, nil),
-		partitionInSync:        prometheus.NewDesc("cursus_cluster_partition_in_sync_replicas", "In-sync replica count for a partition.", []string{"topic", "partition"}, nil),
-		partitionLeaderEpoch:   prometheus.NewDesc("cursus_cluster_partition_leader_epoch", "Current partition leader epoch.", []string{"topic", "partition"}, nil),
-		partitionLeader:        prometheus.NewDesc("cursus_cluster_partition_leader", "Current partition leader identity.", []string{"topic", "partition", "broker_id"}, nil),
+		topics:                          topics,
+		groups:                          groups,
+		disk:                            diskState,
+		streams:                         streams,
+		cluster:                         cluster,
+		readiness:                       readiness,
+		ready:                           prometheus.NewDesc("cursus_broker_ready", "Whether the broker is ready to accept client work.", nil, nil),
+		topicCount:                      prometheus.NewDesc("cursus_broker_topics", "Number of topics loaded by this broker.", nil, nil),
+		metadataLoadFailure:             prometheus.NewDesc("cursus_topic_metadata_manifest_load_failure", "Whether the current durable topic manifest load failed.", nil, nil),
+		metadataOrphanTopics:            prometheus.NewDesc("cursus_topic_metadata_orphan_topics", "Persisted topic directories confirmed absent from the durable manifest.", nil, nil),
+		metadataDurabilityWarning:       prometheus.NewDesc("cursus_topic_metadata_durability_warning", "Whether the latest committed topic metadata update has directory-sync durability uncertainty.", nil, nil),
+		metadataDurabilityWarningsTotal: prometheus.NewDesc("cursus_topic_metadata_durability_warnings_total", "Topic metadata updates committed with directory-sync durability uncertainty.", nil, nil),
+		partitionCount:                  prometheus.NewDesc("cursus_broker_partitions", "Number of topic partitions loaded by this broker.", nil, nil),
+		logStart:                        prometheus.NewDesc("cursus_partition_log_start_offset", "Earliest retained offset for a partition.", []string{"topic", "partition"}, nil),
+		logEnd:                          prometheus.NewDesc("cursus_partition_log_end_offset", "Next offset allocated in a partition.", []string{"topic", "partition"}, nil),
+		highWatermark:                   prometheus.NewDesc("cursus_partition_high_watermark", "Next offset visible to committed readers.", []string{"topic", "partition"}, nil),
+		groupMembers:                    prometheus.NewDesc("cursus_consumer_group_members", "Active members in a consumer group.", []string{"group", "topic"}, nil),
+		groupGeneration:                 prometheus.NewDesc("cursus_consumer_group_generation", "Current consumer group generation.", []string{"group", "topic"}, nil),
+		groupAssignments:                prometheus.NewDesc("cursus_consumer_group_assigned_partitions", "Partitions assigned to active group members.", []string{"group", "topic"}, nil),
+		groupCommittedOffset:            prometheus.NewDesc("cursus_consumer_group_committed_offset", "Committed next offset for a consumer group partition.", []string{"group", "topic", "partition"}, nil),
+		groupLag:                        prometheus.NewDesc("cursus_consumer_group_lag", "Committed-reader lag, max(high watermark - committed next offset, 0).", []string{"group", "topic", "partition"}, nil),
+		legacyGroupLag:                  prometheus.NewDesc("broker_consumer_lag", "Deprecated alias of cursus_consumer_group_lag.", []string{"topic", "partition", "group"}, nil),
+		groupOffsetOutOfRange:           prometheus.NewDesc("cursus_consumer_group_offset_out_of_range", "Whether a committed offset is outside the retained committed-readable range.", []string{"group", "topic", "partition"}, nil),
+		activeStreams:                   prometheus.NewDesc("cursus_streams_active", "Currently registered streaming consumers.", nil, nil),
+		storageHandlers:                 prometheus.NewDesc("cursus_storage_handlers", "Open partition storage handlers.", nil, nil),
+		storageSegments:                 prometheus.NewDesc("cursus_storage_segments", "Open storage segments including active segments.", nil, nil),
+		storageBytes:                    prometheus.NewDesc("cursus_storage_bytes", "Bytes used by segment and offset index files for open handlers.", nil, nil),
+		storagePendingWrites:            prometheus.NewDesc("cursus_storage_pending_writes", "Messages waiting in storage write queues.", nil, nil),
+		storageActiveReaders:            prometheus.NewDesc("cursus_storage_active_readers", "Readers currently accessing storage segments.", nil, nil),
+		storageStatFailures:             prometheus.NewDesc("cursus_storage_stat_failures", "Storage files that could not be inspected during this scrape.", nil, nil),
+		distributionEnabled:             prometheus.NewDesc("cursus_distribution_enabled", "Whether distributed cluster mode is enabled.", nil, nil),
+		clusterBrokers:                  prometheus.NewDesc("cursus_cluster_brokers", "Brokers present in replicated cluster metadata.", nil, nil),
+		clusterHasLeader:                prometheus.NewDesc("cursus_cluster_has_leader", "Whether this broker can resolve the cluster leader.", nil, nil),
+		clusterIsLeader:                 prometheus.NewDesc("cursus_cluster_is_leader", "Whether this broker is the current cluster leader.", nil, nil),
+		clusterOffline:                  prometheus.NewDesc("cursus_cluster_offline_partitions", "Partitions without an assigned leader.", nil, nil),
+		clusterUnderReplicated:          prometheus.NewDesc("cursus_cluster_under_replicated_partitions", "Partitions whose in-sync replica count is below their replica count.", nil, nil),
+		partitionReplicas:               prometheus.NewDesc("cursus_cluster_partition_replicas", "Configured replica count for a partition.", []string{"topic", "partition"}, nil),
+		partitionInSync:                 prometheus.NewDesc("cursus_cluster_partition_in_sync_replicas", "In-sync replica count for a partition.", []string{"topic", "partition"}, nil),
+		partitionLeaderEpoch:            prometheus.NewDesc("cursus_cluster_partition_leader_epoch", "Current partition leader epoch.", []string{"topic", "partition"}, nil),
+		partitionLeader:                 prometheus.NewDesc("cursus_cluster_partition_leader", "Current partition leader identity.", []string{"topic", "partition", "broker_id"}, nil),
 	}
 	c.descriptors = []*prometheus.Desc{
-		c.ready, c.topicCount, c.partitionCount, c.logStart, c.logEnd, c.highWatermark,
+		c.ready, c.topicCount, c.metadataLoadFailure, c.metadataOrphanTopics,
+		c.metadataDurabilityWarning, c.metadataDurabilityWarningsTotal,
+		c.partitionCount, c.logStart, c.logEnd, c.highWatermark,
 		c.groupMembers, c.groupGeneration, c.groupAssignments, c.groupCommittedOffset,
 		c.groupLag, c.legacyGroupLag, c.groupOffsetOutOfRange, c.activeStreams, c.storageHandlers,
 		c.storageSegments, c.storageBytes, c.storagePendingWrites, c.storageActiveReaders,
@@ -150,6 +160,10 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		topicState = c.topics.RuntimeSnapshot()
 	}
 	ch <- gauge(c.topicCount, float64(topicState.TopicCount))
+	ch <- gauge(c.metadataLoadFailure, boolValue(topicState.MetadataLoadFailure != ""))
+	ch <- gauge(c.metadataOrphanTopics, float64(topicState.MetadataOrphanTopicCount))
+	ch <- gauge(c.metadataDurabilityWarning, boolValue(topicState.MetadataDurabilityWarning != ""))
+	ch <- prometheus.MustNewConstMetric(c.metadataDurabilityWarningsTotal, prometheus.CounterValue, float64(topicState.MetadataDurabilityWarningsTotal))
 	ch <- gauge(c.partitionCount, float64(len(topicState.Partitions)))
 	partitionState := make(map[string]topic.PartitionRuntimeSnapshot, len(topicState.Partitions))
 	for _, partition := range topicState.Partitions {

--- a/pkg/observability/collector_test.go
+++ b/pkg/observability/collector_test.go
@@ -46,7 +46,11 @@ func (source fixedReadiness) IsReady() bool { return bool(source) }
 func TestCollectorExportsScrapeTimeBrokerState(t *testing.T) {
 	collector := NewCollector(
 		fixedTopics{snapshot: topic.RuntimeSnapshot{
-			TopicCount: 1,
+			TopicCount:                      1,
+			MetadataLoadFailure:             "decode failed",
+			MetadataOrphanTopicCount:        3,
+			MetadataDurabilityWarning:       "directory sync failed",
+			MetadataDurabilityWarningsTotal: 7,
 			Partitions: []topic.PartitionRuntimeSnapshot{{
 				Topic: "orders", Partition: 0, LogStart: 2, LogEnd: 10, HighWatermark: 8,
 			}},
@@ -81,6 +85,10 @@ func TestCollectorExportsScrapeTimeBrokerState(t *testing.T) {
 	}
 
 	assertGauge(t, families, "cursus_broker_ready", nil, 1)
+	assertGauge(t, families, "cursus_topic_metadata_manifest_load_failure", nil, 1)
+	assertGauge(t, families, "cursus_topic_metadata_orphan_topics", nil, 3)
+	assertGauge(t, families, "cursus_topic_metadata_durability_warning", nil, 1)
+	assertCounter(t, families, "cursus_topic_metadata_durability_warnings_total", 7)
 	assertGauge(t, families, "cursus_partition_high_watermark", map[string]string{"topic": "orders", "partition": "0"}, 8)
 	assertGauge(t, families, "cursus_consumer_group_committed_offset", map[string]string{"group": "workers", "topic": "orders", "partition": "0"}, 5)
 	assertGauge(t, families, "cursus_consumer_group_lag", map[string]string{"group": "workers", "topic": "orders", "partition": "0"}, 3)
@@ -109,6 +117,19 @@ func assertGauge(t *testing.T, families []*dto.MetricFamily, name string, labels
 		}
 	}
 	t.Fatalf("metric %s%v not found", name, labels)
+}
+
+func assertCounter(t *testing.T, families []*dto.MetricFamily, name string, want float64) {
+	t.Helper()
+	for _, family := range families {
+		if family.GetName() == name && family.GetType() == dto.MetricType_COUNTER && len(family.Metric) == 1 {
+			if got := family.Metric[0].GetCounter().GetValue(); got != want {
+				t.Fatalf("%s = %v, want %v", name, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("counter %s not found", name)
 }
 
 func labelsMatch(pairs []*dto.LabelPair, want map[string]string) bool {

--- a/pkg/server/diagnostics.go
+++ b/pkg/server/diagnostics.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/metrics"
+	"github.com/cursus-io/cursus/pkg/observability"
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+func addStorageReadinessChecks(state *HealthState, tm *topic.TopicManager, dm *disk.DiskManager) {
+	state.AddCheck("storage", func(context.Context) error {
+		if tm == nil || dm == nil {
+			return fmt.Errorf("storage subsystem unavailable")
+		}
+		return dm.Ready()
+	})
+	state.AddCheck("topic_metadata", func(context.Context) error {
+		if tm == nil {
+			return fmt.Errorf("topic metadata state unavailable")
+		}
+		return tm.MetadataReadinessError()
+	})
+}
+
+// RunTopicMetadataDiagnostics serves liveness, readiness, and metrics without
+// opening broker client, internal, discovery, or Raft listeners.
+func RunTopicMetadataDiagnostics(ctx context.Context, cfg *config.Config, tm *topic.TopicManager, dm *disk.DiskManager) error {
+	if ctx == nil {
+		return fmt.Errorf("diagnostics context must not be nil")
+	}
+	if cfg == nil {
+		return fmt.Errorf("diagnostics config must not be nil")
+	}
+
+	state := NewHealthState()
+	addStorageReadinessChecks(state, tm, dm)
+	state.SetReady(true)
+	collector := observability.NewCollector(tm, nil, dm, nil, nil, state)
+
+	if cfg.EnableExporter {
+		metricsServer, err := metrics.StartMetricsServer(cfg.ExporterPort, collector)
+		if err != nil {
+			return fmt.Errorf("start diagnostics metrics exporter: %w", err)
+		}
+		defer shutdownHTTPServer(metricsServer)
+	}
+
+	healthPort := cfg.HealthCheckPort
+	if healthPort == 0 {
+		healthPort = DefaultHealthCheckPort
+	}
+	healthServer, err := startHealthCheckServer(healthPort, state)
+	if err != nil {
+		return fmt.Errorf("start diagnostics health server: %w", err)
+	}
+	defer shutdownHTTPServer(healthServer)
+
+	<-ctx.Done()
+	state.SetReady(false)
+	return nil
+}

--- a/pkg/server/diagnostics_test.go
+++ b/pkg/server/diagnostics_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/cursus-io/cursus/pkg/topic"
+)
+
+func TestRunTopicMetadataDiagnosticsServesFailureWithoutBrokerListener(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	cfg.EnabledDistribution = false
+	cfg.EnableExporter = true
+	cfg.HealthCheckPort = reserveTCPPort(t)
+	cfg.ExporterPort = reserveTCPPort(t)
+	cfg.BrokerPort = reserveTCPPort(t)
+	if err := os.WriteFile(filepath.Join(cfg.LogDir, topic.TopicMetadataFileName), []byte(`{"version":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	tm := topic.NewTopicManager(cfg, dm, nil)
+	if err := tm.RestoreTopics(); err == nil {
+		t.Fatal("expected corrupt manifest restore error")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunTopicMetadataDiagnostics(ctx, cfg, tm, dm) }()
+
+	healthBase := fmt.Sprintf("http://127.0.0.1:%d", cfg.HealthCheckPort)
+	waitForHTTPStatus(t, healthBase+"/live", http.StatusOK)
+	response, err := http.Get(healthBase + "/ready") // #nosec G107 -- loopback test address.
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("ready status = %d, want %d", response.StatusCode, http.StatusServiceUnavailable)
+	}
+	var report healthResponse
+	if err := json.NewDecoder(response.Body).Decode(&report); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(report.Checks["topic_metadata"], "manifest load failure") {
+		t.Fatalf("topic_metadata check = %q", report.Checks["topic_metadata"])
+	}
+
+	metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", cfg.ExporterPort)
+	waitForHTTPStatus(t, metricsURL, http.StatusOK)
+	metricsResponse, err := http.Get(metricsURL) // #nosec G107 -- loopback test address.
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricsBody, err := io.ReadAll(metricsResponse.Body)
+	_ = metricsResponse.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"cursus_broker_ready 0",
+		"cursus_topic_metadata_manifest_load_failure 1",
+		"cursus_topic_metadata_orphan_topics 0",
+		"cursus_topic_metadata_durability_warning 0",
+		"cursus_topic_metadata_durability_warnings_total 0",
+	} {
+		if !strings.Contains(string(metricsBody), expected) {
+			t.Fatalf("metrics missing %q", expected)
+		}
+	}
+
+	connection, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.BrokerPort), 100*time.Millisecond)
+	if err == nil {
+		_ = connection.Close()
+		t.Fatal("diagnostics mode unexpectedly opened the broker listener")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("diagnostics returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("diagnostics did not stop after cancellation")
+	}
+}
+
+func TestRunTopicMetadataDiagnosticsRejectsMissingInputs(t *testing.T) {
+	var nilContext context.Context
+	if err := RunTopicMetadataDiagnostics(nilContext, config.DefaultConfig(), nil, nil); err == nil {
+		t.Fatal("expected nil context error")
+	}
+	if err := RunTopicMetadataDiagnostics(context.Background(), nil, nil, nil); err == nil {
+		t.Fatal("expected nil config error")
+	}
+}
+
+func reserveTCPPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func waitForHTTPStatus(t *testing.T, url string, status int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := http.Get(url) // #nosec G107 -- loopback test address.
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == status {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("%s did not return status %d", url, status)
+}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -191,12 +191,7 @@ func RunServerContext(ctx context.Context, cfg *config.Config, tm *topic.TopicMa
 	}
 
 	healthState := NewHealthState()
-	healthState.AddCheck("storage", func(context.Context) error {
-		if tm == nil || dm == nil {
-			return fmt.Errorf("storage subsystem unavailable")
-		}
-		return dm.Ready()
-	})
+	addStorageReadinessChecks(healthState, tm, dm)
 	if cfg.EnabledDistribution {
 		healthState.AddCheck("cluster_leader", func(context.Context) error {
 			if cc == nil {

--- a/pkg/topic/manager.go
+++ b/pkg/topic/manager.go
@@ -36,6 +36,11 @@ type TopicManager struct {
 	coordinator   *coordinator.Coordinator
 	txnResolver   TransactionDecisionResolver
 	metadataStore *topicMetadataStore
+
+	metadataLoadFailure             string
+	metadataOrphanTopicCount        int
+	metadataDurabilityWarning       string
+	metadataDurabilityWarningsTotal uint64
 }
 
 // HandlerProvider defines an interface to provide disk handlers.

--- a/pkg/topic/metadata.go
+++ b/pkg/topic/metadata.go
@@ -114,10 +114,13 @@ func (s *topicMetadataStore) Load() (_ []Definition, err error) {
 			return nil, scanErr
 		}
 		if len(orphaned) > 0 {
-			return nil, fmt.Errorf(
-				"topic metadata manifest is missing while persisted topic storage exists: %s",
-				strings.Join(orphaned, ","),
-			)
+			return nil, &orphanedTopicMetadataError{
+				count: len(orphaned),
+				err: fmt.Errorf(
+					"topic metadata manifest is missing while persisted topic storage exists: %s",
+					strings.Join(orphaned, ","),
+				),
+			}
 		}
 		return nil, nil
 	}
@@ -172,10 +175,13 @@ func (s *topicMetadataStore) Load() (_ []Definition, err error) {
 		return nil, err
 	}
 	if len(orphaned) > 0 {
-		return nil, fmt.Errorf(
-			"topic metadata manifest omits persisted topic storage: %s",
-			strings.Join(orphaned, ","),
-		)
+		return nil, &orphanedTopicMetadataError{
+			count: len(orphaned),
+			err: fmt.Errorf(
+				"topic metadata manifest omits persisted topic storage: %s",
+				strings.Join(orphaned, ","),
+			),
+		}
 	}
 	return definitions, nil
 }
@@ -285,11 +291,16 @@ func (tm *TopicManager) RestoreTopics() error {
 	}
 	definitions, err := tm.metadataStore.Load()
 	if err != nil {
-		return fmt.Errorf("load durable topic metadata: %w", err)
+		restoreErr := fmt.Errorf("load durable topic metadata: %w", err)
+		tm.recordMetadataLoadResult(restoreErr, confirmedOrphanCount(err))
+		return restoreErr
 	}
 	if err := tm.RestoreDefinitions(definitions); err != nil {
-		return fmt.Errorf("restore durable topics: %w", err)
+		restoreErr := fmt.Errorf("restore durable topics: %w", err)
+		tm.recordMetadataLoadResult(restoreErr, 0)
+		return restoreErr
 	}
+	tm.recordMetadataLoadResult(nil, 0)
 	return nil
 }
 
@@ -400,11 +411,13 @@ func (tm *TopicManager) persistDefinitionLocked(override Definition) error {
 	definitions := tm.definitionsLocked(&override, "")
 	if err := tm.metadataStore.Save(definitions); err != nil {
 		if topicMetadataWriteCommitted(err) {
+			tm.recordMetadataDurabilityWarningLocked(err)
 			util.Warn("Topic metadata definition %q committed with durability uncertainty: %v", override.Name, err)
 			return nil
 		}
 		return fmt.Errorf("persist topic definition %q: %w", override.Name, err)
 	}
+	tm.metadataDurabilityWarning = ""
 	return nil
 }
 
@@ -414,11 +427,13 @@ func (tm *TopicManager) persistRemovalLocked(name string) error {
 	}
 	if err := tm.metadataStore.Save(tm.definitionsLocked(nil, name)); err != nil {
 		if topicMetadataWriteCommitted(err) {
+			tm.recordMetadataDurabilityWarningLocked(err)
 			util.Warn("Topic metadata deletion %q committed with durability uncertainty: %v", name, err)
 			return nil
 		}
 		return fmt.Errorf("persist topic deletion %q: %w", name, err)
 	}
+	tm.metadataDurabilityWarning = ""
 	return nil
 }
 

--- a/pkg/topic/metadata_runtime.go
+++ b/pkg/topic/metadata_runtime.go
@@ -1,0 +1,36 @@
+package topic
+
+import "errors"
+
+type orphanedTopicMetadataError struct {
+	count int
+	err   error
+}
+
+func (e *orphanedTopicMetadataError) Error() string { return e.err.Error() }
+func (e *orphanedTopicMetadataError) Unwrap() error { return e.err }
+
+func confirmedOrphanCount(err error) int {
+	var orphanErr *orphanedTopicMetadataError
+	if errors.As(err, &orphanErr) {
+		return orphanErr.count
+	}
+	return 0
+}
+
+func (tm *TopicManager) recordMetadataLoadResult(err error, orphanCount int) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	tm.metadataLoadFailure = ""
+	if err != nil {
+		tm.metadataLoadFailure = err.Error()
+	}
+	tm.metadataOrphanTopicCount = orphanCount
+}
+
+// recordMetadataDurabilityWarningLocked requires tm.mu to be held for writing.
+func (tm *TopicManager) recordMetadataDurabilityWarningLocked(err error) {
+	tm.metadataDurabilityWarning = err.Error()
+	tm.metadataDurabilityWarningsTotal++
+}

--- a/pkg/topic/metadata_runtime_test.go
+++ b/pkg/topic/metadata_runtime_test.go
@@ -1,0 +1,78 @@
+package topic
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cursus-io/cursus/pkg/config"
+	"github.com/cursus-io/cursus/pkg/disk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicMetadataRuntimeReportsManifestFailureAndConfirmedOrphans(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	writePersistedTopicLog(t, cfg.LogDir, "legacy-a")
+	writePersistedTopicLog(t, cfg.LogDir, "legacy-b")
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.Error(t, manager.RestoreTopics())
+
+	snapshot := manager.RuntimeSnapshot()
+	require.NotEmpty(t, snapshot.MetadataLoadFailure)
+	require.Equal(t, 2, snapshot.MetadataOrphanTopicCount)
+	require.ErrorContains(t, manager.MetadataReadinessError(), "manifest load failure")
+	require.ErrorContains(t, manager.MetadataReadinessError(), "2 orphan topic(s) confirmed")
+}
+
+func TestTopicMetadataRuntimeReportsCorruptManifestWithoutGuessingOrphans(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cfg.LogDir, TopicMetadataFileName), []byte(`{"version":`), 0o600))
+
+	dm := disk.NewDiskManager(cfg)
+	t.Cleanup(dm.CloseAllHandlers)
+	manager := NewTopicManager(cfg, dm, nil)
+	require.Error(t, manager.RestoreTopics())
+
+	snapshot := manager.RuntimeSnapshot()
+	require.NotEmpty(t, snapshot.MetadataLoadFailure)
+	require.Zero(t, snapshot.MetadataOrphanTopicCount)
+}
+
+func TestTopicMetadataDurabilityWarningTracksCurrentAndCumulative(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.LogDir = t.TempDir()
+	dm := disk.NewDiskManager(cfg)
+	manager := NewTopicManager(cfg, dm, nil)
+	t.Cleanup(func() {
+		closeTopicManager(manager)
+		dm.CloseAllHandlers()
+	})
+
+	originalSync := syncTopicMetadataDirectoryFn
+	t.Cleanup(func() { syncTopicMetadataDirectoryFn = originalSync })
+	syncTopicMetadataDirectoryFn = func(string) error { return errors.New("directory sync failed") }
+	require.NoError(t, manager.CreateTopic("orders", 1, false, false))
+
+	snapshot := manager.RuntimeSnapshot()
+	require.Contains(t, snapshot.MetadataDurabilityWarning, "directory sync failed")
+	require.Equal(t, uint64(1), snapshot.MetadataDurabilityWarningsTotal)
+	require.ErrorContains(t, manager.MetadataReadinessError(), "metadata durability warning")
+
+	syncTopicMetadataDirectoryFn = originalSync
+	require.NoError(t, manager.CreateTopic("payments", 1, false, false))
+	snapshot = manager.RuntimeSnapshot()
+	require.Empty(t, snapshot.MetadataDurabilityWarning)
+	require.Equal(t, uint64(1), snapshot.MetadataDurabilityWarningsTotal)
+	require.NoError(t, manager.MetadataReadinessError())
+
+	syncTopicMetadataDirectoryFn = func(string) error { return errors.New("directory sync failed again") }
+	require.NoError(t, manager.CreateTopic("shipments", 1, false, false))
+	snapshot = manager.RuntimeSnapshot()
+	require.Equal(t, uint64(2), snapshot.MetadataDurabilityWarningsTotal)
+}

--- a/pkg/topic/runtime.go
+++ b/pkg/topic/runtime.go
@@ -1,6 +1,10 @@
 package topic
 
-import "sort"
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
 
 // PartitionRuntimeSnapshot is a point-in-time view used by broker observability.
 type PartitionRuntimeSnapshot struct {
@@ -13,8 +17,38 @@ type PartitionRuntimeSnapshot struct {
 
 // RuntimeSnapshot is a point-in-time view of topics and partitions.
 type RuntimeSnapshot struct {
-	TopicCount int
-	Partitions []PartitionRuntimeSnapshot
+	TopicCount                      int
+	Partitions                      []PartitionRuntimeSnapshot
+	MetadataLoadFailure             string
+	MetadataOrphanTopicCount        int
+	MetadataDurabilityWarning       string
+	MetadataDurabilityWarningsTotal uint64
+}
+
+// MetadataReadinessError reports durable topic metadata conditions that need
+// operator attention. It is safe to call concurrently with topic mutations.
+func (tm *TopicManager) MetadataReadinessError() error {
+	if tm == nil {
+		return fmt.Errorf("topic metadata state unavailable")
+	}
+
+	tm.mu.RLock()
+	loadFailure := tm.metadataLoadFailure
+	orphanCount := tm.metadataOrphanTopicCount
+	durabilityWarning := tm.metadataDurabilityWarning
+	tm.mu.RUnlock()
+
+	var readinessErr error
+	if loadFailure != "" {
+		readinessErr = errors.Join(readinessErr, fmt.Errorf("manifest load failure: %s", loadFailure))
+	}
+	if orphanCount > 0 {
+		readinessErr = errors.Join(readinessErr, fmt.Errorf("%d orphan topic(s) confirmed", orphanCount))
+	}
+	if durabilityWarning != "" {
+		readinessErr = errors.Join(readinessErr, fmt.Errorf("metadata durability warning: %s", durabilityWarning))
+	}
+	return readinessErr
 }
 
 // RuntimeSnapshot returns a race-safe copy of broker topic state.
@@ -28,10 +62,20 @@ func (tm *TopicManager) RuntimeSnapshot() RuntimeSnapshot {
 	for _, current := range tm.topics {
 		topics = append(topics, current)
 	}
+	metadataLoadFailure := tm.metadataLoadFailure
+	metadataOrphanTopicCount := tm.metadataOrphanTopicCount
+	metadataDurabilityWarning := tm.metadataDurabilityWarning
+	metadataDurabilityWarningsTotal := tm.metadataDurabilityWarningsTotal
 	tm.mu.RUnlock()
 
 	sort.Slice(topics, func(i, j int) bool { return topics[i].Name < topics[j].Name })
-	snapshot := RuntimeSnapshot{TopicCount: len(topics)}
+	snapshot := RuntimeSnapshot{
+		TopicCount:                      len(topics),
+		MetadataLoadFailure:             metadataLoadFailure,
+		MetadataOrphanTopicCount:        metadataOrphanTopicCount,
+		MetadataDurabilityWarning:       metadataDurabilityWarning,
+		MetadataDurabilityWarningsTotal: metadataDurabilityWarningsTotal,
+	}
 	for _, current := range topics {
 		current.mu.RLock()
 		partitions := append([]*Partition(nil), current.Partitions...)


### PR DESCRIPTION
Fixes N/A

Exposes standalone topic metadata failures as actionable readiness and Prometheus state. Manifest load failures and confirmed orphan counts remain visible, committed directory-sync uncertainty is tracked as current and cumulative state, and startup enters a diagnostics-only health/metrics mode instead of opening broker, internal, discovery, or Raft listeners with unsafe storage metadata.

Diagnostics mode intentionally requires an operator repair or migration followed by a broker restart; it does not mutate storage or live-reload a repaired manifest.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (no issue number is available).
- [x] Documentation has been updated as needed (documentation is intentionally excluded from this change).
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.