### PR TITLE
feat: expose Raft snapshot progress

### DIFF
--- a/pkg/cluster/replication/manager.go
+++ b/pkg/cluster/replication/manager.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,6 +33,16 @@ type RaftInterface interface {
 	GetConfiguration() raft.ConfigurationFuture
 	BootstrapCluster(raft.Configuration) raft.Future
 	Shutdown() raft.Future
+	Stats() map[string]string
+}
+
+type RaftStatus struct {
+	State             string
+	AppliedIndex      uint64
+	CommitIndex       uint64
+	LastLogIndex      uint64
+	LastSnapshotIndex uint64
+	LastSnapshotTerm  uint64
 }
 
 type ISRManagerInterface interface {
@@ -62,15 +73,10 @@ func NewRaftReplicationManager(ctx context.Context, cfg *config.Config, brokerID
 	brokerFSM := fsm.NewBrokerFSM(topicManager, coordinator)
 
 	localAddr := fmt.Sprintf("%s:%d", cfg.AdvertisedHost, cfg.RaftPort)
-	raftCfg := raft.DefaultConfig()
-	raftCfg.LocalID = raft.ServerID(brokerID)
-
-	// Raft Security Rule: HeartbeatTimeout must be larger than LeaderLeaseTimeout
-	raftCfg.HeartbeatTimeout = 1000 * time.Millisecond
-	raftCfg.ElectionTimeout = 2000 * time.Millisecond
-	raftCfg.LeaderLeaseTimeout = 800 * time.Millisecond
-	raftCfg.CommitTimeout = 50 * time.Millisecond
-	raftCfg.LogLevel = "Info"
+	raftCfg, err := buildRaftConfig(cfg, brokerID)
+	if err != nil {
+		return nil, err
+	}
 
 	notifyCh := make(chan bool, 10)
 	raftCfg.NotifyCh = notifyCh
@@ -189,6 +195,36 @@ func NewRaftReplicationManager(ctx context.Context, cfg *config.Config, brokerID
 	return rm, nil
 }
 
+func buildRaftConfig(cfg *config.Config, brokerID string) (*raft.Config, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("raft config is required")
+	}
+	if cfg.RaftSnapshotIntervalMS < 5 {
+		return nil, fmt.Errorf("raft_snapshot_interval_ms must be at least 5")
+	}
+	if cfg.RaftSnapshotThreshold == 0 {
+		return nil, fmt.Errorf("raft_snapshot_threshold must be greater than zero")
+	}
+
+	raftCfg := raft.DefaultConfig()
+	raftCfg.LocalID = raft.ServerID(brokerID)
+	raftCfg.SnapshotInterval = time.Duration(cfg.RaftSnapshotIntervalMS) * time.Millisecond
+	raftCfg.SnapshotThreshold = cfg.RaftSnapshotThreshold
+	raftCfg.TrailingLogs = cfg.RaftTrailingLogs
+
+	// Raft Security Rule: HeartbeatTimeout must be larger than LeaderLeaseTimeout.
+	raftCfg.HeartbeatTimeout = 1000 * time.Millisecond
+	raftCfg.ElectionTimeout = 2000 * time.Millisecond
+	raftCfg.LeaderLeaseTimeout = 800 * time.Millisecond
+	raftCfg.CommitTimeout = 50 * time.Millisecond
+	raftCfg.LogLevel = "Info"
+
+	if err := raft.ValidateConfig(raftCfg); err != nil {
+		return nil, fmt.Errorf("invalid raft config: %w", err)
+	}
+	return raftCfg, nil
+}
+
 func (rm *RaftReplicationManager) observeLeadership(notifyCh <-chan bool) {
 	for isLeader := range notifyCh {
 		rm.isLeader.Store(isLeader)
@@ -218,6 +254,40 @@ func (rm *RaftReplicationManager) LeaderCh() <-chan bool {
 
 func (rm *RaftReplicationManager) GetLeaderAddress() string {
 	return string(rm.raft.Leader())
+}
+
+func (rm *RaftReplicationManager) GetRaftStatus() (RaftStatus, error) {
+	if rm == nil || rm.raft == nil {
+		return RaftStatus{}, fmt.Errorf("raft is not available")
+	}
+	stats := rm.raft.Stats()
+	state := strings.TrimSpace(stats["state"])
+	if state == "" {
+		return RaftStatus{}, fmt.Errorf("raft stat %q is missing or blank", "state")
+	}
+	status := RaftStatus{State: state}
+	fields := []struct {
+		key    string
+		target *uint64
+	}{
+		{key: "applied_index", target: &status.AppliedIndex},
+		{key: "commit_index", target: &status.CommitIndex},
+		{key: "last_log_index", target: &status.LastLogIndex},
+		{key: "last_snapshot_index", target: &status.LastSnapshotIndex},
+		{key: "last_snapshot_term", target: &status.LastSnapshotTerm},
+	}
+	for _, field := range fields {
+		value, ok := stats[field.key]
+		if !ok {
+			return RaftStatus{}, fmt.Errorf("raft stat %q is missing", field.key)
+		}
+		parsed, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return RaftStatus{}, fmt.Errorf("parse raft stat %q: %w", field.key, err)
+		}
+		*field.target = parsed
+	}
+	return status, nil
 }
 
 func (rm *RaftReplicationManager) GetFSM() *fsm.BrokerFSM {

--- a/pkg/cluster/replication/manager_test.go
+++ b/pkg/cluster/replication/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/types"
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,10 @@ func (m *MockRaft) Shutdown() raft.Future {
 	return m.Called().Get(0).(raft.Future)
 }
 
+func (m *MockRaft) Stats() map[string]string {
+	return m.Called().Get(0).(map[string]string)
+}
+
 type MockApplyFuture struct {
 	mock.Mock
 }
@@ -63,6 +68,101 @@ type MockIndexFuture struct {
 
 func (m *MockIndexFuture) Error() error  { return m.Called().Error(0) }
 func (m *MockIndexFuture) Index() uint64 { return 0 }
+
+func TestBuildRaftConfigMapsSnapshotSettings(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RaftSnapshotIntervalMS = 250
+	cfg.RaftSnapshotThreshold = 16
+	cfg.RaftTrailingLogs = 0
+
+	got, err := buildRaftConfig(cfg, "broker-1")
+	assert.NoError(t, err)
+	assert.Equal(t, 250*time.Millisecond, got.SnapshotInterval)
+	assert.Equal(t, uint64(16), got.SnapshotThreshold)
+	assert.Equal(t, uint64(0), got.TrailingLogs)
+}
+
+func TestBuildRaftConfigDefaultsMatchHashicorp(t *testing.T) {
+	got, err := buildRaftConfig(config.DefaultConfig(), "broker-1")
+	assert.NoError(t, err)
+	want := raft.DefaultConfig()
+	assert.Equal(t, want.SnapshotInterval, got.SnapshotInterval)
+	assert.Equal(t, want.SnapshotThreshold, got.SnapshotThreshold)
+	assert.Equal(t, want.TrailingLogs, got.TrailingLogs)
+}
+
+func TestBuildRaftConfigRejectsUnsafeSnapshotSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*config.Config)
+		want string
+	}{
+		{
+			name: "interval below library minimum",
+			edit: func(cfg *config.Config) { cfg.RaftSnapshotIntervalMS = 4 },
+			want: "raft_snapshot_interval_ms",
+		},
+		{
+			name: "zero threshold",
+			edit: func(cfg *config.Config) { cfg.RaftSnapshotThreshold = 0 },
+			want: "raft_snapshot_threshold",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			test.edit(cfg)
+			_, err := buildRaftConfig(cfg, "broker-1")
+			assert.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestRaftReplicationManagerGetRaftStatus(t *testing.T) {
+	mr := new(MockRaft)
+	mr.On("Stats").Return(map[string]string{
+		"state":               "Follower",
+		"applied_index":       "41",
+		"commit_index":        "42",
+		"last_log_index":      "43",
+		"last_snapshot_index": "40",
+		"last_snapshot_term":  "3",
+	})
+	rm := &RaftReplicationManager{raft: mr}
+
+	got, err := rm.GetRaftStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, RaftStatus{
+		State: "Follower", AppliedIndex: 41, CommitIndex: 42, LastLogIndex: 43,
+		LastSnapshotIndex: 40, LastSnapshotTerm: 3,
+	}, got)
+}
+
+func TestRaftReplicationManagerGetRaftStatusRejectsMissingOrBlankState(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		state map[string]string
+	}{
+		{name: "missing", state: map[string]string{}},
+		{name: "blank", state: map[string]string{"state": "  "}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mr := new(MockRaft)
+			mr.On("Stats").Return(test.state)
+			rm := &RaftReplicationManager{raft: mr}
+			_, err := rm.GetRaftStatus()
+			assert.ErrorContains(t, err, "state")
+		})
+	}
+}
+
+func TestRaftReplicationManagerGetRaftStatusRejectsInvalidStats(t *testing.T) {
+	mr := new(MockRaft)
+	mr.On("Stats").Return(map[string]string{"state": "Follower", "applied_index": "not-a-number"})
+	rm := &RaftReplicationManager{raft: mr}
+	_, err := rm.GetRaftStatus()
+	assert.ErrorContains(t, err, "applied_index")
+}
 
 func TestRaftReplicationManager_ApplyCommand(t *testing.T) {
 	mr := new(MockRaft)

--- a/pkg/config/properties.go
+++ b/pkg/config/properties.go
@@ -68,14 +68,17 @@ type Config struct {
 	BroadcastChannelBufferSize int `yaml:"broadcast_channel_buffer_size" json:"broadcast.channel.buffer.size"`
 
 	// distributed cluster
-	EnabledDistribution  bool     `yaml:"enabled_distribution" json:"distribution.enabled"`
-	InternalAuthToken    string   `yaml:"internal_auth_token" json:"distribution.internal_auth_token"`
-	InternalBrokerPort   int      `yaml:"internal_broker_port" json:"distribution.internal_broker_port"`
-	RaftPort             int      `yaml:"raft_port" json:"distribution.raft.port"`
-	DiscoveryPort        int      `yaml:"discovery_port" json:"distribution.discovery.port"`
-	RaftPeers            []string `yaml:"raft_peers" json:"distribution.raft.peers"`
-	StaticClusterMembers []string `yaml:"static_cluster_members" json:"distribution.static_cluster_members"`
-	BootstrapCluster     bool     `yaml:"bootstrap_cluster" json:"distribution.bootstrap"`
+	EnabledDistribution    bool     `yaml:"enabled_distribution" json:"distribution.enabled"`
+	InternalAuthToken      string   `yaml:"internal_auth_token" json:"distribution.internal_auth_token"`
+	InternalBrokerPort     int      `yaml:"internal_broker_port" json:"distribution.internal_broker_port"`
+	RaftPort               int      `yaml:"raft_port" json:"distribution.raft.port"`
+	RaftSnapshotIntervalMS int      `yaml:"raft_snapshot_interval_ms" json:"distribution.raft.snapshot.interval.ms"`
+	RaftSnapshotThreshold  uint64   `yaml:"raft_snapshot_threshold" json:"distribution.raft.snapshot.threshold"`
+	RaftTrailingLogs       uint64   `yaml:"raft_trailing_logs" json:"distribution.raft.trailing.logs"`
+	DiscoveryPort          int      `yaml:"discovery_port" json:"distribution.discovery.port"`
+	RaftPeers              []string `yaml:"raft_peers" json:"distribution.raft.peers"`
+	StaticClusterMembers   []string `yaml:"static_cluster_members" json:"distribution.static_cluster_members"`
+	BootstrapCluster       bool     `yaml:"bootstrap_cluster" json:"distribution.bootstrap"`
 
 	AdvertisedHost           string `yaml:"advertised_host" json:"distribution.advertised_host"`
 	AdvertisedBrokerPort     int    `yaml:"advertised_broker_port" json:"distribution.advertised_broker_port"`
@@ -158,6 +161,9 @@ func DefaultConfig() *Config {
 			InternalAuthToken:        "",
 			InternalBrokerPort:       0,
 			RaftPort:                 9001,
+			RaftSnapshotIntervalMS:   120000,
+			RaftSnapshotThreshold:    8192,
+			RaftTrailingLogs:         10240,
 			DiscoveryPort:            8000,
 			RaftPeers:                []string{},
 			StaticClusterMembers:     []string{},
@@ -251,6 +257,9 @@ func LoadConfig() (*Config, error) {
 	flag.StringVar(&cfg.InternalAuthToken, "internal-auth-token", cfg.InternalAuthToken, "Shared token for broker-to-broker internal text commands")
 	flag.IntVar(&cfg.InternalBrokerPort, "internal-broker-port", cfg.InternalBrokerPort, "Dedicated broker-to-broker internal command port")
 	flag.IntVar(&cfg.RaftPort, "raft-port", cfg.RaftPort, "Raft port for replication")
+	flag.IntVar(&cfg.RaftSnapshotIntervalMS, "raft-snapshot-interval-ms", cfg.RaftSnapshotIntervalMS, "Raft snapshot check interval in milliseconds")
+	flag.Uint64Var(&cfg.RaftSnapshotThreshold, "raft-snapshot-threshold", cfg.RaftSnapshotThreshold, "Outstanding Raft log entries required before snapshotting")
+	flag.Uint64Var(&cfg.RaftTrailingLogs, "raft-trailing-logs", cfg.RaftTrailingLogs, "Raft log entries retained after snapshotting")
 	flag.IntVar(&cfg.DiscoveryPort, "discovery-port", cfg.DiscoveryPort, "Discovery service port")
 	raftPeersFlag := flag.String("raft-peers", "", "Raft peer addresses (comma-separated)")
 	flag.BoolVar(&cfg.BootstrapCluster, "bootstrap-cluster", cfg.BootstrapCluster, "Bootstrap Raft cluster")
@@ -374,6 +383,9 @@ func LoadConfig() (*Config, error) {
 	overrideEnvInt(&cfg.AdvertisedBrokerPort, "ADVERTISED_BROKER_PORT")
 	overrideEnvString(&cfg.AdvertisedClientHost, "ADVERTISED_CLIENT_HOST")
 	overrideEnvInt(&cfg.RaftPort, "RAFT_PORT")
+	overrideEnvInt(&cfg.RaftSnapshotIntervalMS, "RAFT_SNAPSHOT_INTERVAL_MS")
+	overrideEnvUint64(&cfg.RaftSnapshotThreshold, "RAFT_SNAPSHOT_THRESHOLD")
+	overrideEnvUint64(&cfg.RaftTrailingLogs, "RAFT_TRAILING_LOGS")
 	overrideEnvInt(&cfg.DiscoveryPort, "DISCOVERY_PORT")
 	overrideEnvStringSlice(&cfg.RaftPeers, "RAFT_PEERS")
 	overrideEnvStringSlice(&cfg.StaticClusterMembers, "STATIC_CLUSTER_MEMBERS")

--- a/pkg/config/properties_ext_test.go
+++ b/pkg/config/properties_ext_test.go
@@ -15,11 +15,23 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.LogLevel != util.LogLevelInfo {
 		t.Errorf("Expected default LogLevel Info, got %v", cfg.LogLevel)
 	}
+	if cfg.RaftSnapshotIntervalMS != 120000 {
+		t.Errorf("Expected default RaftSnapshotIntervalMS 120000, got %d", cfg.RaftSnapshotIntervalMS)
+	}
+	if cfg.RaftSnapshotThreshold != 8192 {
+		t.Errorf("Expected default RaftSnapshotThreshold 8192, got %d", cfg.RaftSnapshotThreshold)
+	}
+	if cfg.RaftTrailingLogs != 10240 {
+		t.Errorf("Expected default RaftTrailingLogs 10240, got %d", cfg.RaftTrailingLogs)
+	}
 }
 
 func TestLoadConfig_EnvOverrides(t *testing.T) {
 	t.Setenv("BROKER_PORT", "9999")
 	t.Setenv("LOG_RETENTION_HOURS", "24")
+	t.Setenv("RAFT_SNAPSHOT_INTERVAL_MS", "250")
+	t.Setenv("RAFT_SNAPSHOT_THRESHOLD", "16")
+	t.Setenv("RAFT_TRAILING_LOGS", "0")
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -31,6 +43,15 @@ func TestLoadConfig_EnvOverrides(t *testing.T) {
 	}
 	if cfg.RetentionHours != 24 {
 		t.Errorf("Expected RetentionHours 24 from env, got %d", cfg.RetentionHours)
+	}
+	if cfg.RaftSnapshotIntervalMS != 250 {
+		t.Errorf("Expected RaftSnapshotIntervalMS 250 from env, got %d", cfg.RaftSnapshotIntervalMS)
+	}
+	if cfg.RaftSnapshotThreshold != 16 {
+		t.Errorf("Expected RaftSnapshotThreshold 16 from env, got %d", cfg.RaftSnapshotThreshold)
+	}
+	if cfg.RaftTrailingLogs != 0 {
+		t.Errorf("Expected RaftTrailingLogs 0 from env, got %d", cfg.RaftTrailingLogs)
 	}
 }
 

--- a/pkg/controller/cluster_admin_handler.go
+++ b/pkg/controller/cluster_admin_handler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cursus-io/cursus/pkg/cluster/replication"
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 )
 
@@ -31,15 +32,21 @@ type clusterPartitionStatus struct {
 }
 
 type clusterStatus struct {
-	RaftLeader      string                   `json:"raft_leader"`
-	BrokerCount     int                      `json:"broker_count"`
-	ActiveBrokers   int                      `json:"active_brokers"`
-	InactiveBrokers int                      `json:"inactive_brokers"`
-	PartitionCount  int                      `json:"partition_count"`
-	Leaderless      int                      `json:"leaderless_partitions"`
-	UnderReplicated int                      `json:"under_replicated_partitions"`
-	Brokers         []clusterBrokerStatus    `json:"brokers"`
-	Partitions      []clusterPartitionStatus `json:"partitions"`
+	RaftLeader            string                   `json:"raft_leader"`
+	RaftState             string                   `json:"raft_state"`
+	RaftAppliedIndex      uint64                   `json:"raft_applied_index"`
+	RaftCommitIndex       uint64                   `json:"raft_commit_index"`
+	RaftLastLogIndex      uint64                   `json:"raft_last_log_index"`
+	RaftLastSnapshotIndex uint64                   `json:"raft_last_snapshot_index"`
+	RaftLastSnapshotTerm  uint64                   `json:"raft_last_snapshot_term"`
+	BrokerCount           int                      `json:"broker_count"`
+	ActiveBrokers         int                      `json:"active_brokers"`
+	InactiveBrokers       int                      `json:"inactive_brokers"`
+	PartitionCount        int                      `json:"partition_count"`
+	Leaderless            int                      `json:"leaderless_partitions"`
+	UnderReplicated       int                      `json:"under_replicated_partitions"`
+	Brokers               []clusterBrokerStatus    `json:"brokers"`
+	Partitions            []clusterPartitionStatus `json:"partitions"`
 }
 
 // handleListCluster processes the read-only LIST_CLUSTER command.
@@ -70,6 +77,21 @@ func (ch *CommandHandler) handleClusterStatus() string {
 	}
 
 	status := buildClusterStatus(state, ch.Cluster.RaftManager.GetLeaderAddress())
+	if provider, ok := ch.Cluster.RaftManager.(interface {
+		GetRaftStatus() (replication.RaftStatus, error)
+	}); ok {
+		raftStatus, err := provider.GetRaftStatus()
+		if err != nil {
+			status.RaftState = "unavailable"
+		} else {
+			status.RaftState = raftStatus.State
+			status.RaftAppliedIndex = raftStatus.AppliedIndex
+			status.RaftCommitIndex = raftStatus.CommitIndex
+			status.RaftLastLogIndex = raftStatus.LastLogIndex
+			status.RaftLastSnapshotIndex = raftStatus.LastSnapshotIndex
+			status.RaftLastSnapshotTerm = raftStatus.LastSnapshotTerm
+		}
+	}
 	data, err := json.Marshal(status)
 	if err != nil {
 		return fmt.Sprintf("ERROR: marshal_cluster_status_failed reason=%q", err.Error())

--- a/pkg/controller/cluster_handler_test.go
+++ b/pkg/controller/cluster_handler_test.go
@@ -19,6 +19,8 @@ type MockRaftManagerForForward struct {
 	isLeader      bool
 	leaderAddress atomic.Value
 	state         *fsm.BrokerFSM
+	raftStatus    replication.RaftStatus
+	raftStatusErr error
 }
 
 func (m *MockRaftManagerForForward) IsLeader() bool { return m.isLeader }
@@ -32,7 +34,10 @@ func (m *MockRaftManagerForForward) GetLeaderAddress() string {
 func (m *MockRaftManagerForForward) ApplyCommand(prefix string, data []byte) error { return nil }
 func (m *MockRaftManagerForForward) LeaderCh() <-chan bool                         { return nil }
 func (m *MockRaftManagerForForward) GetFSM() *fsm.BrokerFSM                        { return m.state }
-func (m *MockRaftManagerForForward) GetConfiguration() raft.ConfigurationFuture    { return nil }
+func (m *MockRaftManagerForForward) GetRaftStatus() (replication.RaftStatus, error) {
+	return m.raftStatus, m.raftStatusErr
+}
+func (m *MockRaftManagerForForward) GetConfiguration() raft.ConfigurationFuture { return nil }
 func (m *MockRaftManagerForForward) ReplicateWithQuorum(t string, p int, msg types.Message, i int, idemp bool, scope string) (types.AckResponse, error) {
 	return types.AckResponse{}, nil
 }

--- a/pkg/controller/cluster_observation_contract_test.go
+++ b/pkg/controller/cluster_observation_contract_test.go
@@ -2,10 +2,12 @@ package controller
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	clusterController "github.com/cursus-io/cursus/pkg/cluster/controller"
+	"github.com/cursus-io/cursus/pkg/cluster/replication"
 	"github.com/cursus-io/cursus/pkg/cluster/replication/fsm"
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/hashicorp/raft"
@@ -71,5 +73,59 @@ func TestListClusterReportsMissingFSM(t *testing.T) {
 
 	if got := ch.HandleCommand("LIST_CLUSTER", NewClientContext("", 0)); got != "ERROR: fsm_not_available" {
 		t.Fatalf("unexpected missing FSM response: %q", got)
+	}
+}
+
+func TestClusterStatusExposesLocalRaftSnapshotProgress(t *testing.T) {
+	state := fsm.NewBrokerFSM(nil, nil)
+	rm := &MockRaftManagerForForward{
+		state: state,
+		raftStatus: replication.RaftStatus{
+			State: "Follower", AppliedIndex: 41, CommitIndex: 42, LastLogIndex: 43,
+			LastSnapshotIndex: 40, LastSnapshotTerm: 3,
+		},
+	}
+	ch := NewCommandHandler(nil, &config.Config{EnabledDistribution: true}, nil, nil, &clusterController.ClusterController{RaftManager: rm})
+	t.Cleanup(func() { _ = ch.Close() })
+
+	response := ch.HandleCommand("CLUSTER_STATUS", NewClientContext("", 0))
+	const prefix = "OK cluster="
+	if !strings.HasPrefix(response, prefix) {
+		t.Fatalf("unexpected CLUSTER_STATUS response: %s", response)
+	}
+	var status clusterStatus
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(response, prefix)), &status); err != nil {
+		t.Fatalf("invalid cluster status JSON: %v", err)
+	}
+	if status.RaftState != "Follower" || status.RaftAppliedIndex != 41 ||
+		status.RaftCommitIndex != 42 || status.RaftLastLogIndex != 43 ||
+		status.RaftLastSnapshotIndex != 40 || status.RaftLastSnapshotTerm != 3 {
+		t.Fatalf("unexpected local Raft status: %+v", status)
+	}
+}
+
+func TestClusterStatusPreservesDiagnosticsWhenLocalRaftStatsAreUnavailable(t *testing.T) {
+	state := fsm.NewBrokerFSM(nil, nil)
+	rm := &MockRaftManagerForForward{
+		state:         state,
+		raftStatusErr: fmt.Errorf("parse raft stat %q", "last_snapshot_index"),
+	}
+	ch := NewCommandHandler(nil, &config.Config{EnabledDistribution: true}, nil, nil, &clusterController.ClusterController{RaftManager: rm})
+	t.Cleanup(func() { _ = ch.Close() })
+
+	response := ch.HandleCommand("CLUSTER_STATUS", NewClientContext("", 0))
+	const prefix = "OK cluster="
+	if !strings.HasPrefix(response, prefix) {
+		t.Fatalf("unexpected CLUSTER_STATUS response: %s", response)
+	}
+	var status clusterStatus
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(response, prefix)), &status); err != nil {
+		t.Fatalf("invalid cluster status JSON: %v", err)
+	}
+	if status.RaftState != "unavailable" {
+		t.Fatalf("expected unavailable Raft telemetry, got %+v", status)
+	}
+	if status.BrokerCount != 0 || status.PartitionCount != 0 {
+		t.Fatalf("expected broker and partition diagnostics to remain available, got %+v", status)
 	}
 }


### PR DESCRIPTION
Fixes

Adds production-safe Raft snapshot tuning and local snapshot progress visibility so cluster E2E tests can prove a specific follower restored from a snapshot without exposing a force-snapshot mutation endpoint. Production defaults remain identical to Hashicorp Raft defaults; invalid intervals and zero thresholds fail fast.

Checklist:

- [x] This PR addresses an existing issue or proposes a new enhancement.
- [x] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

Validation:
- go test ./pkg/protocol ./pkg/config ./pkg/cluster/replication ./pkg/controller
- go vet ./pkg/protocol ./pkg/config ./pkg/cluster/replication ./pkg/controller
- go test ./... reached the existing Windows TempDir cleanup race in TestCoordinator_DurableOffsetReplayFromDisk; isolated rerun passed