### PR TITLE
fix: stop producer reconnects during close

### DIFF
--- a/sdk/producer_batch.go
+++ b/sdk/producer_batch.go
@@ -183,19 +183,29 @@ func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error)
 
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		select {
+		case <-p.done:
+			return nil, fmt.Errorf("producer is closed")
+		default:
+		}
+
 		conn := p.client.GetConn(part)
 		if conn == nil {
 			brokerAddr := p.getPartitionLeaderAddr(part)
 			if err := p.client.ReconnectPartition(part, brokerAddr); err != nil {
 				lastErr = fmt.Errorf("reconnect failed: %w", err)
-				time.Sleep(time.Duration(backoff) * time.Millisecond)
+				if !p.waitForRetry(backoff) {
+					return nil, fmt.Errorf("producer is closed")
+				}
 				backoff = min(backoff*2, p.config.MaxBackoffMS)
 				continue
 			}
 			conn = p.client.GetConn(part)
 			if conn == nil {
 				lastErr = fmt.Errorf("no connection after reconnect")
-				time.Sleep(time.Duration(backoff) * time.Millisecond)
+				if !p.waitForRetry(backoff) {
+					return nil, fmt.Errorf("producer is closed")
+				}
 				backoff = min(backoff*2, p.config.MaxBackoffMS)
 				continue
 			}
@@ -203,7 +213,9 @@ func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error)
 
 		if err := conn.SetWriteDeadline(time.Now().Add(time.Duration(p.config.WriteTimeoutMS) * time.Millisecond)); err != nil {
 			lastErr = fmt.Errorf("set write deadline failed: %w", err)
-			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			if !p.waitForRetry(backoff) {
+				return nil, fmt.Errorf("producer is closed")
+			}
 			backoff = min(backoff*2, p.config.MaxBackoffMS)
 			continue
 		}
@@ -212,7 +224,9 @@ func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error)
 			lastErr = fmt.Errorf("write failed: %w", err)
 			brokerAddr := p.getPartitionLeaderAddr(part)
 			_ = p.client.ReconnectPartition(part, brokerAddr)
-			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			if !p.waitForRetry(backoff) {
+				return nil, fmt.Errorf("producer is closed")
+			}
 			backoff = min(backoff*2, p.config.MaxBackoffMS)
 			continue
 		}
@@ -227,7 +241,9 @@ func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error)
 
 		if err != nil {
 			lastErr = fmt.Errorf("read ack failed: %w", err)
-			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			if !p.waitForRetry(backoff) {
+				return nil, fmt.Errorf("producer is closed")
+			}
 			backoff = min(backoff*2, p.config.MaxBackoffMS)
 			continue
 		}
@@ -235,7 +251,9 @@ func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error)
 		ackResp, err := p.parseAckResponse(resp)
 		if err != nil {
 			lastErr = err
-			time.Sleep(time.Duration(backoff) * time.Millisecond)
+			if !p.waitForRetry(backoff) {
+				return nil, fmt.Errorf("producer is closed")
+			}
 			backoff = min(backoff*2, p.config.MaxBackoffMS)
 			continue
 		}
@@ -243,6 +261,18 @@ func (p *Producer) sendWithRetry(payload []byte, part int) (*AckResponse, error)
 		return ackResp, nil
 	}
 	return nil, lastErr
+}
+
+func (p *Producer) waitForRetry(backoffMS int) bool {
+	timer := time.NewTimer(time.Duration(backoffMS) * time.Millisecond)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+	case <-p.done:
+		return false
+	}
 }
 
 func (p *Producer) markBatchAckedByID(part int, batchID string, batchLen int) {

--- a/sdk/producer_client.go
+++ b/sdk/producer_client.go
@@ -28,6 +28,7 @@ type ProducerClient struct {
 	tlsConfig *tls.Config
 
 	leader atomic.Pointer[leaderInfo]
+	closed atomic.Bool
 }
 
 func NewProducerClient(config *PublisherConfig) (*ProducerClient, error) {
@@ -66,6 +67,9 @@ func (pc *ProducerClient) NextSeqNum(partition int) uint64 {
 }
 
 func (pc *ProducerClient) connectPartitionLocked(idx int, addr string) error {
+	if pc.closed.Load() {
+		return fmt.Errorf("producer client is closed")
+	}
 	if idx < 0 {
 		return fmt.Errorf("invalid partition index: %d", idx)
 	}
@@ -141,6 +145,7 @@ func (pc *ProducerClient) GetConn(part int) net.Conn {
 func (pc *ProducerClient) Close() error {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
+	pc.closed.Store(true)
 
 	ptr := pc.conns.Swap(nil)
 	if ptr == nil {

--- a/sdk/producer_context_test.go
+++ b/sdk/producer_context_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -65,6 +66,54 @@ func TestProducerConcurrentCloseWaitsForShutdown(t *testing.T) {
 	}
 	if err := <-secondDone; err != nil {
 		t.Fatalf("second Close failed: %v", err)
+	}
+}
+
+func TestProducerClientClosePreventsReconnect(t *testing.T) {
+	cfg := NewDefaultPublisherConfig()
+	client := mustNewProducerClient(cfg)
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	err := client.ReconnectPartition(0, "127.0.0.1:1")
+	if err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("ReconnectPartition after Close error = %v, want closed error", err)
+	}
+	if conn := client.GetConn(0); conn != nil {
+		t.Fatal("ReconnectPartition installed a connection after Close")
+	}
+}
+
+func TestProducerRetryBackoffStopsOnClose(t *testing.T) {
+	producer := &Producer{done: make(chan struct{})}
+	result := make(chan bool, 1)
+	go func() {
+		result <- producer.waitForRetry(30_000)
+	}()
+	close(producer.done)
+
+	select {
+	case completed := <-result:
+		if completed {
+			t.Fatal("waitForRetry completed its timer after producer closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForRetry did not stop when producer closed")
+	}
+}
+
+func TestProducerSendRetryRejectsClosedClient(t *testing.T) {
+	cfg := NewDefaultPublisherConfig()
+	client := mustNewProducerClient(cfg)
+	if err := client.Close(); err != nil {
+		t.Fatalf("client Close failed: %v", err)
+	}
+	producer := &Producer{config: cfg, client: client, done: make(chan struct{})}
+	close(producer.done)
+
+	if _, err := producer.sendWithRetry([]byte("payload"), 0); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("sendWithRetry error = %v, want closed error", err)
 	}
 }
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes: no linked issue; addresses a producer shutdown lifecycle defect found during the main branch audit.

## Summary

- mark the producer closed before partition connections are torn down
- prevent new partition reconnects after shutdown begins
- make retry backoff interruptible by producer closure
- add coverage for reconnect and retry cancellation behavior

## Why

Close could race with batch retry and partition reconnection paths. Those paths used unconditional sleeps and did not share a closed-state guard, so they could continue reconnecting after shutdown had started.

## Impact

Producer shutdown now terminates pending retry work promptly and does not create replacement connections after Close.

## Validation

- `go test ./sdk`
- Docker E2E: `go test -v -timeout 10m ./test/e2e/...`
- Docker broker health check passed before E2E
- Docker containers and volumes were removed after validation

Checklist:

- [ ] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

No issue is linked, so the first two issue-specific checklist items remain unchecked. Documentation changes are not required for this internal lifecycle fix.
