### PR TITLE
feat: propagate controller request contexts

### DIFF
--- a/pkg/controller/cluster_admin_handler.go
+++ b/pkg/controller/cluster_admin_handler.go
@@ -163,11 +163,12 @@ func splitPartitionMetadataKey(key string) (string, int) {
 	return key[:idx], partition
 }
 
-func (ch *CommandHandler) handleElectLeader(cmd string) string {
+func (ch *CommandHandler) handleElectLeader(cmd string, ctx ...*ClientContext) string {
+	requestCtx := firstClientContext(ctx).RequestContext()
 	if !ch.isDistributed() {
 		return "ERROR: distribution_required command=ELECT_LEADER"
 	}
-	if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
+	if resp, forwarded, _ := ch.isLeaderAndForwardContext(requestCtx, cmd); forwarded {
 		return resp
 	}
 
@@ -195,7 +196,7 @@ func (ch *CommandHandler) handleElectLeader(cmd string) string {
 		return fmt.Sprintf("ERROR: partition_not_found topic=%s partition=%d", topicName, partition)
 	}
 
-	result, err := ch.applyAndWait("LEADER_ELECTION", map[string]interface{}{
+	result, err := ch.applyAndWaitContext(requestCtx, "LEADER_ELECTION", map[string]interface{}{
 		"topic":                 topicName,
 		"partition":             partition,
 		"broker":                brokerID,

--- a/pkg/controller/cluster_handler.go
+++ b/pkg/controller/cluster_handler.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -60,8 +61,26 @@ func (ch *CommandHandler) isAuthorizedForPartition(topic string, partition int) 
 	return ch.Cluster.IsAuthorized(topic, partition)
 }
 
+func waitForContext(ctx context.Context, delay time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // isLeaderAndForward checks if the current node is the cluster leader
 func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
+	return ch.isLeaderAndForwardContext(context.Background(), cmd)
+}
+
+func (ch *CommandHandler) isLeaderAndForwardContext(ctx context.Context, cmd string) (string, bool, error) {
 	if !ch.isDistributed() {
 		return "", false, nil
 	}
@@ -76,7 +95,9 @@ func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
 			return "ERROR: no_raft_leader", true, fmt.Errorf("no leader elected")
 		}
 		util.Debug("Waiting for Raft leader to be elected... (attempt %d/%d)", i+1, maxRetries)
-		time.Sleep(backoffDelay(i, 100*time.Millisecond))
+		if err := waitForContext(ctx, backoffDelay(i, 100*time.Millisecond)); err != nil {
+			return "ERROR: request_cancelled", true, err
+		}
 	}
 
 	if !ch.Cluster.RaftManager.IsLeader() {
@@ -94,7 +115,9 @@ func (ch *CommandHandler) isLeaderAndForward(cmd string) (string, bool, error) {
 			lastErr = err
 			util.Debug("Retrying forward to leader (Target Leader %s)... attempt %d: %v", ch.Cluster.RaftManager.GetLeaderAddress(), i+1, err)
 			if i < maxRetries-1 {
-				time.Sleep(backoffDelay(i, 100*time.Millisecond))
+				if err := waitForContext(ctx, backoffDelay(i, 100*time.Millisecond)); err != nil {
+					return "ERROR: request_cancelled", true, err
+				}
 			}
 		}
 		leaderAddr := ch.Cluster.RaftManager.GetLeaderAddress()
@@ -225,6 +248,10 @@ func notCoordinatorResponse(addr AdvertisedAddr) string {
 }
 
 func (ch *CommandHandler) isPartitionLeaderAndForward(topic string, partition int, cmd string) (string, bool, error) {
+	return ch.isPartitionLeaderAndForwardContext(context.Background(), topic, partition, cmd)
+}
+
+func (ch *CommandHandler) isPartitionLeaderAndForwardContext(ctx context.Context, topic string, partition int, cmd string) (string, bool, error) {
 	if !ch.hasRouter() {
 		return "", false, nil
 	}
@@ -251,7 +278,11 @@ func (ch *CommandHandler) isPartitionLeaderAndForward(topic string, partition in
 		} else {
 			lastErr = err
 		}
-		time.Sleep(backoffDelay(i, 100*time.Millisecond))
+		if i < maxRetries-1 {
+			if err := waitForContext(ctx, backoffDelay(i, 100*time.Millisecond)); err != nil {
+				return "ERROR: request_cancelled", true, err
+			}
+		}
 	}
 
 	return fmt.Sprintf("ERROR: forward_to_partition_leader_failed topic=%s partition=%d reason=%q", topic, partition, lastErr.Error()), true, nil
@@ -337,7 +368,14 @@ func (ch *CommandHandler) handleRaftApply(cmd string) string {
 
 // applyViaLeader tries local Raft apply first; if not leader, forwards to leader via RAFT_APPLY.
 func (ch *CommandHandler) applyViaLeader(cmdType string, payload map[string]interface{}) (interface{}, error) {
-	result, err := ch.applyAndWait(cmdType, payload)
+	return ch.applyViaLeaderContext(context.Background(), cmdType, payload)
+}
+
+func (ch *CommandHandler) applyViaLeaderContext(ctx context.Context, cmdType string, payload map[string]interface{}) (interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result, err := ch.applyAndWaitContext(ctx, cmdType, payload)
 	if err == nil {
 		return result, nil
 	}
@@ -353,6 +391,11 @@ func (ch *CommandHandler) applyViaLeader(cmdType string, payload map[string]inte
 
 	forwardCmd := fmt.Sprintf("RAFT_APPLY %stype=%s payload=%s", ch.internalAuthPrefix(), cmdType, string(data))
 	encodedCmd := util.EncodeMessage("", forwardCmd)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	resp, fwdErr := ch.Cluster.Router.ForwardToLeader(string(encodedCmd))
 	if fwdErr != nil {
 		return nil, fmt.Errorf("forward raft apply to leader: %w", fwdErr)
@@ -364,6 +407,18 @@ func (ch *CommandHandler) applyViaLeader(cmdType string, payload map[string]inte
 }
 
 func (ch *CommandHandler) applyAndWait(cmdType string, payload map[string]interface{}) (interface{}, error) {
+	return ch.applyAndWaitContext(context.Background(), cmdType, payload)
+}
+
+func (ch *CommandHandler) applyAndWaitContext(ctx context.Context, cmdType string, payload map[string]interface{}) (interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	if ch.Cluster == nil {
 		return nil, fmt.Errorf("cluster controller is not initialized")
 	}
@@ -391,13 +446,18 @@ func (ch *CommandHandler) applyAndWait(cmdType string, payload map[string]interf
 		return nil, fmt.Errorf("raft apply failed: %w", err)
 	}
 
+	timer := time.NewTimer(DefaultFSMApplyTimeout)
+	defer timer.Stop()
+
 	select {
 	case res := <-respChan:
 		if err, ok := res.(error); ok && err != nil {
 			return nil, err
 		}
 		return res, nil
-	case <-time.After(DefaultFSMApplyTimeout):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
 		return nil, fmt.Errorf("timeout waiting for FSM")
 	}
 }

--- a/pkg/controller/command_handler.go
+++ b/pkg/controller/command_handler.go
@@ -26,7 +26,8 @@ var (
 )
 
 // handleCreate processes CREATE command
-func (ch *CommandHandler) handleCreate(cmd string) string {
+func (ch *CommandHandler) handleCreate(cmd string, ctx ...*ClientContext) string {
+	requestCtx := firstClientContext(ctx).RequestContext()
 	args := parseKeyValueArgs(cmd[7:])
 	topicName, ok := args["topic"]
 	if !ok || topicName == "" {
@@ -84,7 +85,7 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 
 	tm := ch.TopicManager
 	if ch.isDistributed() {
-		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
+		if resp, forwarded, _ := ch.isLeaderAndForwardContext(requestCtx, cmd); forwarded {
 			return resp
 		}
 
@@ -96,7 +97,7 @@ func (ch *CommandHandler) handleCreate(cmd string) string {
 			"replication_factor": replicationFactor,
 			"policy":             policy,
 		}
-		_, err := ch.applyAndWait("TOPIC", payload)
+		_, err := ch.applyAndWaitContext(requestCtx, "TOPIC", payload)
 		if err != nil {
 			return fmt.Sprintf("ERROR: create_topic_failed reason=%q", err.Error())
 		}
@@ -173,7 +174,8 @@ func parseACLArg(value string) []string {
 }
 
 // handleDelete processes DELETE command
-func (ch *CommandHandler) handleDelete(cmd string) string {
+func (ch *CommandHandler) handleDelete(cmd string, ctx ...*ClientContext) string {
+	requestCtx := firstClientContext(ctx).RequestContext()
 	args := parseKeyValueArgs(cmd[7:])
 	topicName, ok := args["topic"]
 	if !ok || topicName == "" {
@@ -185,14 +187,14 @@ func (ch *CommandHandler) handleDelete(cmd string) string {
 	}
 
 	if ch.isDistributed() {
-		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
+		if resp, forwarded, _ := ch.isLeaderAndForwardContext(requestCtx, cmd); forwarded {
 			return resp
 		}
 
 		payload := map[string]interface{}{
 			"topic": topicName,
 		}
-		if _, err := ch.applyAndWait("TOPIC_DELETE", payload); err != nil {
+		if _, err := ch.applyAndWaitContext(requestCtx, "TOPIC_DELETE", payload); err != nil {
 			if errors.Is(err, topic.ErrTopicNotFound) {
 				return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
 			}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"sort"
 
 	wireprotocol "github.com/cursus-io/cursus/pkg/protocol"
@@ -18,6 +19,7 @@ type ClientContext struct {
 	Internal        bool
 	ProtocolVersion int
 	Features        map[wireprotocol.Feature]struct{}
+	requestContext  context.Context
 }
 
 func NewClientContext(group string, idx int) *ClientContext {
@@ -30,6 +32,7 @@ func NewClientContext(group string, idx int) *ClientContext {
 		OffsetCache:     make(map[string]uint64),
 		ProtocolVersion: wireprotocol.CurrentVersion,
 		Features:        make(map[wireprotocol.Feature]struct{}),
+		requestContext:  context.Background(),
 	}
 }
 
@@ -37,6 +40,30 @@ func NewInternalClientContext(group string, idx int) *ClientContext {
 	ctx := NewClientContext(group, idx)
 	ctx.Internal = true
 	return ctx
+}
+
+func firstClientContext(contexts []*ClientContext) *ClientContext {
+	if len(contexts) == 0 {
+		return nil
+	}
+	return contexts[0]
+}
+
+func (ctx *ClientContext) SetRequestContext(requestContext context.Context) {
+	if ctx == nil {
+		return
+	}
+	if requestContext == nil {
+		requestContext = context.Background()
+	}
+	ctx.requestContext = requestContext
+}
+
+func (ctx *ClientContext) RequestContext() context.Context {
+	if ctx == nil || ctx.requestContext == nil {
+		return context.Background()
+	}
+	return ctx.requestContext
 }
 
 func (ctx *ClientContext) SetConsumerGroup(groupName string) {

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -117,11 +118,11 @@ func NewCommandHandler(
 		{prefix: "NEGOTIATE ", exact: false, handler: func(cmd string, ctx *ClientContext) string { return ch.handleNegotiate(cmd, ctx) }},
 		{prefix: "LIST_CLUSTER", exact: true, helpOrder: 34, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListCluster() }},
 		{prefix: "CLUSTER_STATUS", exact: true, helpOrder: 35, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleClusterStatus() }},
-		{prefix: "ELECT_LEADER ", exact: false, helpOrder: 36, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleElectLeader(cmd) }},
-		{prefix: "LIST", exact: true, helpOrder: 3, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleList() }},
+		{prefix: "ELECT_LEADER ", exact: false, helpOrder: 36, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleElectLeader(cmd, ctx) }},
+		{prefix: "LIST", exact: true, helpOrder: 3, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleList(ctx) }},
 		{prefix: "LIST_GROUPS", exact: true, helpOrder: 23, permissions: []string{PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListGroups() }},
-		{prefix: "CREATE ", exact: false, helpOrder: 1, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCreate(cmd) }},
-		{prefix: "DELETE ", exact: false, helpOrder: 2, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDelete(cmd) }},
+		{prefix: "CREATE ", exact: false, helpOrder: 1, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCreate(cmd, ctx) }},
+		{prefix: "DELETE ", exact: false, helpOrder: 2, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDelete(cmd, ctx) }},
 		{prefix: "PUBLISH ", exact: false, helpOrder: 4, permissions: []string{PermissionTopicWrite}, handler: func(cmd string, ctx *ClientContext) string { return ch.handlePublish(cmd, ctx) }},
 		{prefix: "CONSUME ", exact: false, helpOrder: 5, permissions: []string{PermissionTopicRead, PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.validateConsumeSyntax(cmd, cmd) }},
 		{prefix: "STREAM ", exact: false, helpOrder: 6, permissions: []string{PermissionTopicRead, PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.validateStreamSyntax(cmd, cmd) }},
@@ -133,7 +134,7 @@ func NewCommandHandler(
 		{prefix: "LIST_OFFSETS", exact: true, helpOrder: 14, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd, ctx) }},
 		{prefix: "LIST_OFFSETS ", exact: false, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListOffsets(cmd, ctx) }},
 		{prefix: "GROUP_STATUS ", exact: false, helpOrder: 22, permissions: []string{PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleGroupStatus(cmd) }},
-		{prefix: "DESCRIBE ", exact: false, helpOrder: 24, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDescribeTopic(cmd) }},
+		{prefix: "DESCRIBE ", exact: false, helpOrder: 24, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDescribeTopic(cmd, ctx) }},
 		{prefix: "HEARTBEAT ", exact: false, helpOrder: 10, permissions: []string{PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleHeartbeat(cmd) }},
 		{prefix: "COMMIT_OFFSET ", exact: false, helpOrder: 11, permissions: []string{PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCommitOffset(cmd) }},
 		{prefix: "BATCH_COMMIT ", exact: false, helpOrder: 12, permissions: []string{PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleBatchCommit(cmd) }},
@@ -203,6 +204,21 @@ func redactOneCommandSecret(s, key string) string {
 	}
 	b.WriteString(s)
 	return b.String()
+}
+
+// HandleCommandContext applies a request-scoped cancellation and deadline while
+// preserving the connection-level context for subsequent commands.
+func (ch *CommandHandler) HandleCommandContext(requestCtx context.Context, rawCmd string, clientCtx *ClientContext) string {
+	if requestCtx == nil {
+		requestCtx = context.Background()
+	}
+	if clientCtx == nil {
+		return ch.HandleCommand(rawCmd, nil)
+	}
+	previous := clientCtx.RequestContext()
+	clientCtx.SetRequestContext(requestCtx)
+	defer clientCtx.SetRequestContext(previous)
+	return ch.HandleCommand(rawCmd, clientCtx)
 }
 
 // HandleCommand processes non-streaming commands and returns a signal for streaming commands.

--- a/pkg/controller/produce_handler.go
+++ b/pkg/controller/produce_handler.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -39,6 +40,7 @@ func (ch *CommandHandler) handlePublish(cmd string, ctx ...*ClientContext) strin
 	if len(ctx) > 0 {
 		clientCtx = ctx[0]
 	}
+	requestCtx := clientCtx.RequestContext()
 	args := parseKeyValueArgs(cmd[8:])
 	if authResp := ch.authenticateInline(args, clientCtx); authResp != "" {
 		return authResp
@@ -109,7 +111,10 @@ func (ch *CommandHandler) handlePublish(cmd string, ctx ...*ClientContext) strin
 	}
 
 	var ackResp types.AckResponse
-	t := ch.waitForTopic(topicName)
+	t, waitErr := ch.waitForTopicContext(requestCtx, topicName)
+	if waitErr != nil {
+		return "ERROR: request_cancelled"
+	}
 	if t == nil {
 		util.Warn("ch publish: topic '%s' does not exist after retries", topicName)
 		return fmt.Sprintf("ERROR: topic_not_found topic=%s", topicName)
@@ -198,7 +203,7 @@ func (ch *CommandHandler) handlePublish(cmd string, ctx ...*ClientContext) strin
 			}
 			forwardCmd += " message=" + message
 		}
-		if resp, forwarded, _ := ch.isPartitionLeaderAndForward(topicName, partition, forwardCmd); forwarded {
+		if resp, forwarded, _ := ch.isPartitionLeaderAndForwardContext(requestCtx, topicName, partition, forwardCmd); forwarded {
 			return resp
 		}
 
@@ -319,9 +324,14 @@ Respond:
 }
 
 func (ch *CommandHandler) waitForTopic(topicName string) *topic.Topic {
+	t, _ := ch.waitForTopicContext(context.Background(), topicName)
+	return t
+}
+
+func (ch *CommandHandler) waitForTopicContext(ctx context.Context, topicName string) (*topic.Topic, error) {
 	t := ch.TopicManager.GetTopic(topicName)
 	if t != nil {
-		return t
+		return t, nil
 	}
 
 	const maxRetries = 5
@@ -330,11 +340,13 @@ func (ch *CommandHandler) waitForTopic(topicName string) *topic.Topic {
 	for i := 0; i < maxRetries; i++ {
 		t = ch.TopicManager.GetTopic(topicName)
 		if t != nil {
-			return t
+			return t, nil
 		}
-		time.Sleep(retryDelay)
+		if err := waitForContext(ctx, retryDelay); err != nil {
+			return nil, err
+		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (ch *CommandHandler) handleReplicateMessage(cmd string) string {
@@ -403,6 +415,7 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn, ctx ...
 	if len(ctx) > 0 {
 		clientCtx = ctx[0]
 	}
+	requestCtx := clientCtx.RequestContext()
 	batch, err := util.DecodeBatchMessages(data)
 	if err != nil {
 		util.Error("Batch message decoding failed: %v", err)
@@ -438,7 +451,9 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn, ctx ...
 				util.Debug("Failed to forward batch to Partition leader: %v", forwardErr)
 
 				if i < maxRetries-1 {
-					time.Sleep(retryDelay)
+					if err := waitForContext(requestCtx, retryDelay); err != nil {
+						return "ERROR: request_cancelled", nil
+					}
 				}
 				lastErr = forwardErr
 			}
@@ -448,7 +463,10 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn, ctx ...
 
 		util.Debug("Processing BATCH locally as Partition leader for %s:%d", batch.Topic, batch.Partition)
 
-		t := ch.waitForTopic(batch.Topic)
+		t, waitErr := ch.waitForTopicContext(requestCtx, batch.Topic)
+		if waitErr != nil {
+			return "ERROR: request_cancelled", nil
+		}
 		if t == nil {
 			util.Error("Batch process failed: topic '%s' not found", batch.Topic)
 			return fmt.Sprintf("ERROR: topic_not_found topic=%s", batch.Topic), nil
@@ -541,7 +559,10 @@ func (ch *CommandHandler) HandleBatchMessage(data []byte, conn net.Conn, ctx ...
 
 	// stand-alone
 	{
-		t := ch.waitForTopic(batch.Topic)
+		t, waitErr := ch.waitForTopicContext(requestCtx, batch.Topic)
+		if waitErr != nil {
+			return "ERROR: request_cancelled", nil
+		}
 		if t == nil {
 			return fmt.Sprintf("ERROR: topic_not_found topic=%s", batch.Topic), nil
 		}

--- a/pkg/controller/request_context_test.go
+++ b/pkg/controller/request_context_test.go
@@ -20,6 +20,7 @@ func TestClientContextRequestContext(t *testing.T) {
 		t.Fatalf("request context error = %v, want context.Canceled", clientCtx.RequestContext().Err())
 	}
 
+	//nolint:staticcheck // Intentionally verify the defensive nil-context fallback.
 	clientCtx.SetRequestContext(nil)
 	if err := clientCtx.RequestContext().Err(); err != nil {
 		t.Fatalf("nil context should restore background context, got %v", err)

--- a/pkg/controller/request_context_test.go
+++ b/pkg/controller/request_context_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestClientContextRequestContext(t *testing.T) {
+	clientCtx := NewClientContext("group", 0)
+	if clientCtx.RequestContext() == nil {
+		t.Fatal("default request context is nil")
+	}
+
+	requestCtx, cancel := context.WithCancel(context.Background())
+	clientCtx.SetRequestContext(requestCtx)
+	cancel()
+	if !errors.Is(clientCtx.RequestContext().Err(), context.Canceled) {
+		t.Fatalf("request context error = %v, want context.Canceled", clientCtx.RequestContext().Err())
+	}
+
+	clientCtx.SetRequestContext(nil)
+	if err := clientCtx.RequestContext().Err(); err != nil {
+		t.Fatalf("nil context should restore background context, got %v", err)
+	}
+}
+
+func TestWaitForContextStopsOnCancellation(t *testing.T) {
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+
+	err := waitForContext(requestCtx, time.Minute)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForContext error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("cancelled wait took %v", elapsed)
+	}
+}
+
+func TestApplyAndWaitContextRejectsCancelledRequestFirst(t *testing.T) {
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	handler := &CommandHandler{}
+	_, err := handler.applyAndWaitContext(requestCtx, "TEST", map[string]interface{}{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("applyAndWaitContext error = %v, want context.Canceled", err)
+	}
+}
+
+func TestPublishTopicWaitStopsOnRequestCancellation(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	clientCtx := NewClientContext("group", 0)
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+
+	response := handler.HandleCommandContext(requestCtx, "PUBLISH topic=missing producerId=p1 message=value", clientCtx)
+	if response != "ERROR: request_cancelled" {
+		t.Fatalf("response = %q, want request cancellation", response)
+	}
+	if err := clientCtx.RequestContext().Err(); err != nil {
+		t.Fatalf("connection context was not restored: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("cancelled publish took %v", elapsed)
+	}
+}

--- a/pkg/controller/topic_query_handler.go
+++ b/pkg/controller/topic_query_handler.go
@@ -10,9 +10,10 @@ import (
 )
 
 // handleList processes LIST command
-func (ch *CommandHandler) handleList() string {
+func (ch *CommandHandler) handleList(ctx ...*ClientContext) string {
+	requestCtx := firstClientContext(ctx).RequestContext()
 	if ch.isDistributed() {
-		if resp, forwarded, _ := ch.isLeaderAndForward("LIST"); forwarded {
+		if resp, forwarded, _ := ch.isLeaderAndForwardContext(requestCtx, "LIST"); forwarded {
 			return resp
 		}
 	}
@@ -23,7 +24,8 @@ func (ch *CommandHandler) handleList() string {
 }
 
 // handleDescribeTopic processes DESCRIBE topic=<name> command
-func (ch *CommandHandler) handleDescribeTopic(cmd string) string {
+func (ch *CommandHandler) handleDescribeTopic(cmd string, ctx ...*ClientContext) string {
+	requestCtx := firstClientContext(ctx).RequestContext()
 	args := decodeCommandInput(cmd).Args
 	topicName, ok := args["topic"]
 	if !ok || topicName == "" {
@@ -31,7 +33,7 @@ func (ch *CommandHandler) handleDescribeTopic(cmd string) string {
 	}
 
 	if ch.isDistributed() {
-		if resp, forwarded, _ := ch.isLeaderAndForward(cmd); forwarded {
+		if resp, forwarded, _ := ch.isLeaderAndForwardContext(requestCtx, cmd); forwarded {
 			return resp
 		}
 	}

--- a/pkg/protocol/errors.go
+++ b/pkg/protocol/errors.go
@@ -62,7 +62,7 @@ func buildErrorRegistry() map[string]ErrorClassification {
 	)
 	register(ErrorClassAvailability, true,
 		"cluster_metadata_unavailable", "cluster_not_available", "coordinator_not_available", "fsm_not_available",
-		"leader_election_result_unavailable", "leader_not_found", "no_raft_leader", "offset_manager_not_available", "router_not_available",
+		"leader_election_result_unavailable", "leader_not_found", "no_raft_leader", "offset_manager_not_available", "request_cancelled", "router_not_available",
 		"transaction_abort_marker_failed", "transaction_commit_failed", "transaction_manager_not_available", "transaction_sync_failed",
 	)
 	register(ErrorClassFencing, false,

--- a/pkg/protocol/errors_test.go
+++ b/pkg/protocol/errors_test.go
@@ -46,6 +46,7 @@ func TestClassifyFencingAndAvailability(t *testing.T) {
 		{"authentication_failed", ErrorClassAuthorization, false},
 		{"coordinator_not_available", ErrorClassAvailability, true},
 		{"cluster_metadata_unavailable", ErrorClassAvailability, true},
+		{"request_cancelled", ErrorClassAvailability, true},
 		{"NOT_PARTITION_LEADER", ErrorClassRouting, true},
 		{"STALE_LEADER_EPOCH", ErrorClassFencing, false},
 		{"partition_metadata_not_found", ErrorClassNotFound, false},

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -368,6 +368,7 @@ func handleConnWithContext(ctx context.Context, conn net.Conn, cmdHandler *contr
 
 	clientCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	cmdCtx.SetRequestContext(clientCtx)
 
 	for {
 		select {
@@ -430,6 +431,7 @@ func HandleConnection(ctx context.Context, conn net.Conn, tm *topic.TopicManager
 
 	cmdHandler, cmdCtx := initializeConnection(cfg, tm, cd, sm, cc)
 	defer func() { _ = cmdHandler.Close() }()
+	cmdCtx.SetRequestContext(clientCtx)
 
 	for {
 		select {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes: no linked issue; addresses missing request cancellation propagation found during the main branch audit.

## Summary

- attach the server connection context to controller client contexts
- expose context-aware command handling while preserving the existing API
- propagate cancellation through forwarding, leader waits, Raft apply, and topic waits
- add tests for pre-cancelled and in-flight request cancellation

## Why

Controller operations could outlive the originating connection because blocking waits, forwarding, and Raft apply paths did not receive the request context.

## Impact

Disconnected or cancelled requests now stop downstream controller work promptly instead of consuming resources until fixed timeouts expire.

## Validation

- `go test ./pkg/controller`
- `go test ./pkg/server`
- targeted request-context tests
- Docker E2E: `go test -v -timeout 10m ./test/e2e/...`
- Docker broker health check passed before E2E
- Docker containers and volumes were removed after validation

Checklist:

- [ ] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

No issue is linked, so the first two issue-specific checklist items remain unchecked. Documentation changes are not required for this request-lifecycle behavior.
