### PR TITLE
fix: filter listed topics by read access

### DIFF
--- a/pkg/controller/auth_test.go
+++ b/pkg/controller/auth_test.go
@@ -2,11 +2,14 @@ package controller
 
 import (
 	"context"
+	"encoding/binary"
+	"io"
 	"net"
 	"strings"
 	"testing"
 	"time"
 
+	clustercontroller "github.com/cursus-io/cursus/pkg/cluster/controller"
 	"github.com/cursus-io/cursus/pkg/config"
 	"github.com/cursus-io/cursus/pkg/coordinator"
 	"github.com/cursus-io/cursus/pkg/topic"
@@ -163,6 +166,86 @@ func TestListFiltersTopicsByReadACL(t *testing.T) {
 	internal := listedTopics(t, ch.HandleCommand("LIST", NewInternalClientContext("", 0)))
 	if len(internal) != len(policies) {
 		t.Fatalf("internal LIST visibility = %v, want all topics", internal)
+	}
+}
+
+func TestListFiltersForwardedTopicsByReadACL(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnableSASL = true
+	cfg.EnabledDistribution = true
+	cfg.SASLUsers = []config.SASLUser{{Principal: "alice", Token: "alice-secret"}}
+
+	tm := topic.NewTopicManager(cfg, &authStorageProvider{storage: &authTestStorage{}}, nil)
+	policies := map[string]topic.Policy{
+		"open-topic": topic.DefaultPolicy(),
+		"alice-topic": {
+			AuthPolicy: topic.AuthPolicyACL,
+			ReadACL:    []string{"alice"},
+		},
+		"bob-topic": {
+			AuthPolicy: topic.AuthPolicyACL,
+			ReadACL:    []string{"bob"},
+		},
+		"denied-topic": {
+			AuthPolicy: topic.AuthPolicyDenyRead,
+		},
+	}
+	for name, policy := range policies {
+		if err := tm.CreateTopicWithPolicy(name, 1, false, false, policy); err != nil {
+			t.Fatalf("CreateTopicWithPolicy(%q) failed: %v", name, err)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	cfg.BrokerPort = listener.Addr().(*net.TCPAddr).Port
+
+	rm := &MockRaftManagerForForward{isLeader: false}
+	rm.leaderAddress.Store("127.0.0.1:7001")
+	router := clustercontroller.NewClusterRouter("follower", "127.0.0.1:7002", nil, rm, cfg.BrokerPort, "", cfg)
+	cluster := &clustercontroller.ClusterController{RaftManager: rm, Router: router}
+	ch := NewCommandHandler(tm, cfg, nil, nil, cluster)
+	alice := NewClientContext("", 0)
+	if response := ch.HandleCommand("AUTH principal=alice token=alice-secret", alice); !strings.HasPrefix(response, "OK") {
+		t.Fatalf("AUTH failed: %q", response)
+	}
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverErr <- acceptErr
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		length := make([]byte, 4)
+		if _, readErr := io.ReadFull(conn, length); readErr != nil {
+			serverErr <- readErr
+			return
+		}
+		request := make([]byte, binary.BigEndian.Uint32(length))
+		if _, readErr := io.ReadFull(conn, request); readErr != nil {
+			serverErr <- readErr
+			return
+		}
+		response := []byte("OK count=4 topics=alice-topic,bob-topic,denied-topic,open-topic")
+		binary.BigEndian.PutUint32(length, uint32(len(response)))
+		if _, writeErr := conn.Write(append(length, response...)); writeErr != nil {
+			serverErr <- writeErr
+			return
+		}
+		serverErr <- nil
+	}()
+
+	visible := listedTopics(t, ch.HandleCommand("LIST", alice))
+	if err := <-serverErr; err != nil {
+		t.Fatalf("forwarded LIST server: %v", err)
+	}
+	if len(visible) != 2 || !visible["open-topic"] || !visible["alice-topic"] {
+		t.Fatalf("forwarded LIST visibility = %v, want open-topic and alice-topic", visible)
 	}
 }
 

--- a/pkg/controller/auth_test.go
+++ b/pkg/controller/auth_test.go
@@ -116,6 +116,72 @@ func TestListOffsetsRequiresReadACL(t *testing.T) {
 	}
 }
 
+func TestListFiltersTopicsByReadACL(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.EnableSASL = true
+	cfg.SASLUsers = []config.SASLUser{
+		{Principal: "alice", Token: "alice-secret"},
+		{Principal: "bob", Token: "bob-secret"},
+	}
+
+	tm := topic.NewTopicManager(cfg, &authStorageProvider{storage: &authTestStorage{}}, nil)
+	policies := map[string]topic.Policy{
+		"open-topic": topic.DefaultPolicy(),
+		"alice-topic": {
+			AuthPolicy: topic.AuthPolicyACL,
+			ReadACL:    []string{"alice"},
+		},
+		"bob-topic": {
+			AuthPolicy: topic.AuthPolicyACL,
+			ReadACL:    []string{"bob"},
+		},
+		"denied-topic": {
+			AuthPolicy: topic.AuthPolicyDenyRead,
+		},
+	}
+	for name, policy := range policies {
+		if err := tm.CreateTopicWithPolicy(name, 1, false, false, policy); err != nil {
+			t.Fatalf("CreateTopicWithPolicy(%q) failed: %v", name, err)
+		}
+	}
+
+	ch := NewCommandHandler(tm, cfg, nil, nil, nil)
+	alice := NewClientContext("", 0)
+	if response := ch.HandleCommand("AUTH principal=alice token=alice-secret", alice); !strings.HasPrefix(response, "OK") {
+		t.Fatalf("AUTH failed: %q", response)
+	}
+
+	response := ch.HandleCommand("LIST", alice)
+	visible := listedTopics(t, response)
+	if len(visible) != 2 || !visible["open-topic"] || !visible["alice-topic"] {
+		t.Fatalf("alice LIST visibility = %v, want open-topic and alice-topic", visible)
+	}
+	if visible["bob-topic"] || visible["denied-topic"] {
+		t.Fatalf("alice LIST exposed unauthorized topics: %v", visible)
+	}
+
+	internal := listedTopics(t, ch.HandleCommand("LIST", NewInternalClientContext("", 0)))
+	if len(internal) != len(policies) {
+		t.Fatalf("internal LIST visibility = %v, want all topics", internal)
+	}
+}
+
+func listedTopics(t *testing.T, response string) map[string]bool {
+	t.Helper()
+	if !strings.HasPrefix(response, "OK ") {
+		t.Fatalf("LIST failed: %q", response)
+	}
+	visible := make(map[string]bool)
+	for _, field := range strings.Fields(response) {
+		if topics, ok := strings.CutPrefix(field, "topics="); ok && topics != "" {
+			for _, name := range strings.Split(topics, ",") {
+				visible[name] = true
+			}
+		}
+	}
+	return visible
+}
+
 func TestPublicPublishCannotUseInternalTxnFlag(t *testing.T) {
 	cfg := config.DefaultConfig()
 	storage := &authTestStorage{}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -118,7 +118,7 @@ func NewCommandHandler(
 		{prefix: "LIST_CLUSTER", exact: true, helpOrder: 34, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListCluster() }},
 		{prefix: "CLUSTER_STATUS", exact: true, helpOrder: 35, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleClusterStatus() }},
 		{prefix: "ELECT_LEADER ", exact: false, helpOrder: 36, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleElectLeader(cmd) }},
-		{prefix: "LIST", exact: true, helpOrder: 3, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleList() }},
+		{prefix: "LIST", exact: true, helpOrder: 3, permissions: []string{PermissionTopicRead}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleList(ctx) }},
 		{prefix: "LIST_GROUPS", exact: true, helpOrder: 23, permissions: []string{PermissionGroup}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleListGroups() }},
 		{prefix: "CREATE ", exact: false, helpOrder: 1, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleCreate(cmd) }},
 		{prefix: "DELETE ", exact: false, helpOrder: 2, permissions: []string{PermissionAdmin}, handler: func(cmd string, ctx *ClientContext) string { return ch.handleDelete(cmd) }},

--- a/pkg/controller/topic_query_handler.go
+++ b/pkg/controller/topic_query_handler.go
@@ -17,15 +17,38 @@ func (ch *CommandHandler) handleList(ctx ...*ClientContext) string {
 	}
 	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward("LIST"); forwarded {
-			return resp
+			if clientCtx != nil && clientCtx.Internal {
+				return resp
+			}
+			return ch.filterListResponse(resp, clientCtx)
 		}
 	}
 
 	tm := ch.TopicManager
 	names := tm.ListTopics()
+	names = ch.filterVisibleTopics(names, clientCtx)
+	return formatTopicList(names)
+}
+
+func (ch *CommandHandler) filterListResponse(response string, clientCtx *ClientContext) string {
+	if !strings.HasPrefix(response, "OK ") {
+		return response
+	}
+	for _, field := range strings.Fields(response) {
+		if topics, ok := strings.CutPrefix(field, "topics="); ok {
+			if topics == "" {
+				return formatTopicList(nil)
+			}
+			return formatTopicList(ch.filterVisibleTopics(strings.Split(topics, ","), clientCtx))
+		}
+	}
+	return formatTopicList(nil)
+}
+
+func (ch *CommandHandler) filterVisibleTopics(names []string, clientCtx *ClientContext) []string {
 	visible := names[:0]
 	for _, name := range names {
-		t := tm.GetTopic(name)
+		t := ch.TopicManager.GetTopic(name)
 		if t == nil {
 			continue
 		}
@@ -37,7 +60,10 @@ func (ch *CommandHandler) handleList(ctx ...*ClientContext) string {
 			visible = append(visible, name)
 		}
 	}
-	names = visible
+	return visible
+}
+
+func formatTopicList(names []string) string {
 	return fmt.Sprintf("OK count=%d topics=%s", len(names), strings.Join(names, ","))
 }
 

--- a/pkg/controller/topic_query_handler.go
+++ b/pkg/controller/topic_query_handler.go
@@ -10,7 +10,11 @@ import (
 )
 
 // handleList processes LIST command
-func (ch *CommandHandler) handleList() string {
+func (ch *CommandHandler) handleList(ctx ...*ClientContext) string {
+	var clientCtx *ClientContext
+	if len(ctx) > 0 {
+		clientCtx = ctx[0]
+	}
 	if ch.isDistributed() {
 		if resp, forwarded, _ := ch.isLeaderAndForward("LIST"); forwarded {
 			return resp
@@ -19,6 +23,21 @@ func (ch *CommandHandler) handleList() string {
 
 	tm := ch.TopicManager
 	names := tm.ListTopics()
+	visible := names[:0]
+	for _, name := range names {
+		t := tm.GetTopic(name)
+		if t == nil {
+			continue
+		}
+		if clientCtx != nil && clientCtx.Internal {
+			visible = append(visible, name)
+			continue
+		}
+		if t.Policy.CanReadPrincipal(principalFromContext(clientCtx)) {
+			visible = append(visible, name)
+		}
+	}
+	names = visible
 	return fmt.Sprintf("OK count=%d topics=%s", len(names), strings.Join(names, ","))
 }
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes: no linked issue; addresses topic metadata exposure found during the main branch audit.

## Summary

- pass the authenticated client context into LIST handling
- filter listed topics through each topic's read policy
- preserve full topic visibility for trusted internal clients
- cover open, principal ACL, other-principal ACL, and deny-read policies

## Why

The LIST permission check authorized the command category but returned every topic name without applying per-topic read policies, exposing metadata for topics the caller could not read.

## Impact

Authenticated clients now discover only topics they are allowed to read, while internal cluster operations retain full visibility.

## Validation

- `go test ./pkg/controller`
- targeted LIST ACL filter test
- Docker E2E: `go test -v -timeout 10m ./test/e2e/...`
- Docker broker health check passed before E2E
- Docker containers and volumes were removed after validation

Checklist:

- [ ] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [x] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

No issue is linked, so the first two issue-specific checklist items remain unchecked. Documentation changes are not required for this authorization-boundary fix.
