### PR TITLE
ci: skip bot PR author assignment

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yaml
+++ b/.github/workflows/auto-assign-pr-author.yaml
@@ -16,6 +16,10 @@ jobs:
         with:
           script: |
             const { number, user } = context.payload.pull_request;
+            if (user.type === 'Bot' || user.login.endsWith('[bot]')) {
+              core.info(`Skipping author assignment for bot account ${user.login}`);
+              return;
+            }
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. 
Please sign off your commits with `git commit -s` before submitting the PR.
-->

Fixes: no linked issue; addresses the bot-authored PR CI failure demonstrated by #136.

## Summary

- detect GitHub App and `[bot]` pull request authors before assignment
- skip the unsupported assignee API call for bot accounts
- keep automatic author assignment unchanged for human-authored pull requests

## Why

GitHub rejects assigning bot accounts with the workflow's installation token. The resulting 403 made the `assign-author` check fail on Dependabot and other bot-authored pull requests.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/auto-assign-pr-author.yaml`
- `git diff --check`

Checklist:

- [ ] This PR addresses an existing issue or proposes a new enhancement.
- [ ] The PR title clearly states the change and related issue number (for automatic issue closing).
- [x] Documentation has been updated as needed.
- [x] All commits are signed off as required by DCO.
- [ ] Unit and/or integration tests have been added for new functionality.
- [x] The build passes successfully.
- [x] The change follows Cursus design and feature guidelines.
- [x] A brief description of why this PR is necessary or what problem it solves is included.

No issue is linked, so the issue-specific checklist items remain unchecked. This workflow-only change requires no documentation or application tests; actionlint validates the changed workflow.
